### PR TITLE
chore: sync internal version strings to 1.2.2

### DIFF
--- a/fiberq/__init__.py
+++ b/fiberq/__init__.py
@@ -1,12 +1,12 @@
 """
-FiberQ v1.3 - QGIS Plugin for Fiber Optic Network Design
+FiberQ - QGIS Plugin for Fiber Optic Network Design
 
 This plugin provides tools for designing and documenting fiber optic networks
 including route planning, cable laying, element placement, and documentation.
 
 Supported QGIS Versions: 3.22 LTR - 4.x (Qt5 and Qt6)
 
-Version: 1.2.1 (QGIS Repo)
+Version: 1.2.2 (QGIS Repo)
 """
 
 # Minimum supported QGIS version
@@ -123,7 +123,7 @@ class _FiberQStub:
 # PACKAGE INFO
 # =============================================================================
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "Vladimir Vukovic"
 __email__ = "vukovicvl@fiberq.net"
 __license__ = "GPL-3.0-or-later"

--- a/fiberq/metadata.txt
+++ b/fiberq/metadata.txt
@@ -1,7 +1,7 @@
 [general]
 name=FiberQ
 description=Open-source fiber network design tools for QGIS (FTTH/GPON/FTTx)
-about=FiberQ helps telecom engineers and GIS professionals design, analyze, and document fiber optic networks inside QGIS. Version 1.2.1 adds full compatibility with QGIS 4 / Qt6 while keeping support for QGIS 3.22 LTR and later, and clears all findings from the QGIS repository security scan. Some advanced features may require an activation key.
+about=FiberQ helps telecom engineers and GIS professionals design, analyze, and document fiber optic networks inside QGIS. FiberQ supports QGIS 4 / Qt6 while keeping support for QGIS 3.22 LTR and later, and clears all findings from the QGIS repository security scan. Some advanced features may require an activation key.
 
 version=1.2.2
 qgisMinimumVersion=3.22


### PR DESCRIPTION
Cosmetic only (QGIS reads the version from metadata.txt, which was already correct). Surfaced by the release-readiness check:
- fiberq/__init__.py: __version__ 1.2.1 -> 1.2.2; dropped stale "v1.3" title and "Version: 1.2.1" header.
- metadata.txt 'about': removed the version-specific "Version 1.2.1 adds..." phrasing so it no longer goes stale.