### PR TITLE
chore: clean plugins.qgis.org scan to zero findings (v1.2.3)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,16 +1,17 @@
 [flake8]
-# FiberQ flake8 configuration.
-# The QGIS plugin repo runs flake8 with defaults (79 chars, all rules) which
-# produces ~1300 E501 warnings on our codebase. We use a 120-char limit
-# which is the common convention for QGIS plugins and most modern Python
-# projects, and we silence a few noisy cosmetic rules that aren't worth
-# chasing across 50+ files of working code.
+# FiberQ flake8 configuration (development only).
+#
+# Kept at the repository ROOT (not inside the fiberq/ package) so it is never
+# shipped in the published plugin zip -- the plugins.qgis.org scanner flags
+# hidden/dotfiles inside the package as "suspicious files".
+#
+# The plugins.qgis.org scanner runs flake8 in isolated mode as:
+#     flake8 --max-line-length=120 --ignore=E501
+# so it does NOT read this file. This config is only for local dev runs.
 
 max-line-length = 120
 
 # Rules silenced with rationale:
-#   E501  covered by max-line-length above -- this entry is redundant but
-#         kept for clarity
 #   E203  whitespace before ':' -- conflicts with PEP 8 for slices
 #   E402  module level import not at top of file -- we do conditional Qt
 #         imports inside try/except, which is correct
@@ -20,12 +21,13 @@ max-line-length = 120
 #         short one-line contexts
 extend-ignore = E203, E402, W503, E731, E741
 
-# Exclude generated/cache directories
+# Exclude generated/cache and dev-only directories
 exclude =
     .git,
     __pycache__,
     build,
     dist,
+    dev,
     *.egg-info
 
 # Per-file rules we accept only where unavoidable

--- a/fiberq/__init__.py
+++ b/fiberq/__init__.py
@@ -6,7 +6,7 @@ including route planning, cable laying, element placement, and documentation.
 
 Supported QGIS Versions: 3.22 LTR - 4.x (Qt5 and Qt6)
 
-Version: 1.2.2 (QGIS Repo)
+Version: 1.2.3 (QGIS Repo)
 """
 
 # Minimum supported QGIS version
@@ -123,7 +123,7 @@ class _FiberQStub:
 # PACKAGE INFO
 # =============================================================================
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __author__ = "Vladimir Vukovic"
 __email__ = "vukovicvl@fiberq.net"
 __license__ = "GPL-3.0-or-later"

--- a/fiberq/addons/fiber_break.py
+++ b/fiberq/addons/fiber_break.py
@@ -144,8 +144,8 @@ class FiberBreakTool(QgsMapTool):
             try:
                 is_break_layer = (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry
-                    and lyr.name() in ("Prekid vlakna", "Fiber break")
+                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.name() in ("Prekid vlakna", "Fiber break")  # noqa: W503
                 )
                 if not is_break_layer:
                     continue
@@ -196,8 +196,8 @@ class FiberBreakTool(QgsMapTool):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
-                    and lyr.isValid()
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.isValid()  # noqa: W503
                 ):
                     yield lyr
             except Exception:

--- a/fiberq/addons/fiberq_preview.py
+++ b/fiberq/addons/fiberq_preview.py
@@ -604,7 +604,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
 
         try:
             current_layers = list(self.canvas.layers())
-        except Exception as e:
+        except Exception:
             current_layers = []
 
         base_layers = getattr(self, "baseLayers", [])
@@ -720,7 +720,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                     self.baseLayers.append(osm)
                     layers_for_canvas.append(osm)
 
-        proj = QgsProject.instance()
+        proj = QgsProject.instance()  # noqa: F841
 
         # Load ALL layers directly from PostGIS with project CRS
         for label, table in layer_defs:
@@ -753,7 +753,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                                 self._apply_preview_manhole_labels(vlayer)
                             vlayer.triggerRepaint()
                             applied_style = True
-                except Exception as e:
+                except Exception:
                     applied_style = False
 
                 if not applied_style:
@@ -781,7 +781,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                 item.setCheckState(QtCore.Qt.CheckState.Checked)
                 self.layersList.addItem(item)
 
-            except Exception as e:
+            except Exception:
                 continue
 
         if layers_for_canvas:
@@ -794,7 +794,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                     self.canvas.setExtent(main_canvas.extent())
                 else:
                     self.canvas.setExtent(layers_for_canvas[-1].extent())
-            except Exception as e:
+            except Exception:
                 self.canvas.setExtent(layers_for_canvas[-1].extent())
             self.canvas.refresh()
             if "Route" in self.previewLayers:
@@ -901,7 +901,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
     def _refresh_layers(self):
         try:
             current_extent = self.canvas.extent()
-        except Exception as e:
+        except Exception:
             current_extent = None
 
         try:
@@ -963,7 +963,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                 continue
             try:
                 ext = layer.extent()
-            except Exception as e:
+            except Exception:
                 continue
             if not ext or ext.isEmpty():
                 continue
@@ -1016,7 +1016,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                 s = str(v).strip()
                 if s:
                     values.add(s)
-        except Exception as e:
+        except Exception:
             self.searchEdit.setCompleter(None)
             return
 
@@ -1127,7 +1127,7 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
 
         try:
             req = QgsFeatureRequest().setFilterExpression(expr)
-        except Exception as e:
+        except Exception:
             QtWidgets.QMessageBox.warning(
                 self, "Locator", "Invalid search expression."
             )

--- a/fiberq/addons/hotkeys.py
+++ b/fiberq/addons/hotkeys.py
@@ -40,13 +40,19 @@ def register_hotkeys(plugin):
                 sc.setContext(Qt.ShortcutContext.ApplicationShortcut)
                 sc.activated.connect(slot)
                 plugin._hk_shortcuts.append(sc)
-        if hasattr(plugin, 'apply_cable_offset'): add('Ctrl+G', plugin.apply_cable_offset)
-        if hasattr(plugin, 'open_bom_dialog'): add('Ctrl+B', plugin.open_bom_dialog)
-        if hasattr(plugin, 'activate_fiber_break_tool'): add('Ctrl+F', plugin.activate_fiber_break_tool)
+        if hasattr(plugin, 'apply_cable_offset'):
+            add('Ctrl+G', plugin.apply_cable_offset)
+        if hasattr(plugin, 'open_bom_dialog'):
+            add('Ctrl+B', plugin.open_bom_dialog)
+        if hasattr(plugin, 'activate_fiber_break_tool'):
+            add('Ctrl+F', plugin.activate_fiber_break_tool)
         pub = getattr(plugin, 'open_publish_dialog', None) or getattr(plugin, 'publish_to_postgis', None)
-        if callable(pub): add('Ctrl+P', pub)
-        if hasattr(plugin, '_start_rezerva_interaktivno'): add('R', lambda: plugin._start_rezerva_interaktivno('zavrsna'))
+        if callable(pub):
+            add('Ctrl+P', pub)
+        if hasattr(plugin, '_start_rezerva_interaktivno'):
+            add('R', lambda: plugin._start_rezerva_interaktivno('zavrsna'))
         # helper: Shift+R -> mid-span slack
-        if hasattr(plugin, '_start_rezerva_interaktivno'): add('Shift+R', lambda: plugin._start_rezerva_interaktivno('prolazna'))
+        if hasattr(plugin, '_start_rezerva_interaktivno'):
+            add('Shift+R', lambda: plugin._start_rezerva_interaktivno('prolazna'))
     except Exception as e:
         logger.debug(f"Error in add: {e}")

--- a/fiberq/addons/infrastructure_cut.py
+++ b/fiberq/addons/infrastructure_cut.py
@@ -57,7 +57,7 @@ class InfrastructureCutTool(QgsMapTool):
     def _map_tol(self):
         try:
             return self._tol_px * self.canvas.mapSettings().mapUnitsPerPixel()
-        except Exception as e:
+        except Exception:
             return 1.0
 
     def _candidate_layers(self):
@@ -90,7 +90,7 @@ class InfrastructureCutTool(QgsMapTool):
         apx, apy = px - ax, py - ay
         ab2 = abx * abx + aby * aby
         if ab2 == 0.0:
-            return (ax, ay, 0.0, (px-ax)**2 + (py-ay)**2)
+            return (ax, ay, 0.0, (px - ax)**2 + (py - ay)**2)
         t = max(0.0, min(1.0, (apx * abx + apy * aby) / ab2))
         cx, cy = ax + t * abx, ay + t * aby
         d2 = (px - cx) ** 2 + (py - cy) ** 2
@@ -128,8 +128,9 @@ class InfrastructureCutTool(QgsMapTool):
                     continue
                 # Walk segments
                 best_seg = None  # (cx, cy, i, t, d2)
-                for i in range(len(poly)-1):
-                    a = poly[i]; b = poly[i+1]
+                for i in range(len(poly) - 1):
+                    a = poly[i]
+                    b = poly[i + 1]
                     cx, cy, t, d2 = self._closest_point_on_segment(map_pt.x(), map_pt.y(), a.x(), a.y(), b.x(), b.y())
                     if best_seg is None or d2 < best_seg[-1]:
                         best_seg = (cx, cy, i, t, d2)
@@ -212,8 +213,10 @@ class InfrastructureCutTool(QgsMapTool):
             return
 
         if not layer.isEditable():
-            try: layer.startEditing()
-            except Exception as e: logger.debug(f"Error in InfrastructureCutTool.canvasReleaseEvent: {e}")
+            try:
+                layer.startEditing()
+            except Exception as e:
+                logger.debug(f"Error in InfrastructureCutTool.canvasReleaseEvent: {e}")
 
         ok = self._split_feature_at_point(layer, feat, cp)
         if ok:
@@ -237,7 +240,8 @@ class InfrastructureCutTool(QgsMapTool):
         # Find nearest segment and insert the cut point
         best = None  # (i, t, d2, cp)
         for i in range(len(poly) - 1):
-            a = poly[i]; b = poly[i+1]
+            a = poly[i]
+            b = poly[i + 1]
             cx, cy, t, d2 = self._closest_point_on_segment(cut_pt.x(), cut_pt.y(), a.x(), a.y(), b.x(), b.y())
             if best is None or d2 < best[2]:
                 best = (i, t, d2, QgsPointXY(cx, cy))
@@ -254,10 +258,10 @@ class InfrastructureCutTool(QgsMapTool):
         if t <= EPS:
             cp = poly[i]
         elif t >= 1.0 - EPS:
-            cp = poly[i+1]
+            cp = poly[i + 1]
         else:
             # Insert new vertex at position i+1
-            poly.insert(i+1, cp)
+            poly.insert(i + 1, cp)
 
         # Recompute index of cp in list (ensure it exists)
         # Find first occurrence by coordinates
@@ -270,16 +274,20 @@ class InfrastructureCutTool(QgsMapTool):
             # splitting at ends creates an empty part -> abort
             return False
 
-        part1 = poly[:idx+1]
-        part2 = [poly[idx]] + poly[idx+1:]
+        part1 = poly[:idx + 1]
+        part2 = [poly[idx]] + poly[idx + 1:]
 
         g1 = QgsGeometry.fromPolylineXY(part1)
         g2 = QgsGeometry.fromPolylineXY(part2)
 
         # Prepare new features
         attrs = feat.attributes()
-        f1 = QgsFeature(layer.fields()); f1.setAttributes(attrs); f1.setGeometry(g1)
-        f2 = QgsFeature(layer.fields()); f2.setAttributes(attrs); f2.setGeometry(g2)
+        f1 = QgsFeature(layer.fields())
+        f1.setAttributes(attrs)
+        f1.setGeometry(g1)
+        f2 = QgsFeature(layer.fields())
+        f2.setAttributes(attrs)
+        f2.setGeometry(g2)
 
         # Update length fields if present
         self._update_length_fields(layer, f1)
@@ -338,15 +346,17 @@ class InfrastructureCutTool(QgsMapTool):
                     feat.setAttribute(idx, int(round(val_m)))
                 else:
                     feat.setAttribute(idx, val_m)
-            except Exception as e:
-                try: feat.setAttribute(idx, val_m)
-                except Exception as e: logger.debug(f"Error in InfrastructureCutTool._norm: {e}")
+            except Exception:
+                try:
+                    feat.setAttribute(idx, val_m)
+                except Exception as e:
+                    logger.debug(f"Error in InfrastructureCutTool._norm: {e}")
 
     # ------------- Misc UI helpers -------------
     def _flash(self, msg: str):
         try:
             self.iface.messageBar().pushWarning("Cutting", msg)
-        except Exception as e:
+        except Exception:
             try:
                 QMessageBox.warning(self.iface.mainWindow(), "Cutting", msg)
             except Exception as e:

--- a/fiberq/addons/reserve_hook.py
+++ b/fiberq/addons/reserve_hook.py
@@ -26,7 +26,7 @@ class ReserveHook(QObject):
     def ensure_connected(self):
         if self._connected:
             return
-        for l in QgsProject.instance().mapLayers().values():
+        for l in QgsProject.instance().mapLayers().values():  # noqa: E741
             try:
                 if isinstance(l, QgsVectorLayer) and l.geometryType() == QgsWkbTypes.PointGeometry and l.name().lower().startswith('opticke_rezerve'):
                     self._connect_layer(l)
@@ -36,7 +36,7 @@ class ReserveHook(QObject):
 
     def _layers_added(self, layers):
         try:
-            for l in layers:
+            for l in layers:  # noqa: E741
                 if isinstance(l, QgsVectorLayer) and l.geometryType() == QgsWkbTypes.PointGeometry and l.name().lower().startswith('opticke_rezerve'):
                     self._connect_layer(l)
         except Exception as e:
@@ -96,7 +96,7 @@ class ReserveHook(QObject):
                     s.changeSymbolLayer(0, sl)
                 else:
                     s.setSizeUnit(QgsUnitTypes.RenderMapUnits)
-            except Exception as e:
+            except Exception:
                 s.setSizeUnit(QgsUnitTypes.RenderMapUnits)
             return s
         cats = [
@@ -161,7 +161,8 @@ class ReserveHook(QObject):
             for fid in changedAttrsMap.keys():
                 f = next(rez.getFeatures(f'id={int(fid)}'), None)
                 if f:
-                    kid = f.attribute(idx_kid); kfid = f.attribute(idx_fid)
+                    kid = f.attribute(idx_kid)
+                    kfid = f.attribute(idx_fid)
                     if kid is not None and kfid is not None:
                         touched.add((kid, int(kfid)))
             for kid, fid in touched:
@@ -181,7 +182,8 @@ class ReserveHook(QObject):
             for fid in geomMap.keys():
                 f = next(rez.getFeatures(f'id={int(fid)}'), None)
                 if f:
-                    kid = f.attribute(idx_kid); kfid = f.attribute(idx_fid)
+                    kid = f.attribute(idx_kid)
+                    kfid = f.attribute(idx_fid)
                     if kid is not None and kfid is not None:
                         touched.add((kid, int(kfid)))
             for kid, fid in touched:
@@ -200,7 +202,8 @@ class ReserveHook(QObject):
             touched = set()
             for f in rez.getFeatures():
                 try:
-                    kid = f.attribute(idx_kid); kfid = f.attribute(idx_fid)
+                    kid = f.attribute(idx_kid)
+                    kfid = f.attribute(idx_fid)
                     if kid is not None and kfid is not None:
                         touched.add((kid, int(kfid)))
                 except Exception as e:
@@ -219,9 +222,10 @@ class ReserveHook(QObject):
 
         # Sum slack from all reserves for this cable
         rez = None
-        for l in proj.mapLayers().values():
+        for l in proj.mapLayers().values():  # noqa: E741
             if isinstance(l, QgsVectorLayer) and l.name().lower().startswith('opticke_rezerve'):
-                rez = l; break
+                rez = l
+                break
         if rez is None:
             return
 
@@ -254,7 +258,10 @@ class ReserveHook(QObject):
         if tot_idx == -1:
             attrs_to_add.append(QgsField('total_len_m', QVariant.Double))
         if attrs_to_add:
-            lyr.startEditing(); lyr.dataProvider().addAttributes(attrs_to_add); lyr.updateFields(); lyr.commitChanges()
+            lyr.startEditing()
+            lyr.dataProvider().addAttributes(attrs_to_add)
+            lyr.updateFields()
+            lyr.commitChanges()
             slack_idx = lyr.fields().indexFromName('slack_m')
             tot_idx = lyr.fields().indexFromName('total_len_m')
 
@@ -264,7 +271,8 @@ class ReserveHook(QObject):
             lyr.changeAttributeValue(int(cable_fid), slack_idx, round(total_slack, 2))
             lyr.changeAttributeValue(int(cable_fid), tot_idx, round((g_m or 0) + total_slack, 2))
         finally:
-            lyr.commitChanges(); lyr.triggerRepaint()
+            lyr.commitChanges()
+            lyr.triggerRepaint()
 
         # Ensure labeling on total_len_m so the user sees the update
         try:

--- a/fiberq/core/cable_manager.py
+++ b/fiberq/core/cable_manager.py
@@ -42,7 +42,7 @@ from ..utils.logger import get_logger
 logger = get_logger(__name__)
 
 # Phase 0.1: UUID support for FiberQ Designer
-from ..utils.uuid_utils import FIBERQ_UUID_FIELD, generate_uuid
+from ..utils.uuid_utils import FIBERQ_UUID_FIELD, generate_uuid  # noqa: E402
 
 
 class CableManager:
@@ -220,7 +220,7 @@ class CableManager:
                 (
                     lyr for lyr in QgsProject.instance().mapLayers().values()
                     if lyr.name().lower().strip() in ("trasa", "route")
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
                 ),
                 None
             )
@@ -359,7 +359,7 @@ class CableManager:
                     line = g.asMultiPolyline()[0]
                 else:
                     line = g.asPolyline()
-            except Exception as e:
+            except Exception:
                 continue
 
             if len(line) < 2:
@@ -462,7 +462,7 @@ class CableManager:
             if hasattr(renderer, "symbol"):
                 try:
                     sym = renderer.symbol()
-                except Exception as e:
+                except Exception:
                     sym = None
             if sym is not None:
                 apply_on_symbol(sym)
@@ -484,11 +484,11 @@ class CableManager:
         """
         try:
             layer = self.iface.activeLayer()
-        except Exception as e:
+        except Exception:
             layer = None
 
         if not (layer and isinstance(layer, QgsVectorLayer)
-                and layer.geometryType() == QgsWkbTypes.LineGeometry):
+                and layer.geometryType() == QgsWkbTypes.LineGeometry):  # noqa: W503
             try:
                 self.iface.messageBar().pushWarning(
                     "Branch cables",
@@ -542,11 +542,11 @@ class CableManager:
             try:
                 if (
                     not isinstance(lyr, QgsVectorLayer)
-                    or lyr.geometryType() != QgsWkbTypes.LineGeometry
-                    or lyr.name() not in candidate_names
+                    or lyr.geometryType() != QgsWkbTypes.LineGeometry  # noqa: W503
+                    or lyr.name() not in candidate_names  # noqa: W503
                 ):
                     continue
-            except Exception as e:
+            except Exception:
                 continue
 
             fields = lyr.fields()
@@ -715,8 +715,8 @@ class CableManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
-                    and lyr.name() in candidate_names
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.name() in candidate_names  # noqa: W503
                 ):
                     cables_layer = lyr
                     break
@@ -859,9 +859,9 @@ class CableManager:
             idx2 = dists2.index(min_dist2)
             if min_dist1 < 1 and min_dist2 < 1 and idx1 != idx2:
                 if idx1 < idx2:
-                    cable_geom = QgsGeometry.fromPolylineXY(line[idx1:idx2+1])
+                    cable_geom = QgsGeometry.fromPolylineXY(line[idx1:idx2 + 1])
                 else:
-                    cable_geom = QgsGeometry.fromPolylineXY(list(reversed(line[idx2:idx1+1])))
+                    cable_geom = QgsGeometry.fromPolylineXY(list(reversed(line[idx2:idx1 + 1])))
                 break
 
         if cable_geom is None:

--- a/fiberq/core/color_manager.py
+++ b/fiberq/core/color_manager.py
@@ -121,7 +121,7 @@ class ColorManager:
             if not isinstance(obj, dict) or "catalogs" not in obj:
                 obj = {"catalogs": self.get_default_color_sets()}
             return obj
-        except Exception as e:
+        except Exception:
             return {"catalogs": self.get_default_color_sets()}
 
     def save_color_catalogs(self, data: Dict[str, Any]) -> None:

--- a/fiberq/core/config_manager.py
+++ b/fiberq/core/config_manager.py
@@ -193,7 +193,7 @@ class ConfigManager:
                 parser = configparser.ConfigParser()
                 parser.read(self.config_file_path, encoding='utf-8')
                 self._config_parser = parser
-        except Exception as e:
+        except Exception:
             self._config_parser = None
 
     def _get_ini_value(
@@ -217,8 +217,8 @@ class ConfigManager:
             return default
 
         try:
-            if (self._config_parser.has_section(section) and
-                self._config_parser.has_option(section, key)):
+            if (self._config_parser.has_section(section) and  # noqa: W504
+                    self._config_parser.has_option(section, key)):
                 return self._config_parser.get(section, key)
         except Exception as e:
             logger.debug(f"Error in ConfigManager._get_ini_value: {e}")
@@ -259,7 +259,7 @@ class ConfigManager:
         """
         try:
             return QSettings().value(self.KEY_LANGUAGE, "en")
-        except Exception as e:
+        except Exception:
             return "en"
 
     def set_language(self, lang: str) -> None:
@@ -288,7 +288,7 @@ class ConfigManager:
         try:
             settings = QSettings(self.SETTINGS_ORG, self.SETTINGS_APP)
             return settings.value(self.KEY_PRO_ENABLED, False, type=bool)
-        except Exception as e:
+        except Exception:
             return False
 
     def set_pro_enabled(self, enabled: bool) -> None:
@@ -320,7 +320,7 @@ class ConfigManager:
         try:
             cleaned_key = key.strip().upper()
             return cleaned_key == self.PRO_MASTER_KEY
-        except Exception as e:
+        except Exception:
             return False
 
     # -------------------------------------------------------------------------
@@ -348,7 +348,7 @@ class ConfigManager:
             project = QgsProject.instance()
             value, success = project.readEntry(scope, key, default)
             return value if success else default
-        except Exception as e:
+        except Exception:
             return default
 
     def set_project_setting(
@@ -371,7 +371,7 @@ class ConfigManager:
         try:
             project = QgsProject.instance()
             return project.writeEntry(scope, key, value)
-        except Exception as e:
+        except Exception:
             return False
 
 

--- a/fiberq/core/data_manager.py
+++ b/fiberq/core/data_manager.py
@@ -63,7 +63,7 @@ class DataManager:
             return {"relations": []}
         try:
             return json.loads(s)
-        except Exception as e:
+        except Exception:
             return {"relations": []}
 
     def save_relations(self, data):
@@ -132,7 +132,7 @@ class DataManager:
             return {"cables": {}}
         try:
             return json.loads(s)
-        except Exception as e:
+        except Exception:
             return {"cables": {}}
 
     def save_latent(self, data):
@@ -211,7 +211,7 @@ class DataManager:
             if not isinstance(obj, dict) or "catalogs" not in obj:
                 obj = {"catalogs": self.get_default_color_sets()}
             return obj
-        except Exception as e:
+        except Exception:
             return {"catalogs": self.get_default_color_sets()}
 
     def save_color_catalogs(self, data):
@@ -395,11 +395,11 @@ class DataManager:
             try:
                 if (
                     not isinstance(lyr, QgsVectorLayer)
-                    or lyr.geometryType() != QgsWkbTypes.LineGeometry
-                    or lyr.name() not in candidate_names
+                    or lyr.geometryType() != QgsWkbTypes.LineGeometry  # noqa: W503
+                    or lyr.name() not in candidate_names  # noqa: W503
                 ):
                     continue
-            except Exception as e:
+            except Exception:
                 continue
 
             fields = lyr.fields()
@@ -466,8 +466,8 @@ class DataManager:
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
-                    and lyr.name() in pipe_names):
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                        and lyr.name() in pipe_names):  # noqa: W503
                     layers.append(lyr)
             except Exception as e:
                 logger.debug(f"Error in DataManager.list_all_pipes: {e}")
@@ -540,7 +540,7 @@ class DataManager:
         try:
             od = str(cable_feature['od']) if 'od' in cable_layer.fields().names() and cable_feature['od'] is not None else ''
             do = str(cable_feature['do']) if 'do' in cable_layer.fields().names() and cable_feature['do'] is not None else ''
-        except Exception as e:
+        except Exception:
             od = ''
             do = ''
 
@@ -569,7 +569,7 @@ class DataManager:
                     try:
                         m = geom.lineLocatePoint(pgeom)
                         m = float(m)
-                    except Exception as e:
+                    except Exception:
                         nearest = geom.closestSegmentWithContext(pgeom.asPoint())[1] if hasattr(geom, 'closestSegmentWithContext') else None
                         m = float(geom.length()) if nearest is None else float(geom.lineLocatePoint(QgsGeometry.fromPointXY(QgsPointXY(nearest))))
 
@@ -591,7 +591,7 @@ class DataManager:
                         "m": m,
                         "distance": float(d),
                     })
-            except Exception as e:
+            except Exception:
                 continue
 
         # Sort and deduplicate

--- a/fiberq/core/drawing_manager.py
+++ b/fiberq/core/drawing_manager.py
@@ -190,7 +190,7 @@ class DrawingManager:
         def norm(p: str) -> str:
             try:
                 return os.path.normcase(os.path.abspath(p)).replace("\\", "/")
-            except Exception as e:
+            except Exception:
                 return (p or "").replace("\\", "/")
 
         target = norm(path)
@@ -219,7 +219,7 @@ class DrawingManager:
                 if target_base and target_base.lower() in src_norm.lower():
                     return True
 
-            except Exception as e:
+            except Exception:
                 continue
 
         return False
@@ -260,7 +260,7 @@ class DrawingManager:
             sublayers = []
             try:
                 sublayers = tmp.dataProvider().subLayers() or tmp.subLayers() or []
-            except Exception as e:
+            except Exception:
                 sublayers = tmp.subLayers() if hasattr(tmp, "subLayers") else []
 
             if not sublayers:
@@ -336,7 +336,7 @@ class DrawingManager:
                 self.CATEGORIES.index(default_cat) if default_cat in self.CATEGORIES else 0,
                 False
             )
-        except Exception as e:
+        except Exception:
             ok = True
             cat = default_cat
         if not ok:

--- a/fiberq/core/export_manager.py
+++ b/fiberq/core/export_manager.py
@@ -155,7 +155,7 @@ class ExportManager:
         driver_name = ""
         try:
             driver_name = QgsVectorFileWriter.driverForExtension(lower_ext)
-        except Exception as e:
+        except Exception:
             driver_name = ""
 
         if not driver_name:
@@ -267,7 +267,7 @@ class ExportManager:
                 logger.debug(f"Error in ExportManager.save_all_layers_to_gpkg: {e}")
 
             # Get all vector layers
-            layers = [l for l in prj.mapLayers().values() if isinstance(l, QgsVectorLayer)]
+            layers = [l for l in prj.mapLayers().values() if isinstance(l, QgsVectorLayer)]  # noqa: E741
             if not layers:
                 self.iface.messageBar().pushWarning("GPKG export", "No vector layers to save.")
                 return
@@ -285,7 +285,7 @@ class ExportManager:
 
             for idx, lyr in enumerate(layers):
                 # Generate unique layer name
-                base = re.sub(r"[^A-Za-z0-9_]+", "_", lyr.name()).strip("_") or f"layer_{idx+1}"
+                base = re.sub(r"[^A-Za-z0-9_]+", "_", lyr.name()).strip("_") or f"layer_{idx + 1}"
                 name = base
                 c = 1
                 while name in used:
@@ -326,7 +326,7 @@ class ExportManager:
                         lyr.saveStyleToDatabase("default", "auto-saved by FiberQ", True, "")
                     except Exception as e:
                         logger.debug(f"Error in ExportManager.save_all_layers_to_gpkg: {e}")
-                except Exception as e:
+                except Exception:
                     # Fallback: add new layer
                     new_lyr = QgsVectorLayer(uri, lyr.name(), "ogr")
                     if new_lyr and new_lyr.isValid():
@@ -429,7 +429,7 @@ class ExportManager:
             except Exception as e:
                 logger.debug(f"Error in ExportManager.export_one_layer_to_gpkg: {e}")
             return True
-        except Exception as e:
+        except Exception:
             return False
 
     # =========================================================================

--- a/fiberq/core/layer_manager.py
+++ b/fiberq/core/layer_manager.py
@@ -33,7 +33,7 @@ from ..utils.logger import get_logger
 logger = get_logger(__name__)
 
 # Phase 0.1: UUID support for FiberQ Designer
-from ..utils.uuid_utils import FIBERQ_UUID_FIELD, ensure_uuid_field
+from ..utils.uuid_utils import FIBERQ_UUID_FIELD, ensure_uuid_field  # noqa: E402
 
 
 # =============================================================================
@@ -45,7 +45,7 @@ def _get_map_icon_path(filename: str) -> str:
     try:
         base = os.path.dirname(os.path.dirname(__file__))
         return os.path.join(base, 'resources', 'map_icons', filename)
-    except Exception as e:
+    except Exception:
         return filename
 
 
@@ -80,7 +80,7 @@ def _normalize_name(s: str) -> str:
         s = s.lower()
         s = re.sub(r"[^a-z0-9_]+", "_", s)
         return s.strip("_")
-    except Exception as e:
+    except Exception:
         return s
 
 
@@ -204,7 +204,7 @@ def _ensure_element_layer_with_style(plugin, layer_name: str):
         # Add default attrs for that element
         try:
             specs = _default_fields_for(layer_name)
-        except Exception as e:
+        except Exception:
             specs = [("naziv", "Naziv", "text", "", None)]
 
         fields = []
@@ -241,7 +241,7 @@ def _ensure_element_layer_with_style(plugin, layer_name: str):
                     logger.debug(f"Error in element layer creation: {e}")
                 try:
                     svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
-                except Exception as e:
+                except Exception:
                     svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
                 symbol.changeSymbolLayer(0, svg_layer)
             except Exception as e:
@@ -259,7 +259,7 @@ def _ensure_element_layer_with_style(plugin, layer_name: str):
         # Apply labels
         try:
             _apply_fixed_text_label(elem_layer, 'naziv', 8.0, 5.0)
-        except Exception as e:
+        except Exception:
             try:
                 s = QgsPalLayerSettings()
                 s.fieldName = "naziv"
@@ -326,7 +326,7 @@ def _copy_attributes_between_layers(src_feat, dst_layer):
         if key not in dst_map:
             try:
                 to_add.append(QgsField(f.name(), f.type() if hasattr(f, "type") else QVariant.String))
-            except Exception as e:
+            except Exception:
                 to_add.append(QgsField(f.name(), QVariant.String))
 
     if to_add and allow_schema_change:
@@ -371,8 +371,8 @@ def _ensure_region_layer(core):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PolygonGeometry
-                    and lyr.name() in ('Rejon', 'Service Area')
+                    and lyr.geometryType() == QgsWkbTypes.PolygonGeometry  # noqa: W503
+                    and lyr.name() in ('Rejon', 'Service Area')  # noqa: W503
                 ):
                     # Rename old 'Rejon' to 'Service Area'
                     if lyr.name() == 'Rejon':
@@ -382,7 +382,7 @@ def _ensure_region_layer(core):
                             logger.debug(f"Error in _ensure_region_layer: {e}")
                     ensure_uuid_field(lyr)
                     return lyr
-            except Exception as e:
+            except Exception:
                 continue
 
         # Create new layer
@@ -440,7 +440,7 @@ def _collect_selected_geometries(core):
                     if not g or g.isEmpty():
                         continue
                     geoms.append((lyr, f, g))
-            except Exception as e:
+            except Exception:
                 continue
     except Exception as e:
         logger.debug(f"Error in _collect_selected_geometries: {e}")
@@ -463,7 +463,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
     if not geoms:
         try:
             QMessageBox.information(core.iface.mainWindow(), 'Create Service Area',
-                                   'No selected objects. Select cables/elements and try again.')
+                                    'No selected objects. Select cables/elements and try again.')
         except Exception as e:
             logger.debug(f"Error in _create_region_from_selection: {e}")
         return False
@@ -484,7 +484,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
                     polys.append(g.buffer(buf_m, 8))
                 else:
                     polys.append(g)
-        except Exception as e:
+        except Exception:
             continue
 
     if not polys:
@@ -497,7 +497,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
     # Union/Dissolve all
     try:
         u = QgsGeometry.unaryUnion(polys)
-    except Exception as e:
+    except Exception:
         u = None
         for p in polys:
             if u is None:
@@ -533,7 +533,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
                     logger.debug(f"Error in _create_region_from_selection: {e}")
         else:
             parts.append(u)
-    except Exception as e:
+    except Exception:
         parts = [u]
 
     region = _ensure_region_layer(core)
@@ -587,7 +587,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
 
     try:
         QMessageBox.information(core.iface.mainWindow(), 'Create Service Area',
-                               f'Created: {added} polygon(s) in "Service Area" layer.')
+                                f'Created: {added} polygon(s) in "Service Area" layer.')
     except Exception as e:
         logger.debug(f"Error in _create_region_from_selection: {e}")
     return True
@@ -633,13 +633,13 @@ def _ensure_objects_layer(core):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.wkbType() in (
+                    and lyr.wkbType() in (  # noqa: W503
                         QgsWkbTypes.Polygon,
                         QgsWkbTypes.MultiPolygon,
                         QgsWkbTypes.PolygonZM,
                         QgsWkbTypes.MultiPolygonZM,
                     )
-                    and lyr.name() in ("Objekti", "Objects")
+                    and lyr.name() in ("Objekti", "Objects")  # noqa: W503
                 ):
                     _apply_objects_field_aliases(lyr)
                     _set_objects_layer_alias(lyr)
@@ -671,7 +671,7 @@ def _ensure_objects_layer(core):
         _set_objects_layer_alias(layer)
 
         return layer
-    except Exception as e:
+    except Exception:
         return None
 
 
@@ -697,7 +697,7 @@ def _stylize_objects_layer(layer):
         try:
             try:
                 hatch.setLineAngle(60.0)
-            except Exception as e:
+            except Exception:
                 try:
                     hatch.setAngle(60.0)
                 except Exception as e:
@@ -777,7 +777,7 @@ def _telecom_save_all_layers_to_gpkg(iface):
         except Exception as e:
             logger.debug(f"Error in _telecom_save_all_layers_to_gpkg: {e}")
 
-        layers = [l for l in prj.mapLayers().values() if isinstance(l, QgsVectorLayer)]
+        layers = [l for l in prj.mapLayers().values() if isinstance(l, QgsVectorLayer)]  # noqa: E741
         if not layers:
             iface.messageBar().pushWarning("GPKG export", "No vector layers to save.")
             return
@@ -794,7 +794,7 @@ def _telecom_save_all_layers_to_gpkg(iface):
         errors = []
 
         for idx, lyr in enumerate(layers):
-            base = re.sub(r"[^A-Za-z0-9_]+", "_", lyr.name()).strip("_") or f"layer_{idx+1}"
+            base = re.sub(r"[^A-Za-z0-9_]+", "_", lyr.name()).strip("_") or f"layer_{idx + 1}"
             name = base
             c = 1
             while name in used:
@@ -832,7 +832,7 @@ def _telecom_save_all_layers_to_gpkg(iface):
                     lyr.saveStyleToDatabase("default", "auto-saved by Telecom plugin", True, "")
                 except Exception as e:
                     logger.debug(f"Error in _telecom_save_all_layers_to_gpkg: {e}")
-            except Exception as e:
+            except Exception:
                 new_lyr = QgsVectorLayer(uri, lyr.name(), "ogr")
                 if new_lyr and new_lyr.isValid():
                     parent = prj.layerTreeRoot().findLayer(lyr.id()).parent()
@@ -921,7 +921,7 @@ def _telecom_export_one_layer_to_gpkg(lyr, gpkg_path, iface):
         except Exception as e:
             logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
         return True
-    except Exception as e:
+    except Exception:
         new_lyr = QgsVectorLayer(uri, lyr.name(), "ogr")
         if new_lyr and new_lyr.isValid():
             prj = QgsProject.instance()
@@ -968,7 +968,7 @@ class LayerManager:
         """Get the current map CRS authority ID."""
         try:
             return self.iface.mapCanvas().mapSettings().destinationCrs().authid()
-        except Exception as e:
+        except Exception:
             return 'EPSG:3857'
 
     # =========================================================================
@@ -987,8 +987,8 @@ class LayerManager:
         # Check if layer exists
         for lyr in project.mapLayers().values():
             if (
-                isinstance(lyr, QgsVectorLayer) and
-                lyr.geometryType() == QgsWkbTypes.PointGeometry and
+                isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
                 lyr.name() in ("Poles", "Stubovi")
             ):
                 self._apply_poles_aliases(lyr)
@@ -1051,8 +1051,8 @@ class LayerManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry
-                    and lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")
+                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")  # noqa: W503
                 ):
                     self._apply_slack_aliases(lyr)
                     ensure_uuid_field(lyr)
@@ -1134,7 +1134,7 @@ class LayerManager:
                     ensure_uuid_field(lyr)
                     self.move_layer_to_top(lyr)
                     return lyr
-            except Exception as e:
+            except Exception:
                 continue
 
         # Create new layer
@@ -1205,7 +1205,7 @@ class LayerManager:
         if group is None:
             try:
                 group = root.insertGroup(0, "Pipes")
-            except Exception as e:
+            except Exception:
                 group = root.addGroup("Pipes")
         else:
             # Rename old group if needed
@@ -1243,8 +1243,8 @@ class LayerManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
-                    and lyr.name() in target_names
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.name() in target_names  # noqa: W503
                 ):
                     self._apply_pipe_aliases(lyr)
                     ensure_uuid_field(lyr)
@@ -1280,7 +1280,7 @@ class LayerManager:
         try:
             group = self.ensure_pipes_group()
             group.addLayer(layer)
-        except Exception as e:
+        except Exception:
             prj.addMapLayer(layer, True)
 
         self.move_group_to_top("Pipes")
@@ -1362,8 +1362,8 @@ class LayerManager:
                 try:
                     if (
                         isinstance(lyr, QgsVectorLayer)
-                        and lyr.geometryType() == QgsWkbTypes.PolygonGeometry
-                        and lyr.name() in ('Rejon', 'Service Area')
+                        and lyr.geometryType() == QgsWkbTypes.PolygonGeometry  # noqa: W503
+                        and lyr.name() in ('Rejon', 'Service Area')  # noqa: W503
                     ):
                         if lyr.name() == 'Rejon':
                             try:
@@ -1372,7 +1372,7 @@ class LayerManager:
                                 logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
                         ensure_uuid_field(lyr)
                         return lyr
-                except Exception as e:
+                except Exception:
                     continue
 
             # Create new layer
@@ -1399,7 +1399,7 @@ class LayerManager:
             proj.addMapLayer(region)
             return region
 
-        except Exception as e:
+        except Exception:
             return None
 
     # =========================================================================
@@ -1421,13 +1421,13 @@ class LayerManager:
                 try:
                     if (
                         isinstance(lyr, QgsVectorLayer)
-                        and lyr.wkbType() in (
+                        and lyr.wkbType() in (  # noqa: W503
                             QgsWkbTypes.Polygon,
                             QgsWkbTypes.MultiPolygon,
                             QgsWkbTypes.PolygonZM,
                             QgsWkbTypes.MultiPolygonZM,
                         )
-                        and lyr.name() in ("Objekti", "Objects")
+                        and lyr.name() in ("Objekti", "Objects")  # noqa: W503
                     ):
                         self._apply_objects_aliases(lyr)
                         ensure_uuid_field(lyr)
@@ -1455,7 +1455,7 @@ class LayerManager:
             self._apply_objects_aliases(layer)
 
             return layer
-        except Exception as e:
+        except Exception:
             return None
 
     def _apply_objects_aliases(self, layer):
@@ -1488,8 +1488,8 @@ class LayerManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry
-                    and lyr.name() == layer_name
+                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.name() == layer_name  # noqa: W503
                 ):
                     self._apply_element_aliases(lyr)
                     ensure_uuid_field(lyr)
@@ -1530,7 +1530,7 @@ class LayerManager:
         try:
             from ..dialogs.base import default_fields_for
             specs = default_fields_for(layer_name)
-        except Exception as e:
+        except Exception:
             specs = [("naziv", "Naziv", "text", "", None)]
 
         fields = []
@@ -1572,7 +1572,7 @@ class LayerManager:
                         logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
                     try:
                         svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
-                    except Exception as e:
+                    except Exception:
                         svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
                     symbol.changeSymbolLayer(0, svg_layer)
                 except Exception as e:
@@ -1614,8 +1614,8 @@ class LayerManager:
         for lyr in prj.mapLayers().values():
             if (
                 isinstance(lyr, QgsVectorLayer)
-                and lyr.name() in ('Route', 'Trasa')
-                and lyr.geometryType() == QgsWkbTypes.LineGeometry
+                and lyr.name() in ('Route', 'Trasa')  # noqa: W503
+                and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
             ):
                 ensure_uuid_field(lyr)
                 return lyr
@@ -1676,12 +1676,12 @@ class LayerManager:
             try:
                 if root.hasCustomLayerOrder():
                     order = list(root.customLayerOrder())
-                    order = [l for l in order if l and l.id() != layer.id()]
+                    order = [l for l in order if l and l.id() != layer.id()]  # noqa: E741
                     order.insert(0, layer)
                     root.setCustomLayerOrder(order)
             except Exception as e:
                 logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
-        except Exception as e:
+        except Exception:
             try:
                 QgsProject.instance().addMapLayer(layer, True)
             except Exception as e:
@@ -1715,7 +1715,7 @@ class LayerManager:
             idx = None
             try:
                 gname = group.name()
-            except Exception as e:
+            except Exception:
                 gname = group_name
 
             for i, ch in enumerate(children):
@@ -1748,7 +1748,7 @@ class LayerManager:
                         return out
 
                     group_layers = _collect_layers(group)
-                    keep = [l for l in order if l not in group_layers]
+                    keep = [l for l in order if l not in group_layers]  # noqa: E741
                     root.setCustomLayerOrder(list(group_layers) + keep)
             except Exception as e:
                 logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")

--- a/fiberq/core/license_manager.py
+++ b/fiberq/core/license_manager.py
@@ -42,7 +42,7 @@ def _fiberq_is_pro_enabled() -> bool:
     try:
         s = QSettings(_FIBERQ_PRO_SETTINGS_ORG, _FIBERQ_PRO_SETTINGS_APP)
         return s.value(_FIBERQ_PRO_ENABLED_KEY, False, type=bool)
-    except Exception as e:
+    except Exception:
         return False
 
 
@@ -75,7 +75,7 @@ def _fiberq_validate_pro_key(key: str) -> bool:
             return False
         k = key.strip().upper()
         return k == _FIBERQ_PRO_MASTER_KEY
-    except Exception as e:
+    except Exception:
         return False
 
 
@@ -143,7 +143,7 @@ def _fiberq_check_pro(iface, feature_label: str = "FiberQ Pro") -> bool:
             )
             return False
 
-    except Exception as e:
+    except Exception:
         return False
 
 

--- a/fiberq/core/pipe_manager.py
+++ b/fiberq/core/pipe_manager.py
@@ -96,7 +96,7 @@ class PipeManager:
             idx = None
             try:
                 gname = group.name()
-            except Exception as e:
+            except Exception:
                 gname = group_name
             for i, ch in enumerate(children):
                 try:
@@ -126,7 +126,7 @@ class PipeManager:
                         return out
 
                     group_layers = _collect_layers(group)
-                    keep = [l for l in order if l not in group_layers]
+                    keep = [l for l in order if l not in group_layers]  # noqa: E741
                     root.setCustomLayerOrder(list(group_layers) + keep)
             except Exception as e:
                 logger.debug(f"Error in PipeManager._collect_layers: {e}")
@@ -155,7 +155,7 @@ class PipeManager:
         if group is None:
             try:
                 group = root.insertGroup(0, "Pipes")
-            except Exception as e:
+            except Exception:
                 group = root.addGroup("Pipes")
         else:
             try:
@@ -229,8 +229,8 @@ class PipeManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
-                    and lyr.name() in target_names
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.name() in target_names  # noqa: W503
                 ):
                     try:
                         self.apply_pipe_field_aliases(lyr)
@@ -265,7 +265,7 @@ class PipeManager:
         try:
             group = self.ensure_pipes_group()
             group.addLayer(layer)
-        except Exception as e:
+        except Exception:
             prj.addMapLayer(layer, True)
 
         try:
@@ -353,8 +353,8 @@ class PipeManager:
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry
-                    and lyr.name() in self.PIPE_LAYER_NAMES):
+                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                        and lyr.name() in self.PIPE_LAYER_NAMES):  # noqa: W503
                     layers.append(lyr)
             except Exception as e:
                 logger.debug(f"Error in PipeManager.list_all_pipes: {e}")

--- a/fiberq/core/relations_manager.py
+++ b/fiberq/core/relations_manager.py
@@ -65,7 +65,7 @@ class RelationsManager:
             return {"relations": []}
         try:
             return json.loads(s)
-        except Exception as e:
+        except Exception:
             return {"relations": []}
 
     def save_relations(self, data: Dict[str, Any]) -> None:
@@ -168,7 +168,7 @@ class RelationsManager:
         return False
 
     def update_relation(self, rid: Any, name: Optional[str] = None,
-                       cables: Optional[List[Dict[str, Any]]] = None) -> bool:
+                        cables: Optional[List[Dict[str, Any]]] = None) -> bool:
         """
         Update an existing relation.
 
@@ -217,7 +217,7 @@ class RelationsManager:
             return {"cables": {}}
         try:
             return json.loads(s)
-        except Exception as e:
+        except Exception:
             return {"cables": {}}
 
     def save_latent(self, data: Dict[str, Any]) -> None:
@@ -269,7 +269,7 @@ class RelationsManager:
         return data.get("cables", {}).get(key, [])
 
     def add_latent_to_cable(self, layer_id: str, fid: int,
-                           element: Dict[str, Any]) -> None:
+                            element: Dict[str, Any]) -> None:
         """
         Add a latent element to a cable.
 
@@ -364,7 +364,7 @@ class RelationsManager:
         try:
             od = str(cable_feature['od']) if 'od' in cable_layer.fields().names() and cable_feature['od'] is not None else ''
             do = str(cable_feature['do']) if 'do' in cable_layer.fields().names() and cable_feature['do'] is not None else ''
-        except Exception as e:
+        except Exception:
             od = ''
             do = ''
 
@@ -393,7 +393,7 @@ class RelationsManager:
                     try:
                         m = geom.lineLocatePoint(pgeom)
                         m = float(m)
-                    except Exception as e:
+                    except Exception:
                         # Fallback: project nearest point and measure distance from start
                         nearest = geom.closestSegmentWithContext(pgeom.asPoint())[1] if hasattr(geom, 'closestSegmentWithContext') else None
                         m = float(geom.length()) if nearest is None else float(geom.lineLocatePoint(QgsGeometry.fromPointXY(QgsPointXY(nearest))))
@@ -416,7 +416,7 @@ class RelationsManager:
                         "m": m,
                         "distance": float(d),
                     })
-            except Exception as e:
+            except Exception:
                 continue
 
         # Sort and remove duplicates

--- a/fiberq/core/route_manager.py
+++ b/fiberq/core/route_manager.py
@@ -128,8 +128,8 @@ class RouteManager:
         return get_first_last_points(geom)
 
     def build_path_across_network(self, route_layer: QgsVectorLayer,
-                                   start_pt: QgsPointXY, end_pt: QgsPointXY,
-                                   tol_units: float) -> Optional[List[QgsPointXY]]:
+                                  start_pt: QgsPointXY, end_pt: QgsPointXY,
+                                  tol_units: float) -> Optional[List[QgsPointXY]]:
         """Route through ALL vertices (including breakpoints) without physically merging features.
 
         Returns list of QgsPointXY or None if no path exists in the network.
@@ -215,8 +215,8 @@ class RouteManager:
         selected_features = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                    lyr.name() in ('Poles', 'Stubovi', 'OKNA', 'Manholes')):
+                if (lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                        lyr.name() in ('Poles', 'Stubovi', 'OKNA', 'Manholes')):
                     if lyr.selectedFeatureCount() > 0:
                         selected_features.extend(lyr.selectedFeatures())
             except Exception as e:

--- a/fiberq/core/slack_manager.py
+++ b/fiberq/core/slack_manager.py
@@ -98,8 +98,8 @@ class SlackManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry
-                    and lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")
+                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")  # noqa: W503
                 ):
                     self.apply_slack_field_aliases(lyr)
                     self.set_slack_layer_alias(lyr)
@@ -182,7 +182,7 @@ class SlackManager:
             expr = f'"cable_layer_id" = \'{cable_layer_id}\' AND "cable_fid" = {int(cable_fid)}'
             try:
                 it = rez.getFeatures(QgsFeatureRequest().setFilterExpression(expr))
-            except Exception as e:
+            except Exception:
                 it = rez.getFeatures()
             for f in it:
                 try:
@@ -219,7 +219,7 @@ class SlackManager:
             if has_total:
                 try:
                     geom_len = float(cable_f.geometry().length())
-                except Exception as e:
+                except Exception:
                     geom_len = 0.0
                 cable_f["total_len_m"] = geom_len + float(slack)
             cable_lyr.updateFeature(cable_f)

--- a/fiberq/core/style_manager.py
+++ b/fiberq/core/style_manager.py
@@ -102,7 +102,7 @@ class StyleManager:
                     (
                         lyr for lyr in QgsProject.instance().mapLayers().values()
                         if lyr.name().lower().strip() in ("trasa", "route")
-                        and lyr.geometryType() == QgsWkbTypes.LineGeometry
+                        and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
                     ),
                     None
                 )
@@ -119,7 +119,7 @@ class StyleManager:
 
             name_l = layer.name().lower()
             is_underground = "podzem" in name_l or "underground" in name_l
-            is_aerial = "vazdus" in name_l or "vazduš" in name_l or "aerial" in name_l
+            is_aerial = "vazdus" in name_l or "vazduš" in name_l or "aerial" in name_l  # noqa: F841
 
             # Colors for cable types
             COLOR_BACKBONE = QColor(0, 51, 153)
@@ -272,13 +272,13 @@ class StyleManager:
             # Size in meters on map
             try:
                 sl.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
-            except Exception as e:
+            except Exception:
                 sl.setSizeUnit(QgsUnitTypes.RenderMapUnits)
 
             # Outline in mm (constant width)
             try:
                 sl.setOutlineWidthUnit(QgsUnitTypes.RenderMillimeters)
-            except Exception as e:
+            except Exception:
                 try:
                     sl.setStrokeWidthUnit(QgsUnitTypes.RenderMillimeters)
                 except Exception as e:
@@ -343,7 +343,7 @@ class StyleManager:
                     if enum_val is None and Qgis:
                         try:
                             enum_val = getattr(Qgis, 'LabelQuadrantPosition').Above
-                        except Exception as e:
+                        except Exception:
                             enum_val = None
                     if enum_val is not None:
                         try:
@@ -479,7 +479,7 @@ class StyleManager:
             try:
                 try:
                     hatch.setLineAngle(60.0)
-                except Exception as e:
+                except Exception:
                     try:
                         hatch.setAngle(60.0)
                     except Exception as e:
@@ -581,7 +581,7 @@ class StyleManager:
                 if hasattr(renderer, "symbol"):
                     try:
                         sym = renderer.symbol()
-                    except Exception as e:
+                    except Exception:
                         sym = None
                 if sym is not None:
                     apply_on_symbol(sym)
@@ -631,7 +631,7 @@ class StyleManager:
                         logger.debug(f"Error in StyleManager.stylize_element_layer: {e}")
                     try:
                         svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
-                    except Exception as e:
+                    except Exception:
                         svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
                     symbol.changeSymbolLayer(0, svg_layer)
                 except Exception as e:

--- a/fiberq/core/undo_manager.py
+++ b/fiberq/core/undo_manager.py
@@ -550,7 +550,7 @@ class FiberQUndoManager:
                     # Prefer the highest FID (most recently added)
                     if best_fid is None or f.id() > best_fid:
                         best_fid = f.id()
-                        best_dist = d
+                        best_dist = d  # noqa: F841
 
         return best_fid
 

--- a/fiberq/dialogs/base.py
+++ b/fiberq/dialogs/base.py
@@ -41,7 +41,7 @@ def normalize_name(s: str) -> str:
         s = s.lower()
         s = re.sub(r"[^a-z0-9_]+", "_", s)
         return s.strip("_")
-    except Exception as e:
+    except Exception:
         return s
 
 

--- a/fiberq/dialogs/bom_dialog.py
+++ b/fiberq/dialogs/bom_dialog.py
@@ -100,7 +100,7 @@ class _BOMDialog(QDialog):
                 logger.debug(f"Error in _BOMDialog.apply_language: {e}")
             # Export button (last widget in root layout)
             try:
-                for i in range(self.layout().count()-1, -1, -1):
+                for i in range(self.layout().count() - 1, -1, -1):
                     w = self.layout().itemAt(i).widget()
                     if isinstance(w, QPushButton):
                         w.setText(_fiberq_translate("Export (.xlsx / .csv)", lang))
@@ -116,7 +116,7 @@ class _BOMDialog(QDialog):
         try:
             d.setSourceCrs(self.iface.mapCanvas().mapSettings().destinationCrs(),
                            QgsProject.instance().transformContext())
-        except Exception as e:
+        except Exception:
             try:
                 d.setSourceCrs(QgsProject.instance().crs(),
                                QgsProject.instance().transformContext())
@@ -128,7 +128,7 @@ class _BOMDialog(QDialog):
     def _build(self):
         """Build the BOM data from project layers."""
         project = QgsProject.instance()
-        layers = [l for l in project.mapLayers().values() if isinstance(l, QgsVectorLayer)]
+        layers = [l for l in project.mapLayers().values() if isinstance(l, QgsVectorLayer)]  # noqa: E741
         d = self._distance_area()
 
         rows = []
@@ -142,7 +142,7 @@ class _BOMDialog(QDialog):
         for lyr in layers:
             try:
                 gtype = lyr.geometryType()
-            except Exception as e:
+            except Exception:
                 continue
 
             # Gather stats
@@ -168,14 +168,14 @@ class _BOMDialog(QDialog):
                     if attr_duz is not None:
                         try:
                             val_len = float(f[attr_duz]) if f[attr_duz] is not None else None
-                        except Exception as e:
+                        except Exception:
                             val_len = None
                     if val_len is None or not (val_len >= 0):
                         try:
                             geom = f.geometry()
                             if geom is not None:
                                 val_len = d.measureLength(geom)
-                        except Exception as e:
+                        except Exception:
                             val_len = 0.0
                     length_m += (val_len or 0.0)
 
@@ -229,7 +229,7 @@ class _BOMDialog(QDialog):
         try:
             import xlsxwriter  # noqa: F401
             has_xlsx = True
-        except Exception as e:
+        except Exception:
             has_xlsx = False
 
         if has_xlsx:
@@ -276,10 +276,14 @@ class _BOMDialog(QDialog):
         # totals sheet
         ws2 = wb.add_worksheet("Total")
         t = self._totals
-        ws2.write(0, 0, "Total length of lines [m]"); ws2.write(0, 1, t["line_len"])
-        ws2.write(1, 0, "Total slack [m]"); ws2.write(1, 1, t["line_slack"])
-        ws2.write(2, 0, "Line + slack [m]"); ws2.write(2, 1, t["line_total"])
-        ws2.write(3, 0, "Total number of point elements"); ws2.write(3, 1, t["points"])
+        ws2.write(0, 0, "Total length of lines [m]")
+        ws2.write(0, 1, t["line_len"])
+        ws2.write(1, 0, "Total slack [m]")
+        ws2.write(1, 1, t["line_slack"])
+        ws2.write(2, 0, "Line + slack [m]")
+        ws2.write(2, 1, t["line_total"])
+        ws2.write(3, 0, "Total number of point elements")
+        ws2.write(3, 1, t["points"])
         wb.close()
         QMessageBox.information(self, "Export", f"XLSX exported:\n{path}")
 

--- a/fiberq/dialogs/color_dialog.py
+++ b/fiberq/dialogs/color_dialog.py
@@ -131,7 +131,7 @@ class ColorCatalogManagerDialog(QDialog):
                 # if dark color, use white text
                 try:
                     c = QColor(hx)
-                    if c.red()*0.299 + c.green()*0.587 + c.blue()*0.114 < 140:
+                    if c.red() * 0.299 + c.green() * 0.587 + c.blue() * 0.114 < 140:
                         it.setForeground(QColor(255, 255, 255))
                 except Exception as e:
                     logger.debug(f"Error in ColorCatalogManagerDialog._on_select_catalog: {e}")
@@ -149,7 +149,7 @@ class ColorCatalogManagerDialog(QDialog):
                 else:
                     self.catalogs.append(c)
                 self._refresh_catalog_list()
-                self.list_catalogs.setCurrentRow(len(self.catalogs)-1)
+                self.list_catalogs.setCurrentRow(len(self.catalogs) - 1)
 
     def _on_edit_catalog(self):
         row = self.list_catalogs.currentRow()
@@ -201,7 +201,7 @@ class ColorCatalogManagerDialog(QDialog):
             else:
                 self.catalogs.append(cat)
             self._refresh_catalog_list()
-            self.list_catalogs.setCurrentRow(max(0, len(self.catalogs)-1))
+            self.list_catalogs.setCurrentRow(max(0, len(self.catalogs) - 1))
             QMessageBox.information(self, "Import", "Catalog imported.")
         except Exception as e:
             QMessageBox.critical(self, "Import", f"Error: {e}")
@@ -284,7 +284,7 @@ class NewColorCatalogDialog(QDialog):
         it.setBackground(QColor(hx))
         try:
             c = QColor(hx)
-            if c.red()*0.299 + c.green()*0.587 + c.blue()*0.114 < 140:
+            if c.red() * 0.299 + c.green() * 0.587 + c.blue() * 0.114 < 140:
                 it.setForeground(QColor(255, 255, 255))
         except Exception as e:
             logger.debug(f"Error in NewColorCatalogDialog._add_color: {e}")
@@ -299,15 +299,15 @@ class NewColorCatalogDialog(QDialog):
         row = self.list.currentRow()
         if row > 0:
             it = self.list.takeItem(row)
-            self.list.insertItem(row-1, it)
-            self.list.setCurrentRow(row-1)
+            self.list.insertItem(row - 1, it)
+            self.list.setCurrentRow(row - 1)
 
     def _move_down(self):
         row = self.list.currentRow()
-        if 0 <= row < self.list.count()-1:
+        if 0 <= row < self.list.count() - 1:
             it = self.list.takeItem(row)
-            self.list.insertItem(row+1, it)
-            self.list.setCurrentRow(row+1)
+            self.list.insertItem(row + 1, it)
+            self.list.setCurrentRow(row + 1)
 
     def result_catalog(self):
         """Returns dict {name, colors:[{name,hex},]}"""

--- a/fiberq/dialogs/latent_dialog.py
+++ b/fiberq/dialogs/latent_dialog.py
@@ -66,7 +66,7 @@ class LatentElementsDialog(QDialog):
                         return
                     if checked:
                         # deselect others
-                        for l in QgsProject.instance().mapLayers().values():
+                        for l in QgsProject.instance().mapLayers().values():  # noqa: E741
                             if isinstance(l, QgsVectorLayer):
                                 l.removeSelection()
                         lyr.selectByIds([fid])
@@ -173,9 +173,9 @@ class CablePitstopsDialog(QDialog):
         for i, it in enumerate(cands, start=1):
             latent = saved.get((it["layer_id"], it["fid"]), False)
             self.elements.append({**it, "latent": latent})
-            self.tbl.setItem(i-1, 0, QTableWidgetItem(str(i)))
-            self.tbl.setItem(i-1, 1, QTableWidgetItem(it.get("naziv", f"{it['layer_name']}:{it['fid']}")))
-            self.tbl.setItem(i-1, 2, QTableWidgetItem("YES" if latent else "NO"))
+            self.tbl.setItem(i - 1, 0, QTableWidgetItem(str(i)))
+            self.tbl.setItem(i - 1, 1, QTableWidgetItem(it.get("naziv", f"{it['layer_name']}:{it['fid']}")))
+            self.tbl.setItem(i - 1, 2, QTableWidgetItem("YES" if latent else "NO"))
 
     def _toggle_row(self, item):
         row = item.row()

--- a/fiberq/dialogs/locator_dialog.py
+++ b/fiberq/dialogs/locator_dialog.py
@@ -142,7 +142,7 @@ class LocatorDialog(QDialog):
             from urllib.parse import quote
             url = (
                 "https://nominatim.openstreetmap.org/search?format=json&limit=1&q="
-                + quote(query)
+                + quote(query)  # noqa: W503
             )
             data = _http_get_json(
                 url,

--- a/fiberq/dialogs/region_dialog.py
+++ b/fiberq/dialogs/region_dialog.py
@@ -53,7 +53,7 @@ class CreateRegionDialog(QDialog):
         """Get the buffer/margin value in meters."""
         try:
             return float(self.spin_buffer.value())
-        except Exception as e:
+        except Exception:
             return 0.0
 
     def region_name(self) -> str:

--- a/fiberq/dialogs/relations_dialog.py
+++ b/fiberq/dialogs/relations_dialog.py
@@ -31,10 +31,10 @@ from qgis.PyQt.QtWidgets import (
 
 pass
 
-from ..utils.legacy_bridge import RELACIJE_KATEGORIJE
+from ..utils.legacy_bridge import RELACIJE_KATEGORIJE  # noqa: E402
 
 # Phase 5.2: Logging
-from ..utils.logger import get_logger
+from ..utils.logger import get_logger  # noqa: E402
 logger = get_logger(__name__)
 
 
@@ -190,7 +190,7 @@ class RelationsDialog(QDialog):
         # Defensive guard if dialog reopened before cables are loaded
         if not hasattr(self, 'cables') or self.cables is None:
             self.cables = []
-        rid = self._current_relation_id()
+        rid = self._current_relation_id()  # noqa: F841
         # Show assigned relation names for all cables (not only the selected relation).
         rel_name_by_cable = {}
         for r in self.data.get("relations", []):

--- a/fiberq/dialogs/schematic_dialog.py
+++ b/fiberq/dialogs/schematic_dialog.py
@@ -74,7 +74,7 @@ class SchematicView(QGraphicsView):
 
     def wheelEvent(self, event):
         """Zoom with mouse wheel."""
-        factor = 1.15 if event.angleDelta().y() > 0 else 1/1.15
+        factor = 1.15 if event.angleDelta().y() > 0 else 1 / 1.15
         self.scale(factor, factor)
 
     def mousePressEvent(self, event):
@@ -281,7 +281,7 @@ class OpticalSchematicDialog(QDialog):
             self.view.centerOn(x, y)
             # highlight momentarily
             r = 12.0
-            item = self.scene.addEllipse(x-r, y-r, 2*r, 2*r, QPen(QColor(255, 165, 0), 2.4), Qt.BrushStyle.NoBrush)
+            item = self.scene.addEllipse(x - r, y - r, 2 * r, 2 * r, QPen(QColor(255, 165, 0), 2.4), Qt.BrushStyle.NoBrush)
             item.setZValue(10)
 
             def _remove():
@@ -327,7 +327,7 @@ class OpticalSchematicDialog(QDialog):
                                     if fields.indexFromName('tip') != -1 and f['tip'] is not None
                                     else ''
                                 )
-                            except Exception as e:
+                            except Exception:
                                 tip = ''
                             nm = ("Pole " + tip).strip() or f"Pole {int(f.id())}"  # Stub -> Pole
 
@@ -337,7 +337,7 @@ class OpticalSchematicDialog(QDialog):
                                 "layer_name": lname,
                                 "fid": int(f.id()),
                             }
-            except Exception as e:
+            except Exception:
                 continue
         return nodes
 
@@ -375,11 +375,11 @@ class OpticalSchematicDialog(QDialog):
                     for p in pl:
                         pt = xform.transform(QgsPointXY(p.x(), p.y()))
                         coords.append((pt.x(), pt.y()))
-            except Exception as e:
+            except Exception:
                 coords = []
             try:
                 length_m = float(geom.length())
-            except Exception as e:
+            except Exception:
                 length_m = 0.0
 
             lname = (it.get('layer_name') or lyr.name() or '').lower()
@@ -400,14 +400,14 @@ class OpticalSchematicDialog(QDialog):
             low_lname = raw_lname.lower()
             is_pipe = (
                 'cevi' in low_lname
-                or 'pipe' in low_lname
-                or 'duct' in low_lname
-                or (it.get('tip') or '').lower() == 'pipe'
+                or 'pipe' in low_lname  # noqa: W503
+                or 'duct' in low_lname  # noqa: W503
+                or (it.get('tip') or '').lower() == 'pipe'  # noqa: W503
             )
 
             edges.append({
                 "from": str(gv('od')).strip(),
-                "to":   str(gv('do')).strip(),
+                "to": str(gv('do')).strip(),
                 "podtip": str(gv('podtip')).lower(),
                 "kapacitet": gv('kapacitet'),
                 "geom_coords": coords,
@@ -534,13 +534,13 @@ class OpticalSchematicDialog(QDialog):
                         try:
                             d = g.length()
                             pt = g.interpolate(d / 2.0).asPoint()
-                        except Exception as e:
+                        except Exception:
                             ps = g.asPolyline()
                             pt = ps[len(ps) // 2] if ps else None
                     else:
                         try:
                             pt = g.centroid().asPoint()
-                        except Exception as e:
+                        except Exception:
                             pt = None
                     if pt is None:
                         continue
@@ -551,7 +551,7 @@ class OpticalSchematicDialog(QDialog):
                     ptt = tr.transform(QgsPointXY(pt.x(), pt.y()))
                     pos[name] = (ptt.x(), ptt.y())
                     world_points.append((ptt.x(), ptt.y()))
-                except Exception as e:
+                except Exception:
                     continue
 
             # Add all points from cable/pipe geometry
@@ -775,7 +775,7 @@ class OpticalSchematicDialog(QDialog):
                 rect = ti.mapRectToScene(ti.boundingRect())
                 if not any(rect.intersects(r) for r in occupied):
                     bg = rect.adjusted(-2, -1, 2, 2)
-                    self.scene.addRect(bg, QPen(Qt.PenStyle.NoPen), QColor(255, 255, 255, 210)).setZValue(ti.zValue()-1)
+                    self.scene.addRect(bg, QPen(Qt.PenStyle.NoPen), QColor(255, 255, 255, 210)).setZValue(ti.zValue() - 1)
                     occupied.append(bg)
                     return
             occupied.append(ti.mapRectToScene(ti.boundingRect()))
@@ -808,7 +808,7 @@ class OpticalSchematicDialog(QDialog):
         for name, meta in nodes.items():
             x, y = pos.get(name, (0.0, 0.0))
             r = 6.0
-            self.scene.addEllipse(x-r, y-r, 2*r, 2*r, QPen(Qt.GlobalColor.black), QColor(240, 240, 240))
+            self.scene.addEllipse(x - r, y - r, 2 * r, 2 * r, QPen(Qt.GlobalColor.black), QColor(240, 240, 240))
             if self.chk_labels.isChecked():
                 place_text(x, y, str(name), QColor(10, 10, 10))
 
@@ -818,10 +818,10 @@ class OpticalSchematicDialog(QDialog):
     def _export_png(self):
         from qgis.PyQt.QtGui import QImage, QPainter
         rect = self.scene.itemsBoundingRect().adjusted(10, 10, 10, 10)
-        img = QImage(int(rect.width())+40, int(rect.height())+40, QImage.Format.Format_ARGB32)
+        img = QImage(int(rect.width()) + 40, int(rect.height()) + 40, QImage.Format.Format_ARGB32)
         img.fill(0x00ffffff)
         p = QPainter(img)
-        p.translate(-rect.x()+20, -rect.y()+20)
+        p.translate(-rect.x() + 20, -rect.y() + 20)
         self.scene.render(p)
         p.end()
         fn, _ = QFileDialog.getSaveFileName(self, "Save PNG", "optical_schematic.png", "PNG (*.png)")
@@ -831,10 +831,10 @@ class OpticalSchematicDialog(QDialog):
     def _export_jpg(self):
         from qgis.PyQt.QtGui import QImage, QPainter
         rect = self.scene.itemsBoundingRect().adjusted(10, 10, 10, 10)
-        img = QImage(int(rect.width())+40, int(rect.height())+40, QImage.Format.Format_RGB32)
+        img = QImage(int(rect.width()) + 40, int(rect.height()) + 40, QImage.Format.Format_RGB32)
         img.fill(0xffffffff)
         p = QPainter(img)
-        p.translate(-rect.x()+20, -rect.y()+20)
+        p.translate(-rect.x() + 20, -rect.y() + 20)
         self.scene.render(p)
         p.end()
         fn, _ = QFileDialog.getSaveFileName(self, "Save JPG", "optical_schematic.jpg", "JPG (*.jpg)")
@@ -846,7 +846,7 @@ class OpticalSchematicDialog(QDialog):
             from qgis.PyQt.QtSvg import QSvgGenerator
             from qgis.PyQt.QtGui import QPainter
 
-        except Exception as e:
+        except Exception:
             return
         rect = self.scene.itemsBoundingRect().adjusted(10, 10, 10, 10)
         fn, _ = QFileDialog.getSaveFileName(self, "Save SVG", "optical_schematic.svg", "SVG (*.svg)")
@@ -854,10 +854,10 @@ class OpticalSchematicDialog(QDialog):
             return
         gen = QSvgGenerator()
         gen.setFileName(fn)
-        gen.setSize(QSize(int(rect.width())+40, int(rect.height())+40))
-        gen.setViewBox(QRect(0, 0, int(rect.width())+40, int(rect.height())+40))
+        gen.setSize(QSize(int(rect.width()) + 40, int(rect.height()) + 40))
+        gen.setViewBox(QRect(0, 0, int(rect.width()) + 40, int(rect.height()) + 40))
         p = QPainter(gen)
-        p.translate(-rect.x()+20, -rect.y()+20)
+        p.translate(-rect.x() + 20, -rect.y() + 20)
         self.scene.render(p)
         p.end()
 
@@ -872,7 +872,7 @@ class OpticalSchematicDialog(QDialog):
                 # fallback, if no timer
                 self._rebuild_pending = False
                 self.rebuild()
-        except Exception as e:
+        except Exception:
             # if something goes wrong, don't block – do direct rebuild
             self._rebuild_pending = False
             self.rebuild()

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -9,7 +9,7 @@ from qgis.core import (
     QgsProject, QgsField, QgsFeature,
     QgsGeometry, QgsPointXY, QgsWkbTypes,
     QgsSymbol, QgsUnitTypes, QgsCoordinateTransform
-    )
+)
 from qgis.PyQt.QtGui import QIcon, QColor
 
 # =============================================================================
@@ -36,20 +36,20 @@ logger = get_logger(__name__)
 # For backward compatibility with QSettings import
 try:
     from qgis.PyQt.QtCore import QSettings
-except Exception as e:
+except Exception:
     QSettings = None
 
 # =============================================================================
 # Phase 1.2: Pro License functions moved to core/license_manager.py
 # =============================================================================
-from .core.license_manager import (
+from .core.license_manager import (  # noqa: E402
     _fiberq_check_pro,
 )
 
 # =============================================================================
 # Phase 1.3: Layer utility functions moved to core/layer_manager.py
 # =============================================================================
-from .core.layer_manager import (
+from .core.layer_manager import (  # noqa: E402
     # Element definitions
     ELEMENT_DEFS,
     NASTAVAK_DEF,
@@ -63,7 +63,7 @@ from .core.layer_manager import (
 )
 
 # Re-exported for ui/ (objects_ui, routing_ui); pending WP2 extraction
-from .core.layer_manager import (  # noqa: F401
+from .core.layer_manager import (  # noqa: E402, F401
     _ensure_objects_layer,
     _stylize_objects_layer,
     _telecom_export_one_layer_to_gpkg,
@@ -74,10 +74,10 @@ from .core.layer_manager import (  # noqa: F401
 # - _fiberq_translate, _apply_text_and_tooltip, _apply_menu_language, _element_icon_for
 # =============================================================================
 
-from qgis.gui import QgsVertexMarker
-from qgis.PyQt.QtCore import QVariant
-from qgis.PyQt import sip
-import os
+from qgis.gui import QgsVertexMarker  # noqa: E402
+from qgis.PyQt.QtCore import QVariant  # noqa: E402
+from qgis.PyQt import sip  # noqa: E402
+import os  # noqa: E402
 
 # === FIXED LABEL UTILITY (screen-fixed text in mm) ===
 # =============================================================================
@@ -112,23 +112,23 @@ def _apply_element_aliases(layer):
 pass
 # === UI GROUPS (modular menus/buttons) ===
 # RoutingUI moved to ui/routing_ui.py (Phase 5)
-from .ui.routing_ui import RoutingUI
+from .ui.routing_ui import RoutingUI  # noqa: E402
 
 
 # DrawingsUI moved to ui/drawings_ui.py (Phase 5)
-from .ui.drawings_ui import DrawingsUI
+from .ui.drawings_ui import DrawingsUI  # noqa: E402
 
 # CableLayingUI moved to ui/cable_ui.py (Phase 5)
-from .ui.cable_ui import CableLayingUI
+from .ui.cable_ui import CableLayingUI  # noqa: E402
 
 # ElementPlacementUI moved to ui/elements_ui.py (Phase 5)
-from .ui.elements_ui import ElementPlacementUI
+from .ui.elements_ui import ElementPlacementUI  # noqa: E402
 
 # DuctingUI moved to ui/ducting_ui.py (Phase 5)
-from .ui.ducting_ui import DuctingUI
+from .ui.ducting_ui import DuctingUI  # noqa: E402
 
 # SelectionUI moved to ui/selection_ui.py (Phase 5)
-from .ui.selection_ui import SelectionUI
+from .ui.selection_ui import SelectionUI  # noqa: E402
 
 # Internal values written to field "tip_trase"
 TRASA_TYPE_OPTIONS = ["vazdusna", "podzemna", "kroz objekat"]
@@ -183,7 +183,8 @@ class FiberQPlugin:
         ]:
             try:
                 a = getattr(self, name, None)
-                if a: _apply_text_and_tooltip(a, lang)
+                if a:
+                    _apply_text_and_tooltip(a, lang)
             except Exception as e:
                 logger.debug(f"Could not translate action '{name}': {e}")
 
@@ -532,67 +533,67 @@ class FiberQPlugin:
 
     # --- Change element type ---
     def _change_element_type(self, src_layer, src_fid, new_name: str):
-            """Move feature from src_layer to target layer `new_name`.
-            Safe against PK/UNIQUE constraints (won't copy fid; won't delete source if insert fails).
-            """
-            from qgis.core import QgsFeature, QgsGeometry
+        """Move feature from src_layer to target layer `new_name`.
+        Safe against PK/UNIQUE constraints (won't copy fid; won't delete source if insert fails).
+        """
+        from qgis.core import QgsFeature, QgsGeometry
 
-            # get source feature
-            f = None
-            for feat in src_layer.getFeatures():
-                if int(feat.id()) == int(src_fid):
-                    f = feat
-                    break
-            if f is None:
-                raise RuntimeError("Selected element was not found.")
+        # get source feature
+        f = None
+        for feat in src_layer.getFeatures():
+            if int(feat.id()) == int(src_fid):
+                f = feat
+                break
+        if f is None:
+            raise RuntimeError("Selected element was not found.")
 
-            # ensure target layer
-            dst_layer = _ensure_element_layer_with_style(self, new_name)
+        # ensure target layer
+        dst_layer = _ensure_element_layer_with_style(self, new_name)
 
-            # copy attributes (without PK fields)
-            vals = _copy_attributes_between_layers(f, dst_layer)
+        # copy attributes (without PK fields)
+        vals = _copy_attributes_between_layers(f, dst_layer)
 
-            # create new feature
-            new_f = QgsFeature(dst_layer.fields())
+        # create new feature
+        new_f = QgsFeature(dst_layer.fields())
+        try:
+            new_f.setGeometry(QgsGeometry(f.geometry()))
+        except Exception as e:
+            logger.debug(f"Could not create geometry copy, using original: {e}")
+            new_f.setGeometry(f.geometry())
+
+        for k, v in vals.items():
             try:
-                new_f.setGeometry(QgsGeometry(f.geometry()))
-            except Exception as e:
-                logger.debug(f"Could not create geometry copy, using original: {e}")
-                new_f.setGeometry(f.geometry())
-
-            for k, v in vals.items():
-                try:
-                    new_f.setAttribute(k, v)
-                except Exception as e:
-                    logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
-
-            # INSERT into destination (check success!)
-            dst_layer.startEditing()
-            ok = dst_layer.addFeature(new_f)
-            if not ok:
-                try:
-                    dst_layer.rollBack()
-                except Exception as e:
-                    logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
-                raise RuntimeError("Failed to insert into target layer (constraint/PK conflict).")
-
-            if not dst_layer.commitChanges():
-                try:
-                    dst_layer.rollBack()
-                except Exception as e:
-                    logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
-                raise RuntimeError("Failed to commit changes to target layer.")
-
-            dst_layer.triggerRepaint()
-
-            # delete old only after successful insert
-            try:
-                src_layer.startEditing()
-                src_layer.deleteFeature(int(src_fid))
-                src_layer.commitChanges()
-                src_layer.triggerRepaint()
+                new_f.setAttribute(k, v)
             except Exception as e:
                 logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
+
+        # INSERT into destination (check success!)
+        dst_layer.startEditing()
+        ok = dst_layer.addFeature(new_f)
+        if not ok:
+            try:
+                dst_layer.rollBack()
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
+            raise RuntimeError("Failed to insert into target layer (constraint/PK conflict).")
+
+        if not dst_layer.commitChanges():
+            try:
+                dst_layer.rollBack()
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
+            raise RuntimeError("Failed to commit changes to target layer.")
+
+        dst_layer.triggerRepaint()
+
+        # delete old only after successful insert
+        try:
+            src_layer.startEditing()
+            src_layer.deleteFeature(int(src_fid))
+            src_layer.commitChanges()
+            src_layer.triggerRepaint()
+        except Exception as e:
+            logger.debug(f"Error in FiberQPlugin._change_element_type: {e}")
 
     def activate_change_element_type_tool(self):
         try:
@@ -1163,7 +1164,7 @@ class FiberQPlugin:
         # Cut infrastructure (new tool)
         try:
             icon_sec = _load_icon('ic_infrastructure_cut.svg')
-        except Exception as e:
+        except Exception:
             try:
                 from qgis.PyQt.QtGui import QIcon as _QIconTmp
                 icon_sec = _QIconTmp()
@@ -1172,7 +1173,7 @@ class FiberQPlugin:
                 icon_sec = None
         try:
             self.action_infra_cut = QAction(icon_sec, "Cut infrastructure", self.iface.mainWindow())
-        except Exception as e:
+        except Exception:
             self.action_infra_cut = QAction("Cut infrastructure")
         try:
             self.action_infra_cut.setObjectName("action_infrastructure_cut")
@@ -1226,7 +1227,7 @@ class FiberQPlugin:
         # === Auto-added button: Save all layers to GeoPackage ===
         try:
             icon_save_gpkg = _load_icon('ic_save_gpkg.svg')
-        except Exception as e:
+        except Exception:
             from qgis.PyQt.QtGui import QIcon as _QIconTmp
             icon_save_gpkg = _QIconTmp()
         self.action_save_gpkg = QAction(icon_save_gpkg, "Save all layers to GeoPackage", self.iface.mainWindow())
@@ -1235,7 +1236,7 @@ class FiberQPlugin:
         # Add to toolbar and list for clean removal
         try:
             self.toolbar.addAction(self.action_save_gpkg)
-        except Exception as e:
+        except Exception:
             # Ako plugin nema svoju toolbar promenljivu
             self.iface.addToolBarIcon(self.action_save_gpkg)
         try:
@@ -1275,7 +1276,7 @@ class FiberQPlugin:
         self.action_open_fiberq_web.triggered.connect(self.open_fiberq_web)
         try:
             self.toolbar.addAction(self.action_open_fiberq_web)
-        except Exception as e:
+        except Exception:
             self.iface.addToolBarIcon(self.action_open_fiberq_web)
         try:
             self.actions.append(self.action_open_fiberq_web)
@@ -1290,7 +1291,7 @@ class FiberQPlugin:
             self.action_create_region.triggered.connect(self.run_create_service_area)
             try:
                 self.toolbar.addAction(self.action_create_region)
-            except Exception as e:
+            except Exception:
                 self.iface.addToolBarIcon(self.action_create_region)
             try:
                 self.actions.append(self.action_create_region)
@@ -1366,7 +1367,7 @@ class FiberQPlugin:
             logger.debug(f"Error in FiberQPlugin.initGui: {e}")
         try:
             self.toolbar.addAction(self.action_hotkeys)
-        except Exception as e:
+        except Exception:
             try:
                 self.iface.addToolBarIcon(self.action_hotkeys)
             except Exception as e:
@@ -1383,7 +1384,7 @@ class FiberQPlugin:
                 self.action_bom.setIcon(_load_icon('ic_bom.svg'))
             except Exception as e:
                 logger.debug(f"Error in FiberQPlugin.initGui: {e}")
-        except Exception as e:
+        except Exception:
             # fallback if QAction construction with parent fails
             self.action_bom = QAction("BOM izveštaj (XLSX/CSV)")
 
@@ -1398,7 +1399,7 @@ class FiberQPlugin:
             logger.debug(f"Error in FiberQPlugin.initGui: {e}")
         try:
             self.toolbar.addAction(self.action_bom)
-        except Exception as e:
+        except Exception:
             self.iface.addToolBarIcon(self.action_bom)
         try:
             self.actions.append(self.action_bom)
@@ -1495,7 +1496,7 @@ class FiberQPlugin:
                 self.action_change_element_type.triggered.connect(self.activate_change_element_type_tool)
                 try:
                     self.toolbar.addAction(self.action_change_element_type)
-                except Exception as e:
+                except Exception:
                     try:
                         self.iface.addToolBarIcon(self.action_change_element_type)
                     except Exception as e:
@@ -1529,7 +1530,7 @@ class FiberQPlugin:
                 self.toolbar.addAction(self.action_move_elements)
                 self.toolbar.addAction(self.action_import_image)
                 self.toolbar.addAction(self.action_clear_image)
-            except Exception as e:
+            except Exception:
                 try:
                     self.iface.addToolBarIcon(self.action_move_elements)
                     self.iface.addToolBarIcon(self.action_import_image)
@@ -1664,7 +1665,7 @@ class FiberQPlugin:
             from .addons.fiber_break import FiberBreakTool
             self._fiber_break_tool = FiberBreakTool(self.iface)
             self.iface.mapCanvas().setMapTool(self._fiber_break_tool)
-        except Exception as e:
+        except Exception:
             try:
                 # fallback keeps previous behavior (compatibility)
                 symbol_spec = {
@@ -1723,7 +1724,7 @@ class FiberQPlugin:
                     except Exception as e:
                         logger.debug(f"Error in FiberQPlugin.activate_fiber_break_tool: {e}")
 
-        except Exception as e:
+        except Exception:
             # if something fails, do not crash tool - just skip style
             pass
 
@@ -2023,7 +2024,7 @@ class FiberQPlugin:
             node = root.findLayer(self.layer.id())
             if node:
                 node.setCustomLayerName("Poles")
-        except Exception as e:
+        except Exception:
             # If something fails (e.g. layerTreeRoot not ready), just skip
             pass
 
@@ -2151,8 +2152,8 @@ class FiberQPlugin:
             # - or if layer actually has only id,fid,naziv fields
             if gtype == QgsWkbTypes.PointGeometry and (
                 lname_l.startswith("joint closures")
-                or lname_l.startswith("nastav")
-                or fset.issubset({"id", "fid", "naziv"})
+                or lname_l.startswith("nastav")  # noqa: W503
+                or fset.issubset({"id", "fid", "naziv"})  # noqa: W503
             ):
                 alias_map = {
                     "id": "ID",
@@ -2171,8 +2172,8 @@ class FiberQPlugin:
             # 3.5) ROUTE (Line) – EN field aliases + EN layer name (posle export/import iz Preview Map)
             if gtype == QgsWkbTypes.LineGeometry and (
                 lname_l.startswith("route")
-                or lname_l.startswith("trasa")
-                or {"naziv", "duzina", "tip_trase"}.issubset(fset)
+                or lname_l.startswith("trasa")  # noqa: W503
+                or {"naziv", "duzina", "tip_trase"}.issubset(fset)  # noqa: W503
             ):
                 try:
                     self._apply_route_field_aliases(layer)   # EN user view (aliases + valuemap)
@@ -2185,8 +2186,8 @@ class FiberQPlugin:
             # 3.6) POLES (Point) – EN field aliases + EN layer name
             if gtype == QgsWkbTypes.PointGeometry and (
                 lname_l.startswith("poles")
-                or lname_l.startswith("stubov")
-                or {"tip", "podtip", "visina", "materijal"}.issubset(fset)
+                or lname_l.startswith("stubov")  # noqa: W503
+                or {"tip", "podtip", "visina", "materijal"}.issubset(fset)  # noqa: W503
             ):
                 try:
                     self._apply_poles_field_aliases(layer)   # EN user view
@@ -2199,8 +2200,8 @@ class FiberQPlugin:
             # 3.7) MANHOLES / OKNA (Point) – EN field aliases + EN layer name
             if gtype == QgsWkbTypes.PointGeometry and (
                 lname_l.startswith("manholes")
-                or lname_l.startswith("okna")
-                or {"broj_okna", "tip_okna"}.issubset(fset)
+                or lname_l.startswith("okna")  # noqa: W503
+                or {"broj_okna", "tip_okna"}.issubset(fset)  # noqa: W503
             ):
                 try:
                     self._apply_manhole_field_aliases(layer)    # EN user view
@@ -2213,14 +2214,14 @@ class FiberQPlugin:
             # 4) GENERIC “Placing elements” (ODF/TB/OTB/TO/Patch panel/Optical slacks…)
             if (
                 gtype in (QgsWkbTypes.PointGeometry, QgsWkbTypes.PolygonGeometry)
-                and (
+                and (  # noqa: W503
                     "proizvodjac" in fset
-                    or "kapacitet" in fset
-                    or "oznaka" in fset
-                    or "address_id" in fset
-                    or "naziv_objekta" in fset
-                    or "adresa_ulica" in fset
-                    or "stanje" in fset
+                    or "kapacitet" in fset  # noqa: W503
+                    or "oznaka" in fset  # noqa: W503
+                    or "address_id" in fset  # noqa: W503
+                    or "naziv_objekta" in fset  # noqa: W503
+                    or "adresa_ulica" in fset  # noqa: W503
+                    or "stanje" in fset  # noqa: W503
                 )
             ):
                 # SR->EN field aliases (user view)
@@ -2279,7 +2280,7 @@ class FiberQPlugin:
             # THIS IS A CHECK THAT USES capabilities()
             if isinstance(lyr, QgsVectorLayer) and (
                 lyr.isEditable()
-                or lyr.dataProvider().capabilities() & QgsVectorDataProvider.DeleteFeatures
+                or lyr.dataProvider().capabilities() & QgsVectorDataProvider.DeleteFeatures  # noqa: W503
             ):
                 selected_feats = list(lyr.selectedFeatures())
 
@@ -2474,7 +2475,7 @@ class FiberQPlugin:
                 nm = NASTAVAK_DEF.get("name", "Joint Closures")
                 if nm and nm not in node_layer_names:
                     node_layer_names.append(nm)
-            except Exception as e:
+            except Exception:
                 if 'Nastavci' not in node_layer_names:
                     node_layer_names.append('Nastavci')
             # all elements from Placing elements (ELEMENT_DEFS)
@@ -2488,8 +2489,8 @@ class FiberQPlugin:
         existing_layers = [
             lyr for lyr in QgsProject.instance().mapLayers().values()
             if isinstance(lyr, QgsVectorLayer)
-            and lyr.geometryType() == QgsWkbTypes.PointGeometry
-            and lyr.name() in node_layer_names
+            and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+            and lyr.name() in node_layer_names  # noqa: W503
         ]
         layer_names = [lyr.name() for lyr in existing_layers]
 
@@ -2510,7 +2511,6 @@ class FiberQPlugin:
             return
 
         # 1) If new layer option selected (Serbian or English)
-                # If new layer option selected (Serbian or English)
         if selected_layer_name in (NEW_LAYER_OPTION_EN, NEW_LAYER_OPTION_SR):
             new_layer_name, ok2 = QInputDialog.getText(
                 self.iface.mainWindow(),
@@ -2532,7 +2532,7 @@ class FiberQPlugin:
                     if layer is None:
                         QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Unable to create or find 'Poles' layer!")
                         return
-                except Exception as e:
+                except Exception:
                     QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Unable to create or find 'Poles' layer!")
                     return
 
@@ -2565,7 +2565,7 @@ class FiberQPlugin:
         else:
 
             # Find layer by name
-            layer = next((l for l in existing_layers if l.name() == selected_layer_name), None)
+            layer = next((l for l in existing_layers if l.name() == selected_layer_name), None)  # noqa: E741
             if layer is None:
                 QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Unable to find the target layer!")
                 return
@@ -2740,7 +2740,6 @@ class FiberQPlugin:
             return
 
         # Perform export using the best available API
-                # Perform export using the best available API
         try:
             result = None
 
@@ -2893,62 +2892,62 @@ class FiberQPlugin:
         # Automatska korekcija
 
     def fix_route_to_pole(self, route_feature, must_start=True):
-            poles_layer = next((lyr for lyr in QgsProject.instance().mapLayers().values()
-                                if lyr.geometryType() == QgsWkbTypes.PointGeometry
-                                and lyr.name() in ('Poles', 'Poles')), None)
+        poles_layer = next((lyr for lyr in QgsProject.instance().mapLayers().values()
+                            if lyr.geometryType() == QgsWkbTypes.PointGeometry
+                            and lyr.name() in ('Poles', 'Poles')), None)  # noqa: W503
 
-            if not poles_layer:
-                QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Layer 'Poles' not found!")
+        if not poles_layer:
+            QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Layer 'Poles' not found!")
+            return
+
+        geom = route_feature.geometry()
+        poly = geom.asPolyline()
+        if not poly:
+            return
+
+        # Find nearest pole for start/end
+        if must_start:
+            route_point = poly[0]
+            idx = 0
+        else:
+            route_point = poly[-1]
+            idx = -1
+
+        min_dist = None
+        nearest_stub = None
+        for pole_feat in poles_layer.getFeatures():
+            pole_pt = pole_feat.geometry().asPoint()
+            dist = QgsPointXY(pole_pt).distance(route_point)
+            if min_dist is None or dist < min_dist:
+                min_dist = dist
+                nearest_stub = pole_pt
+
+        # If pole found, move start/end of route to pole
+        if nearest_stub and min_dist > 1e-2:
+            poly[idx] = QgsPointXY(nearest_stub)
+            new_geom = QgsGeometry.fromPolylineXY(poly)
+
+            # Find 'Route' layer in project (QgsFeature doesn't have .layer())
+            route_layer = next(
+                (lyr for lyr in QgsProject.instance().mapLayers().values()
+                 if isinstance(lyr, QgsVectorLayer)
+                 and lyr.name() in ('Route', 'Route')  # noqa: W503
+                 and lyr.geometryType() == QgsWkbTypes.LineGeometry),  # noqa: W503
+                None
+            )
+            if not route_layer:
+                QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Route layer 'Route' not found!")
                 return
 
-            geom = route_feature.geometry()
-            poly = geom.asPolyline()
-            if not poly:
-                return
-
-            # Find nearest pole for start/end
-            if must_start:
-                route_point = poly[0]
-                idx = 0
-            else:
-                route_point = poly[-1]
-                idx = -1
-
-            min_dist = None
-            nearest_stub = None
-            for pole_feat in poles_layer.getFeatures():
-                pole_pt = pole_feat.geometry().asPoint()
-                dist = QgsPointXY(pole_pt).distance(route_point)
-                if min_dist is None or dist < min_dist:
-                    min_dist = dist
-                    nearest_stub = pole_pt
-
-            # If pole found, move start/end of route to pole
-            if nearest_stub and min_dist > 1e-2:
-                poly[idx] = QgsPointXY(nearest_stub)
-                new_geom = QgsGeometry.fromPolylineXY(poly)
-
-                # Find 'Route' layer in project (QgsFeature doesn't have .layer())
-                route_layer = next(
-                    (lyr for lyr in QgsProject.instance().mapLayers().values()
-                    if isinstance(lyr, QgsVectorLayer)
-                    and lyr.name() in ('Route', 'Route')
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry),
-                    None
-                )
-                if not route_layer:
-                    QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Route layer 'Route' not found!")
-                    return
-
-                route_layer.startEditing()
-                route_layer.changeGeometry(route_feature.id(), new_geom)
-                route_layer.commitChanges()
-                route_layer.triggerRepaint()
-                QMessageBox.information(
-                    self.iface.mainWindow(),
-                    "FiberQ",
-                    "Route has been automatically attached to a pole."
-                )
+            route_layer.startEditing()
+            route_layer.changeGeometry(route_feature.id(), new_geom)
+            route_layer.commitChanges()
+            route_layer.triggerRepaint()
+            QMessageBox.information(
+                self.iface.mainWindow(),
+                "FiberQ",
+                "Route has been automatically attached to a pole."
+            )
 
     # === DRAWINGS / ATTACHMENTS (DWG/DXF) ===
     def _drawing_key(self, layer, fid):
@@ -3158,10 +3157,10 @@ class FiberQPlugin:
                 )
                 # Record with auto-increment state for repeat (v1.2 Feature 3)
                 self._record_cmd('place_manhole',
-                    auto_increment=True,
-                    last_counter=self._manhole_place_tool._id_counter,
-                    id_prefix=self._manhole_place_tool._id_prefix,
-                    id_pad_width=self._manhole_place_tool._id_pad_width)
+                                 auto_increment=True,
+                                 last_counter=self._manhole_place_tool._id_counter,
+                                 id_prefix=self._manhole_place_tool._id_prefix,
+                                 id_pad_width=self._manhole_place_tool._id_pad_width)
             else:
                 self.iface.mapCanvas().setMapTool(self._manhole_place_tool)
                 self.iface.messageBar().pushInfo("Placing manhole", "Click on the map to place the manhole (ESC to exit).")
@@ -3302,7 +3301,7 @@ class FiberQPlugin:
 
 
 # ManholeTypeDialog and ManholeDetailsDialog moved to dialogs/manhole_dialog.py (Phase 4)
-from .dialogs.manhole_dialog import ManholeTypeDialog, ManholeDetailsDialog
+from .dialogs.manhole_dialog import ManholeTypeDialog, ManholeDetailsDialog  # noqa: E402
 
 
 # CablePickerDialog moved to dialogs/cable_dialog.py (Phase 4)
@@ -3311,7 +3310,7 @@ pass
 
 # === DODATO: BreakpointTool za split linije ===
 # BreakpointTool moved to tools/breakpoint_tool.py (Phase 3)
-from .tools.breakpoint_tool import BreakpointTool
+from .tools.breakpoint_tool import BreakpointTool  # noqa: E402
 
 
 # === NEW: SmartMultiSelectTool — multi-layer smart selection ===
@@ -3372,7 +3371,7 @@ def _open_fiberq_web(iface):
                 "FiberQ – pregledna mapa",
                 f"Greška pri otvaranju pregledne mape:\n{e}"
             )
-        except Exception as e:
+        except Exception:
             # if even QMessageBox fails, just ignore
             pass
 
@@ -3388,10 +3387,10 @@ def _open_fiberq_web(iface):
 
 
 # SlackUI moved to ui/slack_ui.py (Phase 5)
-from .ui.slack_ui import SlackUI
+from .ui.slack_ui import SlackUI  # noqa: E402
 
 # SlackDialog moved to dialogs/slack_dialog.py (Phase 4)
-from .dialogs.slack_dialog import SlackDialog
+from .dialogs.slack_dialog import SlackDialog  # noqa: E402
 
 
 # === Map alat za laying rezerve ===
@@ -3421,7 +3420,7 @@ from .dialogs.slack_dialog import SlackDialog
 # =============================================================================
 
 # ObjectsUI moved to ui/objects_ui.py (Phase 5)
-from .ui.objects_ui import ObjectsUI
+from .ui.objects_ui import ObjectsUI  # noqa: E402
 
 
 def _img_key(layer, fid):
@@ -3450,14 +3449,14 @@ def _img_set(layer, fid, path):
 # In v1.0.1 refactor, those classes live in fiberq/extracted_classes.py, while
 # main_plugin.py keeps FiberQPlugin + shared helpers.
 # Tools already modularized elsewhere
-from .tools.manhole_tool import ManholePlaceTool
-from .tools.route_tool import ManualRouteTool
+from .tools.manhole_tool import ManholePlaceTool  # noqa: E402
+from .tools.route_tool import ManualRouteTool  # noqa: E402
 pass
-from .tools.slack_tool import SlackPlaceTool
+from .tools.slack_tool import SlackPlaceTool  # noqa: E402
 
 # Remaining dialogs/tools extracted from the legacy monolith
 # Phase 4.2: Import from dedicated packages instead of extracted_classes
-from .tools import (
+from .tools import (  # noqa: E402
     OpenDrawingMapTool,
     PointTool,
     PlaceElementTool,
@@ -3470,7 +3469,7 @@ from .tools import (
     MoveFeatureTool,
 )
 
-from .dialogs import (
+from .dialogs import (  # noqa: E402
     _BOMDialog,
     CorrectionDialog,
     LocatorDialog,
@@ -3481,7 +3480,7 @@ from .dialogs import (
     FiberQSettingsDialog,
 )
 
-from .utils.image_watcher import CanvasImageClickWatcher
+from .utils.image_watcher import CanvasImageClickWatcher  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/fiberq/metadata.txt
+++ b/fiberq/metadata.txt
@@ -3,7 +3,7 @@ name=FiberQ
 description=Open-source fiber network design tools for QGIS (FTTH/GPON/FTTx)
 about=FiberQ helps telecom engineers and GIS professionals design, analyze, and document fiber optic networks inside QGIS. FiberQ supports QGIS 4 / Qt6 while keeping support for QGIS 3.22 LTR and later, and clears all findings from the QGIS repository security scan. Some advanced features may require an activation key.
 
-version=1.2.2
+version=1.2.3
 qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 
@@ -23,6 +23,21 @@ license=GPL-3.0-or-later
 class_name=FiberQPlugin
 
 changelog=
+    1.2.3 - Repository scan: zero findings (code hygiene, no functional change)
+        * The plugin now scans clean on the plugins.qgis.org Security & Quality
+          scan: flake8 (--max-line-length=120 --ignore=E501) and Bandit
+          (medium/high) both report 0 findings.
+        * Removed unused exception variables (except ... as e where e was never
+          used). The handlers still catch the same exceptions; behavior unchanged.
+        * Normalized whitespace around operators, continuation-line indentation,
+          and split a few compound statements (autopep8). No logic change.
+        * Removed a duplicate LayerNames / is_route_layer / is_cable_layer import
+          in utils (kept the definitions already active at runtime; no change).
+        * Annotated intentional multi-line conditions, conditional imports and
+          accepted names with targeted "# noqa" instead of rewriting working code.
+        * Packaging: the development flake8 config is no longer shipped inside
+          the plugin package.
+
     1.2.2 - Housekeeping (code cleanup, no functional change)
         * Removed dead leftover code from the v1.x monolith split:
           extracted_classes.py (deprecated re-export shim) and two unused

--- a/fiberq/models/color_catalogs.py
+++ b/fiberq/models/color_catalogs.py
@@ -185,7 +185,7 @@ class ColorCatalogManager:
 
         except (json.JSONDecodeError, TypeError):
             return {"catalogs": get_default_color_sets()}
-        except Exception as e:
+        except Exception:
             return {"catalogs": get_default_color_sets()}
 
     def save_catalogs(self, data: Dict[str, Any]) -> bool:
@@ -209,7 +209,7 @@ class ColorCatalogManager:
             )
             self._catalogs = data
             return True
-        except Exception as e:
+        except Exception:
             return False
 
     def get_catalog_names(self) -> List[str]:

--- a/fiberq/models/element_defs.py
+++ b/fiberq/models/element_defs.py
@@ -23,7 +23,7 @@ def _map_icon_path(filename: str) -> str:
     """Get the full path to a map icon file."""
     try:
         return os.path.join(_get_plugin_dir(), 'resources', 'map_icons', filename)
-    except Exception as e:
+    except Exception:
         return filename
 
 
@@ -31,7 +31,7 @@ def _toolbar_icon_path(filename: str) -> str:
     """Get the full path to a toolbar icon file."""
     try:
         return os.path.join(_get_plugin_dir(), 'icons', filename)
-    except Exception as e:
+    except Exception:
         return filename
 
 
@@ -356,7 +356,7 @@ def apply_element_aliases(layer) -> None:
 
     try:
         fields = layer.fields()
-    except Exception as e:
+    except Exception:
         return
 
     for field_name, alias in ELEMENT_FIELD_ALIASES.items():
@@ -364,7 +364,7 @@ def apply_element_aliases(layer) -> None:
             idx = fields.indexFromName(field_name)
             if idx != -1:
                 layer.setFieldAlias(idx, alias)
-        except Exception as e:
+        except Exception:
             continue
 
 

--- a/fiberq/tools/base.py
+++ b/fiberq/tools/base.py
@@ -64,9 +64,9 @@ def find_route_layer():
     """Find the Route layer in the project."""
     for lyr in QgsProject.instance().mapLayers().values():
         try:
-            if (isinstance(lyr, QgsVectorLayer) and
-                lyr.geometryType() == QgsWkbTypes.LineGeometry and
-                lyr.name() in ('Route', 'Trasa')):
+            if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                    lyr.name() in ('Route', 'Trasa')):
                 return lyr
         except Exception as e:
             logger.debug(f"Error in find_route_layer: {e}")
@@ -82,9 +82,9 @@ def find_cable_layers():
     layers = []
     for lyr in QgsProject.instance().mapLayers().values():
         try:
-            if (isinstance(lyr, QgsVectorLayer) and
-                lyr.geometryType() == QgsWkbTypes.LineGeometry and
-                lyr.name() in cable_names):
+            if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                    lyr.name() in cable_names):
                 layers.append(lyr)
         except Exception as e:
             logger.debug(f"Error in find_cable_layers: {e}")
@@ -97,9 +97,9 @@ def find_node_layers():
     layers = []
     for lyr in QgsProject.instance().mapLayers().values():
         try:
-            if (isinstance(lyr, QgsVectorLayer) and
-                lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                lyr.name() in node_names):
+            if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.name() in node_names):
                 layers.append(lyr)
         except Exception as e:
             logger.debug(f"Error in find_node_layers: {e}")
@@ -111,7 +111,7 @@ def find_element_layers():
     try:
         element_defs = get_element_defs()
         element_names = {d.get('name') for d in element_defs if d.get('name')}
-    except Exception as e:
+    except Exception:
         element_names = set()
 
     # Add joint closure
@@ -125,9 +125,9 @@ def find_element_layers():
     layers = []
     for lyr in QgsProject.instance().mapLayers().values():
         try:
-            if (isinstance(lyr, QgsVectorLayer) and
-                lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                lyr.name() in element_names):
+            if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.name() in element_names):
                 layers.append(lyr)
         except Exception as e:
             logger.debug(f"Error in find_element_layers: {e}")
@@ -180,7 +180,7 @@ def snap_to_point_layers(point, layers, tolerance):
                 if min_dist is None or d < min_dist:
                     min_dist = d
                     snapped_point = QgsPointXY(pt)
-            except Exception as e:
+            except Exception:
                 continue
 
     if snapped_point and min_dist is not None and min_dist <= tolerance:

--- a/fiberq/tools/branch_tool.py
+++ b/fiberq/tools/branch_tool.py
@@ -30,7 +30,7 @@ class BranchInfoTool(QgsMapToolIdentify):
         """Return first populated field from list of names."""
         try:
             field_names = f.fields().names()
-        except Exception as e:
+        except Exception:
             field_names = []
         for n in names:
             if n in field_names:
@@ -81,7 +81,7 @@ class BranchInfoTool(QgsMapToolIdentify):
 
         for f in feats:
             tip = self._attr(f, ["tip", "Tip", "TIP"], "n/a")
-            br_c = self._attr(f, ["broj_cevcica", "cevi"], "")
+            br_c = self._attr(f, ["broj_cevcica", "cevi"], "")  # noqa: F841
             br_v = self._attr(f, ["broj_vlakana", "vlakna"], "")
             cap = f"{br_v}f" if br_v else ""  # Issue #3: Show just fiber count with 'f'
             key = f"{tip} {cap}".strip() or "unknown"
@@ -99,7 +99,7 @@ class BranchInfoTool(QgsMapToolIdentify):
         if parts:
             msg += " | " + "; ".join(parts)
         if total_len > 0:
-            msg += f" | Length of those segments: {total_len:.0f} m ({total_len/1000.0:.2f} km)"
+            msg += f" | Length of those segments: {total_len:.0f} m ({total_len / 1000.0:.2f} km)"
         self.iface.messageBar().pushInfo("Branch info", msg)
 
     def keyPressEvent(self, e):

--- a/fiberq/tools/breakpoint_tool.py
+++ b/fiberq/tools/breakpoint_tool.py
@@ -42,9 +42,9 @@ class BreakpointTool(QgsMapToolEmitPoint):
     def _find_route_layer(self):
         """Find the Route layer in the project."""
         for lyr in QgsProject.instance().mapLayers().values():
-            if (isinstance(lyr, QgsVectorLayer) and
-                lyr.name() in ('Route', 'Trasa') and
-                lyr.geometryType() == QgsWkbTypes.LineGeometry):
+            if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.name() in ('Route', 'Trasa') and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
                 return lyr
         return None
 
@@ -115,7 +115,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         min_feat = self.snap_info['feat']
         min_geom = self.snap_info['geom']
         snapped_point = self.snap_info['point']
-        min_seg_idx = self.snap_info['seg_idx']
+        min_seg_idx = self.snap_info['seg_idx']  # noqa: F841
 
         # Handle multipart geometry
         if min_geom.isMultipart():
@@ -142,8 +142,8 @@ class BreakpointTool(QgsMapToolEmitPoint):
             tol = self.canvas.mapUnitsPerPixel() * 2
 
             # Check if split point is too close to endpoints
-            if (QgsGeometry.fromPointXY(snapped_point).distance(QgsGeometry.fromPointXY(p0)) < tol or
-                QgsGeometry.fromPointXY(snapped_point).distance(QgsGeometry.fromPointXY(p1)) < tol):
+            if (QgsGeometry.fromPointXY(snapped_point).distance(QgsGeometry.fromPointXY(p0)) < tol or  # noqa: W504
+                    QgsGeometry.fromPointXY(snapped_point).distance(QgsGeometry.fromPointXY(p1)) < tol):
                 QMessageBox.warning(
                     self.iface.mainWindow(),
                     "Split route",

--- a/fiberq/tools/command_manager.py
+++ b/fiberq/tools/command_manager.py
@@ -27,20 +27,20 @@ logger = get_logger(__name__)
 
 # Human-readable labels for commands
 COMMAND_LABELS = {
-    'place_pole':             'Place Pole',
-    'place_manhole':          'Place Manhole',
-    'place_joint_closure':    'Place Joint Closure',
-    'place_element':          'Place Element',
-    'create_route':           'Create Route',
-    'manual_route':           'Manual Route',
-    'lay_cable':              'Lay Cable',
-    'place_slack':            'Place Slack',
-    'place_pe_duct':          'Place PE Duct',
-    'place_transition_duct':  'Place Transition Duct',
-    'draw_service_area':      'Draw Service Area',
-    'place_object':           'Place Object',
-    'fiber_break':            'Place Fiber Break',
-    'split_route':            'Split Route',
+    'place_pole': 'Place Pole',
+    'place_manhole': 'Place Manhole',
+    'place_joint_closure': 'Place Joint Closure',
+    'place_element': 'Place Element',
+    'create_route': 'Create Route',
+    'manual_route': 'Manual Route',
+    'lay_cable': 'Lay Cable',
+    'place_slack': 'Place Slack',
+    'place_pe_duct': 'Place PE Duct',
+    'place_transition_duct': 'Place Transition Duct',
+    'draw_service_area': 'Draw Service Area',
+    'place_object': 'Place Object',
+    'fiber_break': 'Place Fiber Break',
+    'split_route': 'Split Route',
 }
 
 
@@ -199,7 +199,7 @@ class CommandManager:
         label = COMMAND_LABELS.get(self._last_command, self._last_command)
         element_name = self._last_params.get('layer_name', '')
         if element_name and self._last_command == 'place_element':
-            label = f"Place {element_name}"
+            label = f"Place {element_name}"  # noqa: F841
 
         logger.debug(f"Repeating command: {self._last_command}")
         self._execute(self._last_command, self._last_params)

--- a/fiberq/tools/drawing_tool.py
+++ b/fiberq/tools/drawing_tool.py
@@ -74,17 +74,17 @@ class OpenDrawingMapTool(QgsMapToolIdentify):
                     # If group/layer is off (invisible), treat as "not loaded"
                     try:
                         return node.isVisible()
-                    except Exception as e:
+                    except Exception:
                         try:
                             return node.itemVisibilityChecked()
-                        except Exception as e:
+                        except Exception:
                             return True
 
                 any_loaded = any(_node_present_and_visible(lid) for lid in ids)
 
                 if not any_loaded:
                     QMessageBox.information(self.core.iface.mainWindow(), "Drawing",
-                                "This drawing is linked, but its DWG/DXF layer is not loaded in the project anymore (layer was removed).")
+                                            "This drawing is linked, but its DWG/DXF layer is not loaded in the project anymore (layer was removed).")
                     return
 
                 self.core._open_drawing_path(path)

--- a/fiberq/tools/element_tool.py
+++ b/fiberq/tools/element_tool.py
@@ -124,7 +124,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
                     continue
                 try:
                     pt = geom.asPoint()
-                except Exception as e:
+                except Exception:
                     continue
                 d = QgsPointXY(point).distance(QgsPointXY(pt))
                 if min_dist is None or d < min_dist:
@@ -167,7 +167,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
                 if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry and lyr.name() == self.target_layer_name:
                     existing_layer = lyr
                     break
-        except Exception as e:
+        except Exception:
             existing_layer = None
 
         # If target is 'Prekid', automatically set name without dialog
@@ -179,7 +179,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
                 dlg = PrePlaceAttributesDialog(self.target_layer_name, existing_layer)
                 ok = (dlg.exec() == QDialog.DialogCode.Accepted)
                 _attrs = dlg.values() if ok else {}
-            except Exception as e:
+            except Exception:
                 naziv, ok = QInputDialog.getText(None, "Placing elements", f"Name ({self.target_layer_name}):")
                 _attrs = {'naziv': naziv} if ok and naziv else {}
 
@@ -203,7 +203,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
             # Add fields based on dialog spec
             try:
                 specs = _default_fields_for(self.target_layer_name)
-            except Exception as e:
+            except Exception:
                 specs = [("naziv", "Naziv", "text", "", None)]
 
             fields = []
@@ -237,7 +237,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
                         logger.debug(f"Error in PlaceElementTool.canvasPressEvent: {e}")
                     try:
                         svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
-                    except Exception as e:
+                    except Exception:
                         svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
                     symbol.changeSymbolLayer(0, svg_layer)
                 except Exception as e:
@@ -260,7 +260,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
             # Ensure all fields used by the dialog exist on the layer
             try:
                 specs = _default_fields_for(self.target_layer_name)
-            except Exception as e:
+            except Exception:
                 specs = [("naziv", "Naziv", "text", "", None)]
 
             to_add = []
@@ -349,7 +349,7 @@ class ChangeElementTypeTool(QgsMapToolIdentify):
             self.snap_marker.setIconSize(14)
             self.snap_marker.setColor(QColor(0, 200, 0))
             self.snap_marker.hide()
-        except Exception as e:
+        except Exception:
             self.snap_marker = None
 
     def activate(self):
@@ -404,7 +404,7 @@ class ChangeElementTypeTool(QgsMapToolIdentify):
 
             # Legacy Serbian names for old projects
             return name in ("Nastavci", "Nastavak")
-        except Exception as e:
+        except Exception:
             return False
 
     def canvasReleaseEvent(self, e):
@@ -425,7 +425,7 @@ class ChangeElementTypeTool(QgsMapToolIdentify):
                 hit_layer = layer
                 try:
                     hit_fid = int(feature.id())
-                except Exception as e:
+                except Exception:
                     hit_fid = feature.id()
                 break
 
@@ -440,14 +440,14 @@ class ChangeElementTypeTool(QgsMapToolIdentify):
         names = self._element_names()
         try:
             current = hit_layer.name()
-        except Exception as e:
+        except Exception:
             current = ""
         try:
             new_name, ok = QInputDialog.getItem(
                 self.iface.mainWindow(), "Change element type", "New type:",
                 names, max(0, names.index(current)) if current in names else 0, False
             )
-        except Exception as e:
+        except Exception:
             new_name, ok = (names[0] if names else "", True)
 
         if not ok or not new_name or new_name == current:

--- a/fiberq/tools/extension_tool.py
+++ b/fiberq/tools/extension_tool.py
@@ -99,9 +99,9 @@ class ExtensionTool(QgsMapToolEmitPoint):
                 # --- POINT layers (poles/manholes + optionally cut marker layer) ---
                 is_node_layer = (
                     lyr.name() in ("Poles", "Poles", "OKNA", "Okna", "Manholes")
-                    or "infrastructure cut" in lname
-                    or "infrastructure cuts" in lname
-                    or lname.strip() in ("cuts", "cut")
+                    or "infrastructure cut" in lname  # noqa: W503
+                    or "infrastructure cuts" in lname  # noqa: W503
+                    or lname.strip() in ("cuts", "cut")  # noqa: W503
                 )
 
                 if gtype == QgsWkbTypes.PointGeometry and is_node_layer:
@@ -118,8 +118,8 @@ class ExtensionTool(QgsMapToolEmitPoint):
                 # --- LINE layers of cables (vertex at cut location) ---
                 is_cable_layer = (
                     "cable" in lname
-                    or "kabl" in lname
-                    or lyr.name() in ("Route", "Route")
+                    or "kabl" in lname  # noqa: W503
+                    or lyr.name() in ("Route", "Route")  # noqa: W503
                 )
 
                 if gtype == QgsWkbTypes.LineGeometry and is_cable_layer:
@@ -131,7 +131,7 @@ class ExtensionTool(QgsMapToolEmitPoint):
                         for v in geom.vertices():
                             consider(v)
 
-            except Exception as e:
+            except Exception:
                 # if any layer fails, skip it
                 pass
 
@@ -194,8 +194,8 @@ class ExtensionTool(QgsMapToolEmitPoint):
         for lyr in QgsProject.instance().mapLayers().values():
             if (
                 isinstance(lyr, QgsVectorLayer)
-                and lyr.geometryType() == QgsWkbTypes.PointGeometry
-                and lyr.name() in target_names
+                and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                and lyr.name() in target_names  # noqa: W503
             ):
                 nastavak_layer = lyr
                 self._apply_joint_closure_aliases(nastavak_layer)
@@ -233,7 +233,7 @@ class ExtensionTool(QgsMapToolEmitPoint):
                 svg_layer.setSize(10)
                 try:
                     svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
-                except Exception as e:
+                except Exception:
                     svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
                 symbol.changeSymbolLayer(0, svg_layer)
             except Exception as e:

--- a/fiberq/tools/manhole_tool.py
+++ b/fiberq/tools/manhole_tool.py
@@ -184,9 +184,9 @@ class ManholePlaceTool(QgsMapToolEmitPoint):
         """Find the Manholes layer in the project."""
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.name() in ('Manholes', 'OKNA') and
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.name() in ('Manholes', 'OKNA') and  # noqa: W504
+                        lyr.geometryType() == QgsWkbTypes.PointGeometry):
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in ManholePlaceTool._find_manhole_layer: {e}")
@@ -196,9 +196,9 @@ class ManholePlaceTool(QgsMapToolEmitPoint):
         """Find the Route layer in the project."""
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.name() in ('Route', 'Trasa') and
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.name() in ('Route', 'Trasa') and  # noqa: W504
+                        lyr.geometryType() == QgsWkbTypes.LineGeometry):
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in ManholePlaceTool._find_route_layer: {e}")
@@ -302,7 +302,7 @@ class ManholePlaceTool(QgsMapToolEmitPoint):
             layer.startEditing()
             layer.addFeature(f)
             layer.commitChanges()
-        except Exception as e:
+        except Exception:
             layer.dataProvider().addFeatures([f])
 
         layer.updateExtents()

--- a/fiberq/tools/move_tool.py
+++ b/fiberq/tools/move_tool.py
@@ -88,7 +88,7 @@ class MoveFeatureTool(QgsMapTool):
             self.rb = QgsRubberBand(self.canvas, self.layer.geometryType())
             self.rb.setWidth(2)
             self.rb.setColor(QColor(59, 130, 246, 100))  # blue-ish, semi
-        except Exception as e:
+        except Exception:
             self.rb = None
 
         self.dragging = True
@@ -115,12 +115,12 @@ class MoveFeatureTool(QgsMapTool):
         geom = QgsGeometry(self.orig_geom)
         try:
             geom.translate(dx, dy)
-        except Exception as e:
+        except Exception:
             # Fallback manual translate
             try:
                 geom = QgsGeometry.fromWkt(self.orig_geom.asWkt())
                 geom.translate(dx, dy)
-            except Exception as e:
+            except Exception:
                 return
         if self.rb:
             try:

--- a/fiberq/tools/object_tools.py
+++ b/fiberq/tools/object_tools.py
@@ -109,7 +109,7 @@ class _BaseObjMapTool(QgsMapTool):
         self.points = []
         try:
             self._update_rb([])
-        except Exception as e:
+        except Exception:
             try:
                 self.rb.reset(QgsWkbTypes.PolygonGeometry)
             except Exception as e:
@@ -129,7 +129,7 @@ class _BaseObjMapTool(QgsMapTool):
 
         try:
             was_editing = obj_layer.isEditable()
-        except Exception as e:
+        except Exception:
             was_editing = False
 
         try:
@@ -195,7 +195,7 @@ class _BaseObjMapTool(QgsMapTool):
             # Auto-exit tool after successful add
             try:
                 self.core.iface.actionPan().trigger()  # return to Pan (easiest)
-            except Exception as e:
+            except Exception:
                 try:
                     self.core.iface.mapCanvas().unsetMapTool(self)
                 except Exception as e:

--- a/fiberq/tools/pipe_tool.py
+++ b/fiberq/tools/pipe_tool.py
@@ -64,10 +64,10 @@ class PipePlaceTool(QgsMapTool):
             # QGIS 3.22+
             mp = event.mapPoint()
             return QgsPointXY(mp)
-        except Exception as e:
+        except Exception:
             try:
                 return self.toMapCoordinates(event.pos())
-            except Exception as e:
+            except Exception:
                 return QgsPointXY(0, 0)
 
     def _snap_via_utils(self, qpt):
@@ -96,9 +96,9 @@ class PipePlaceTool(QgsMapTool):
         node_names = {"Poles", "Stubovi", "OKNA", "Manholes"}
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                    lyr.name() in node_names):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                        lyr.name() in node_names):
                     for f in lyr.getFeatures():
                         p = f.geometry().asPoint()
                         d = QgsPointXY(point).distance(QgsPointXY(p))
@@ -111,9 +111,9 @@ class PipePlaceTool(QgsMapTool):
         # 2) Snap to route vertices and segment midpoints
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.name() in ('Route', 'Trasa') and
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.name() in ('Route', 'Trasa') and  # noqa: W504
+                        lyr.geometryType() == QgsWkbTypes.LineGeometry):
 
                     for g in lyr.getFeatures():
                         geom = g.geometry()
@@ -212,9 +212,9 @@ class PipePlaceTool(QgsMapTool):
         """Find the Route layer in the project."""
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.name() in ('Route', 'Trasa') and
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.name() in ('Route', 'Trasa') and  # noqa: W504
+                        lyr.geometryType() == QgsWkbTypes.LineGeometry):
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in PipePlaceTool._find_route_layer: {e}")
@@ -244,7 +244,7 @@ class PipePlaceTool(QgsMapTool):
 
     def _find_nearest_name(self, pt, node_layers):
         """Find the display name of the nearest node to a point."""
-        best = None
+        best = None  # noqa: F841
         best_dist = None
         best_layer = None
         best_feat = None
@@ -304,7 +304,7 @@ class PipePlaceTool(QgsMapTool):
 
         try:
             f['fi'] = int(self.attrs.get('fi')) if self.attrs.get('fi') is not None else None
-        except Exception as e:
+        except Exception:
             f['fi'] = None
 
         # Calculate length
@@ -313,7 +313,7 @@ class PipePlaceTool(QgsMapTool):
                 d = QgsDistanceArea()
                 try:
                     d.setSourceCrs(layer.crs(), QgsProject.instance().transformContext())
-                except Exception as e:
+                except Exception:
                     try:
                         d.setSourceCrs(
                             self.iface.mapCanvas().mapSettings().destinationCrs(),
@@ -326,10 +326,10 @@ class PipePlaceTool(QgsMapTool):
             else:
                 length_m = geom.length() if geom is not None else 0.0
             f['duzina_m'] = float(length_m) if length_m else 0.0
-        except Exception as e:
+        except Exception:
             try:
                 f['duzina_m'] = float(geom.length()) if geom is not None else None
-            except Exception as e:
+            except Exception:
                 f['duzina_m'] = None
 
         # Find FROM/TO names
@@ -337,9 +337,9 @@ class PipePlaceTool(QgsMapTool):
         node_layers = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                    lyr.name() in node_names):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                        lyr.name() in node_names):
                     node_layers.append(lyr)
             except Exception as e:
                 logger.debug(f"Error in PipePlaceTool._finish: {e}")
@@ -395,7 +395,7 @@ class PipePlaceTool(QgsMapTool):
             if getattr(self, "snap_marker", None) is not None:
                 try:
                     self.canvas.scene().removeItem(self.snap_marker)
-                except Exception as e:
+                except Exception:
                     try:
                         self.snap_marker.hide()
                     except Exception as e:

--- a/fiberq/tools/point_tool.py
+++ b/fiberq/tools/point_tool.py
@@ -50,7 +50,7 @@ class PointTool(QgsMapToolEmitPoint):
         try:
             s = QgsSettings()
             snap_px = int(s.value("FiberQ/default_snap_distance", "20"))
-        except Exception as e:
+        except Exception:
             snap_px = 20
 
         snap_tolerance = self.canvas.mapUnitsPerPixel() * snap_px
@@ -74,10 +74,10 @@ class PointTool(QgsMapToolEmitPoint):
                             snap_point = QgsPointXY(pt)
 
                     # Also keep segment midpoints
-                    for i in range(len(line)-1):
+                    for i in range(len(line) - 1):
                         mid = QgsPointXY(
-                            (line[i].x() + line[i+1].x()) / 2,
-                            (line[i].y() + line[i+1].y()) / 2
+                            (line[i].x() + line[i + 1].x()) / 2,
+                            (line[i].y() + line[i + 1].y()) / 2
                         )
                         dist = QgsPointXY(point).distance(mid)
                         if min_dist is None or dist < min_dist:
@@ -141,7 +141,7 @@ class PointTool(QgsMapToolEmitPoint):
         try:
             if hasattr(self, 'plugin') and self.plugin and hasattr(self.plugin, 'undo_manager') and self.plugin.undo_manager:
                 self.plugin.undo_manager.record_add(self.layer, feature)
-        except Exception as e:
+        except Exception:
             pass  # PointTool may not always have plugin reference
 
 

--- a/fiberq/tools/region_tool.py
+++ b/fiberq/tools/region_tool.py
@@ -46,7 +46,7 @@ class DrawRegionPolygonTool(QgsMapTool):
             c = QColor('#60a5fa')  # blue-400
             c.setAlpha(60)
             self.rb.setFillColor(c)
-        except Exception as e:
+        except Exception:
             self.rb = None
 
     def activate(self):
@@ -141,7 +141,7 @@ class DrawRegionPolygonTool(QgsMapTool):
             # Ask for name
             try:
                 name, ok = QInputDialog.getText(self.iface.mainWindow(), 'Service Area', 'Name:')
-            except Exception as e:
+            except Exception:
                 name, ok = ('Rejon', True)
             if not ok:
                 return

--- a/fiberq/tools/route_tool.py
+++ b/fiberq/tools/route_tool.py
@@ -56,7 +56,7 @@ class ManualRouteTool(QgsMapTool):
             nm = jc_def.get('name', 'Joint Closures')
             if nm and nm not in names:
                 names.append(nm)
-        except Exception as e:
+        except Exception:
             if 'Nastavci' not in names:
                 names.append('Nastavci')
 
@@ -89,9 +89,9 @@ class ManualRouteTool(QgsMapTool):
         node_layers = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                    lyr.name() in node_layer_names):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                        lyr.name() in node_layer_names):
                     node_layers.append(lyr)
             except Exception as e:
                 logger.debug(f"Error in ManualRouteTool._find_snap_point: {e}")
@@ -108,16 +108,16 @@ class ManualRouteTool(QgsMapTool):
                     if min_dist is None or d < min_dist:
                         min_dist = d
                         snap_point = QgsPointXY(pt)
-                except Exception as e:
+                except Exception:
                     continue
 
         # Snap to existing routes (vertices and segment midpoints)
         try:
             for lyr in QgsProject.instance().mapLayers().values():
                 try:
-                    if (isinstance(lyr, QgsVectorLayer) and
-                        lyr.geometryType() == QgsWkbTypes.LineGeometry and
-                        lyr.name() in ('Route', 'Trasa')):
+                    if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                        lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                            lyr.name() in ('Route', 'Trasa')):
 
                         for feat in lyr.getFeatures():
                             geom = feat.geometry()
@@ -218,9 +218,9 @@ class ManualRouteTool(QgsMapTool):
         # Find or create Route layer
         route_layer = None
         for lyr in QgsProject.instance().mapLayers().values():
-            if (isinstance(lyr, QgsVectorLayer) and
-                lyr.name() in ('Route', 'Trasa') and
-                lyr.geometryType() == QgsWkbTypes.LineGeometry):
+            if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                lyr.name() in ('Route', 'Trasa') and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
                 route_layer = lyr
                 break
 
@@ -254,7 +254,7 @@ class ManualRouteTool(QgsMapTool):
         # Get route type options
         try:
             TRASA_TYPE_OPTIONS, TRASA_TYPE_LABELS, TRASA_LABEL_TO_CODE = get_route_type_options()
-        except Exception as e:
+        except Exception:
             TRASA_TYPE_OPTIONS = ['vazdusna', 'podzemna', 'kroz objekat']
             TRASA_TYPE_LABELS = {'vazdusna': 'Aerial', 'podzemna': 'Underground', 'kroz objekat': 'Through the object'}
             TRASA_LABEL_TO_CODE = {'Aerial': 'vazdusna', 'Underground': 'podzemna', 'Through the object': 'kroz objekat'}
@@ -287,7 +287,7 @@ class ManualRouteTool(QgsMapTool):
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(feat)
-        except Exception as e:
+        except Exception:
             pass
         route_layer.addFeature(feat)
         route_layer.commitChanges()

--- a/fiberq/tools/select_tool.py
+++ b/fiberq/tools/select_tool.py
@@ -45,7 +45,7 @@ class SmartMultiSelectTool(QgsMapTool):
             self._marker.setIconSize(12)
             self._marker.setPenWidth(3)
             self._marker.hide()
-        except Exception as e:
+        except Exception:
             self._marker = None
 
     def _layer_priority(self, lyr):
@@ -60,7 +60,7 @@ class SmartMultiSelectTool(QgsMapTool):
         try:
             name = (lyr.name() or "").lower()
             gtype = lyr.geometryType()
-        except Exception as e:
+        except Exception:
             return 100
 
         # 1) elements + joint closures (highest priority)
@@ -68,7 +68,7 @@ class SmartMultiSelectTool(QgsMapTool):
         try:
             try:
                 element_names.add(NASTAVAK_DEF.get('name', 'Nastavci').lower())
-            except Exception as e:
+            except Exception:
                 element_names.add('nastavci')
             try:
                 for d in ELEMENT_DEFS:
@@ -101,9 +101,9 @@ class SmartMultiSelectTool(QgsMapTool):
     def _nearest_feature(self, lyr, pt, tol):
         """Return (fid, geom) of nearest feature within tolerance in map units; otherwise (None, None)."""
         try:
-            rect = QgsRectangle(pt.x()-tol, pt.y()-tol, pt.x()+tol, pt.y()+tol)
+            rect = QgsRectangle(pt.x() - tol, pt.y() - tol, pt.x() + tol, pt.y() + tol)
             req = QgsFeatureRequest().setFilterRect(rect)
-        except Exception as e:
+        except Exception:
             req = None
 
         gpt = QgsGeometry.fromPointXY(pt)
@@ -117,7 +117,7 @@ class SmartMultiSelectTool(QgsMapTool):
                 d = geom.distance(gpt)
                 if d <= tol and (best[0] is None or d < best[0]):
                     best = (d, f.id(), geom)
-            except Exception as e:
+            except Exception:
                 continue
         return (best[1], best[2]) if best[1] is not None else (None, None)
 
@@ -140,13 +140,13 @@ class SmartMultiSelectTool(QgsMapTool):
 
         try:
             pt = self.toMapCoordinates(e.pos())
-        except Exception as e:
+        except Exception:
             return
 
         # Tolerance ~10 px
         try:
             tol = self.canvas.extent().width() / max(1, self.canvas.width()) * 10.0
-        except Exception as e:
+        except Exception:
             tol = 5.0
 
         gpt = QgsGeometry.fromPointXY(pt)
@@ -159,7 +159,7 @@ class SmartMultiSelectTool(QgsMapTool):
                 continue
             try:
                 d = float(geom.distance(gpt))
-            except Exception as e:
+            except Exception:
                 d = 0.0
             candidates.append((d, self._layer_priority(lyr), lyr, fid, geom))
 
@@ -187,7 +187,7 @@ class SmartMultiSelectTool(QgsMapTool):
         # Visual feedback
         try:
             cen = geom.asPoint() if geom.isGeosValid() and geom.isSingle() else geom.centroid().asPoint()
-        except Exception as e:
+        except Exception:
             cen = pt
         if self._marker:
             self._marker.setCenter(QgsPointXY(cen))
@@ -250,7 +250,7 @@ class SmartMultiSelectTool(QgsMapTool):
             # 1) Joint Closure
             try:
                 valid_point_names.add(NASTAVAK_DEF.get('name', 'Nastavci'))
-            except Exception as e:
+            except Exception:
                 valid_point_names.add('Nastavci')
 
             # 2) All elements from ELEMENT_DEFS
@@ -304,7 +304,7 @@ class SmartMultiSelectTool(QgsMapTool):
                     elif gtype == QgsWkbTypes.PolygonGeometry:
                         if name in valid_poly_names or lname in low_poly:
                             layers.append(lyr)
-                except Exception as e:
+                except Exception:
                     continue
 
             return layers

--- a/fiberq/tools/slack_tool.py
+++ b/fiberq/tools/slack_tool.py
@@ -62,9 +62,9 @@ class SlackPlaceTool(QgsMapTool):
         }
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry and
-                    lyr.name() in cable_names):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                        lyr.name() in cable_names):
                     yield lyr
             except Exception as e:
                 logger.debug(f"Error in SlackPlaceTool._iter_cable_layers: {e}")
@@ -74,9 +74,9 @@ class SlackPlaceTool(QgsMapTool):
         node_names = {"Poles", "Stubovi", "OKNA", "Manholes"}
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                    lyr.name() in node_names):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                        lyr.name() in node_names):
                     yield lyr
             except Exception as e:
                 logger.debug(f"Error in SlackPlaceTool._iter_node_layers: {e}")
@@ -211,9 +211,9 @@ class SlackPlaceTool(QgsMapTool):
         if vl is None:
             # Fallback: find existing slack layer
             for lyr in QgsProject.instance().mapLayers().values():
-                if (isinstance(lyr, QgsVectorLayer) and
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and
-                    lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")):
+                if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                        lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")):
                     vl = lyr
                     break
 

--- a/fiberq/ui/base.py
+++ b/fiberq/ui/base.py
@@ -42,7 +42,7 @@ def load_icon(filename: str) -> QIcon:
         if os.path.exists(icon_path):
             return QIcon(icon_path)
         return QIcon()
-    except Exception as e:
+    except Exception:
         return QIcon()
 
 

--- a/fiberq/ui/objects_ui.py
+++ b/fiberq/ui/objects_ui.py
@@ -152,7 +152,7 @@ class ObjectsUI:
 
         try:
             core.toolbar.addWidget(btn)
-        except Exception as e:
+        except Exception:
             # Fallback
             act_root = QAction(load_icon('ic_drawing_object.svg'), 'Drawing object', core.iface.mainWindow())
             act_root.setMenu(self.menu)

--- a/fiberq/ui/quick_toolbar.py
+++ b/fiberq/ui/quick_toolbar.py
@@ -12,12 +12,12 @@ View → Toolbars → FiberQ Quick.
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QKeySequence
 pass
-from qgis.PyQt.QtGui import QAction, QShortcut
+from qgis.PyQt.QtGui import QAction, QShortcut  # noqa: E402
 
-from qgis.core import QgsSettings
+from qgis.core import QgsSettings  # noqa: E402
 
-from .base import load_icon
-from ..utils.logger import get_logger
+from .base import load_icon  # noqa: E402
+from ..utils.logger import get_logger  # noqa: E402
 logger = get_logger(__name__)
 
 
@@ -317,13 +317,13 @@ class QuickToolbar:
                 pass
 
         QgsSettings().setValue(SETTING_ENABLE_SHORTCUTS,
-                              'true' if enabled else 'false')
+                               'true' if enabled else 'false')
 
     def set_visible(self, visible):
         """Show or hide the toolbar and persist the setting."""
         self.toolbar.setVisible(visible)
         QgsSettings().setValue(SETTING_SHOW_TOOLBAR,
-                              'true' if visible else 'false')
+                               'true' if visible else 'false')
 
     # ────────────────────────────────────────────────────
     # Cleanup

--- a/fiberq/ui/routing_ui.py
+++ b/fiberq/ui/routing_ui.py
@@ -115,7 +115,7 @@ class RoutingUI:
         try:
             val = QgsProject.instance().readEntry("TelecomPlugin", "gpkg_path", "")[0]
             return val or ""
-        except Exception as e:
+        except Exception:
             return ""
 
     def _set_project_gpkg_path(self, path):
@@ -141,7 +141,7 @@ class RoutingUI:
             except Exception as e:
                 logger.debug(f"Error in RoutingUI._is_memory_vector: {e}")
             return ('memory' in prov) or st.startswith('memory')
-        except Exception as e:
+        except Exception:
             return False
 
     def _toggle_auto_gpkg(self, enabled):
@@ -172,7 +172,7 @@ class RoutingUI:
                 self._set_project_gpkg_path(gpkg)
 
             # Convert existing memory layers
-            layers = [l for l in prj.mapLayers().values() if isinstance(l, QgsVectorLayer)]
+            layers = [l for l in prj.mapLayers().values() if isinstance(l, QgsVectorLayer)]  # noqa: E741
             for lyr in layers:
                 if self._is_memory_vector(lyr):
                     _telecom_export_one_layer_to_gpkg(lyr, self._project_gpkg_path(), self.core.iface)

--- a/fiberq/utils/__init__.py
+++ b/fiberq/utils/__init__.py
@@ -53,9 +53,9 @@ from .helpers import (
     # Layer detection
     find_layer_by_name,
     find_layers_by_names,
-    is_route_layer,
-    is_cable_layer,
     is_pole_layer,
+    # NOTE: is_route_layer / is_cable_layer are re-exported below from
+    # .layer_names (Phase 6.1), which already shadowed these at runtime.
 )
 
 from .constants import (
@@ -87,7 +87,8 @@ from .constants import (
     FIELD_ALIASES,
 
     # Layer names
-    LayerNames,
+    # NOTE: LayerNames is re-exported below from .layer_names (Phase 6.1),
+    # which already shadowed the .constants version at runtime.
     LAYER_NAME_MAPPING,
 
     # Status

--- a/fiberq/utils/field_aliases.py
+++ b/fiberq/utils/field_aliases.py
@@ -301,7 +301,7 @@ def apply_value_map(
 
         return True
 
-    except Exception as e:
+    except Exception:
         return False
 
 

--- a/fiberq/utils/geometry.py
+++ b/fiberq/utils/geometry.py
@@ -246,7 +246,7 @@ def points_equal(p1: QgsPointXY, p2: QgsPointXY, tolerance: float = 1e-9) -> boo
         True if points are equal within tolerance
     """
     return (
-        abs(p1.x() - p2.x()) < tolerance and
+        abs(p1.x() - p2.x()) < tolerance and  # noqa: W504
         abs(p1.y() - p2.y()) < tolerance
     )
 
@@ -326,8 +326,8 @@ def split_line_at_point(
         p0, p1 = QgsPointXY(line_points[0]), QgsPointXY(line_points[1])
 
         # Check if split point is too close to endpoints
-        if (point_distance(split_point, p0) < tolerance or
-            point_distance(split_point, p1) < tolerance):
+        if (point_distance(split_point, p0) < tolerance or  # noqa: W504
+                point_distance(split_point, p1) < tolerance):
             return None, None
 
         geom1 = QgsGeometry.fromPolylineXY([p0, split_point])
@@ -399,7 +399,7 @@ def get_layer_extent_center(layer: QgsVectorLayer) -> Optional[QgsPointXY]:
         if extent.isEmpty():
             return None
         return extent.center()
-    except Exception as e:
+    except Exception:
         return None
 
 
@@ -418,5 +418,5 @@ def calculate_geometry_length(geom: QgsGeometry) -> float:
 
     try:
         return geom.length()
-    except Exception as e:
+    except Exception:
         return 0.0

--- a/fiberq/utils/helpers.py
+++ b/fiberq/utils/helpers.py
@@ -109,7 +109,7 @@ def _load_icon(filename: str) -> QIcon:
     try:
         p = _icon_path(filename)
         return QIcon(p) if os.path.exists(p) else QIcon()
-    except Exception as e:
+    except Exception:
         return QIcon()
 
 
@@ -128,7 +128,7 @@ def _map_icon_path(filename: str) -> str:
     """
     try:
         return os.path.join(get_plugin_dir(), 'resources', 'map_icons', filename)
-    except Exception as e:
+    except Exception:
         return filename
 
 
@@ -240,7 +240,7 @@ def normalize_name(text: str) -> str:
         text = re.sub(r"[^a-z0-9_]+", "_", text)
 
         return text.strip("_")
-    except Exception as e:
+    except Exception:
         return text
 
 
@@ -260,7 +260,7 @@ def clean_layer_name(name: str) -> str:
         cleaned = re.sub(r'\s+', '_', cleaned)
         cleaned = cleaned.strip('_')
         return cleaned if cleaned else 'unnamed_layer'
-    except Exception as e:
+    except Exception:
         return 'unnamed_layer'
 
 
@@ -350,7 +350,7 @@ def apply_fixed_text_label(
 
         return True
 
-    except Exception as e:
+    except Exception:
         return False
 
 
@@ -377,7 +377,7 @@ def apply_field_aliases(
 
     try:
         fields = layer.fields()
-    except Exception as e:
+    except Exception:
         return 0
 
     applied_count = 0
@@ -388,7 +388,7 @@ def apply_field_aliases(
             if idx != -1:
                 layer.setFieldAlias(idx, alias)
                 applied_count += 1
-        except Exception as e:
+        except Exception:
             continue
 
     return applied_count
@@ -413,7 +413,7 @@ def _get_lang() -> str:
     """
     try:
         return QSettings().value(_FIBERQ_LANG_KEY, "en")
-    except Exception as e:
+    except Exception:
         return "en"
 
 
@@ -442,7 +442,7 @@ def get_language() -> str:
     """
     try:
         return QSettings().value(_FIBERQ_LANG_KEY, "en")
-    except Exception as e:
+    except Exception:
         return "en"
 
 
@@ -706,7 +706,7 @@ def is_route_layer(layer: QgsVectorLayer) -> bool:
         is_line = layer.geometryType() == QgsWkbTypes.LineGeometry
 
         return is_line and name in ('trasa', 'route', 'routes')
-    except Exception as e:
+    except Exception:
         return False
 
 
@@ -731,7 +731,7 @@ def is_cable_layer(layer: QgsVectorLayer) -> bool:
 
         cable_keywords = ['kabl', 'cable', 'kablo']
         return is_line and any(kw in name for kw in cable_keywords)
-    except Exception as e:
+    except Exception:
         return False
 
 
@@ -755,7 +755,7 @@ def is_pole_layer(layer: QgsVectorLayer) -> bool:
         is_point = layer.geometryType() == QgsWkbTypes.PointGeometry
 
         return is_point and name in ('stubovi', 'poles', 'pole')
-    except Exception as e:
+    except Exception:
         return False
 
 

--- a/fiberq/utils/layer_names.py
+++ b/fiberq/utils/layer_names.py
@@ -204,7 +204,7 @@ def is_route_layer(layer_name: str) -> bool:
 
 def is_cable_layer(layer_name: str) -> bool:
     """Check if layer name matches any cable layer."""
-    return (layer_name in get_aerial_cable_names() or
+    return (layer_name in get_aerial_cable_names() or  # noqa: W504
             layer_name in get_underground_cable_names())
 
 

--- a/fiberq/utils/legacy_bridge.py
+++ b/fiberq/utils/legacy_bridge.py
@@ -37,9 +37,10 @@ _FIBERQ_LANG_KEY = "FiberQ/lang"
 
 def _get_lang():
     try:
-        if QSettings is None: return "en"
+        if QSettings is None:
+            return "en"
         return QSettings().value(_FIBERQ_LANG_KEY, "en")
-    except Exception as e:
+    except Exception:
         return "en"
 
 
@@ -57,7 +58,7 @@ def _fiberq_translate(text: str, lang: str) -> str:
         'Check (health check)': 'Health check',
         'Cable laying': 'Cable laying',
         'Underground': 'Underground',
-        'Aerial': 'Aerial',        'Main': 'Main',
+        'Aerial': 'Aerial', 'Main': 'Main',
         'Distribution': 'Distribution',
         'Drop': 'Drop',
 
@@ -118,7 +119,7 @@ def _map_icon_path(filename: str) -> str:
     try:
         base = _os_mod2.path.dirname(_os_mod2.path.dirname(__file__))  # plugin root
         return _os_mod2.path.join(base, 'resources', 'map_icons', filename)
-    except Exception as e:
+    except Exception:
         return filename
 
 
@@ -131,7 +132,7 @@ def _normalize_name(s: str) -> str:
         s = s.lower()
         s = re.sub(r"[^a-z0-9_]+", "_", s)
         return s.strip("_")
-    except Exception as e:
+    except Exception:
         return s
 
 
@@ -214,7 +215,7 @@ def _apply_fixed_text_label(layer, field_name='naziv', size_mu=8.0, yoff_mu=5.0)
         layer.setLabeling(QgsVectorLayerSimpleLabeling(s))
         layer.setLabelsEnabled(True)
         layer.triggerRepaint()
-    except Exception as e:
+    except Exception:
         # Do not crash the plugin if labeling fails on some older QGIS.
         pass
 
@@ -257,7 +258,7 @@ def _img_get(layer, fid):
         # Fall back to legacy key for backward compatibility
         path = QgsProject.instance().readEntry("StuboviPlugin", key, "")[0]
         return path
-    except Exception as e:
+    except Exception:
         return ""
 
 
@@ -265,7 +266,7 @@ def _img_set(layer, fid, path):
     """Set image path for a feature."""
     try:
         QgsProject.instance().writeEntry("FiberQPlugin", _img_key(layer, fid), path or "")
-    except Exception as e:
+    except Exception:
         pass
 
 
@@ -301,8 +302,8 @@ def _ensure_region_layer(core):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PolygonGeometry
-                    and lyr.name() in ('Rejon', 'Service Area')
+                    and lyr.geometryType() == QgsWkbTypes.PolygonGeometry  # noqa: W503
+                    and lyr.name() in ('Rejon', 'Service Area')  # noqa: W503
                 ):
                     # If old name 'Rejon', rename so user sees 'Service Area'
                     if lyr.name() == 'Rejon':
@@ -311,7 +312,7 @@ def _ensure_region_layer(core):
                         except Exception as e:
                             logger.debug(f"Error in _ensure_region_layer: {e}")
                     return lyr
-            except Exception as e:
+            except Exception:
                 continue
 
         # 2) If doesn't exist – create new layer named 'Service Area'
@@ -355,13 +356,13 @@ def _ensure_objects_layer(core):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.wkbType() in (
+                    and lyr.wkbType() in (  # noqa: W503
                         QgsWkbTypes.Polygon,
                         QgsWkbTypes.MultiPolygon,
                         QgsWkbTypes.PolygonZM,
                         QgsWkbTypes.MultiPolygonZM,
                     )
-                    and lyr.name() in ("Objekti", "Objects")
+                    and lyr.name() in ("Objekti", "Objects")  # noqa: W503
                 ):
                     _apply_objects_field_aliases(lyr)
                     _set_objects_layer_alias(lyr)
@@ -392,7 +393,7 @@ def _ensure_objects_layer(core):
         _set_objects_layer_alias(layer)
 
         return layer
-    except Exception as e:
+    except Exception:
         return None
 
 
@@ -418,7 +419,7 @@ def _stylize_objects_layer(layer):
         try:
             try:
                 hatch.setLineAngle(60.0)
-            except Exception as e:
+            except Exception:
                 try:
                     hatch.setAngle(60.0)
                 except Exception as e:

--- a/fiberq/utils/routing.py
+++ b/fiberq/utils/routing.py
@@ -226,7 +226,7 @@ def build_path_across_network(
         # Convert keys back to points
         return [key_to_point[k] for k in path_keys]
 
-    except Exception as e:
+    except Exception:
         return None
 
 
@@ -335,8 +335,8 @@ def build_path_across_joined_routes(
             if not path_pts:
                 path_pts.extend(seq)
             else:
-                if (path_pts[-1].x() == seq[0].x() and
-                    path_pts[-1].y() == seq[0].y()):
+                if (path_pts[-1].x() == seq[0].x() and  # noqa: W504
+                        path_pts[-1].y() == seq[0].y()):
                     path_pts.extend(seq[1:])
                 else:
                     path_pts.extend(seq)
@@ -347,7 +347,7 @@ def build_path_across_joined_routes(
 
         return path_pts
 
-    except Exception as e:
+    except Exception:
         return None
 
 

--- a/fiberq/utils/uuid_utils.py
+++ b/fiberq/utils/uuid_utils.py
@@ -274,7 +274,7 @@ def migrate_project_uuids():
             # Match by name OR by having FiberQ-characteristic fields
             is_fiberq = (
                 layer_name in fiberq_layer_names
-                or bool(field_names & fiberq_field_signatures)
+                or bool(field_names & fiberq_field_signatures)  # noqa: W503
             )
 
             if not is_fiberq:


### PR DESCRIPTION
Drive the plugins.qgis.org Security & Quality scan to 0 findings without any functional change, establishing a pristine baseline before the WP1-6 work.

  flake8 (--max-line-length=120 --ignore=E501): 528 -> 0
  Bandit (medium/high): 0    F821 (undefined names): 0    byte-compile: OK

- F841: drop 203 unused "except ... as e" bindings (handlers still catch the same exceptions; behavior unchanged).
- autopep8 (mechanical whitespace/structure only): E225, E226, E241, E123, E127, E128, E129, E701, E702.
- E116/E117: manually dedent two over-indented method bodies and remove two duplicate over-indented comments in main_plugin.py.
- F811: remove duplicate LayerNames / is_route_layer / is_cable_layer import in utils/__init__ (kept the .layer_names versions already active at runtime).
- W503/W504 (multi-line conditions), E402 (conditional imports), E741, and the 8 remaining dead-store F841: targeted "# noqa" instead of rewriting code.
- packaging: move the dev flake8 config to the repo root so it is no longer shipped inside the plugin zip (it was flagged as a suspicious hidden file on the v1.2.2 scan).
- bump version 1.2.2 -> 1.2.3 + changelog.