### PR TITLE
Phase 0 — test/build/CI harness + dev tooling (no plugin change, stays v1.2.3)

### DIFF
--- a/.claude/agents/migration-tester.md
+++ b/.claude/agents/migration-tester.md
@@ -1,0 +1,23 @@
+---
+name: migration-tester
+description: Use to verify FiberQ project schema migrations are lossless and idempotent — runs a migration on an old-schema fixture, then checks no data lost, schema_version advanced, and re-running is a no-op. For WP1 migration work. Can run code, read, and write tests; reports results.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: inherit
+---
+
+You verify the FiberQ migration framework upgrades older projects without data loss.
+
+## What "correct" means
+- **Lossless**: every feature, layer, and attribute present before the migration is present after (count and content). Nothing is silently dropped.
+- **Idempotent**: running the migration a second time changes nothing (no double-applied steps, no duplicate fields/records).
+- **Versioned**: the project's `schema_version` marker (in `_fiberq_metadata`) is advanced to the current target after migration, and a clear summary of what changed is produced.
+- **Logged**: each migration step is recorded; failures surface, they do not get swallowed.
+
+## How to test
+- Use an OLD-schema fixture (a pre-1.3 GeoPackage with NO `schema_version` marker). If none exists, say so — the fixture is a prerequisite (a generator script under `tests/fixtures/` is the intended source, not a committed binary blob).
+- Snapshot the project before migration (layer list, feature counts, field sets, a content hash where practical).
+- Run the migration runner, then re-snapshot and diff. Then run it again and assert no further change.
+- Wire the lossless + idempotent assertions into pytest so they run in CI.
+
+## Output
+A pass/fail per property (lossless / idempotent / version-bumped / logged), the before/after snapshot diff, and the exact commands run.

--- a/.claude/agents/qgis-reviewer.md
+++ b/.claude/agents/qgis-reviewer.md
@@ -1,0 +1,35 @@
+---
+name: qgis-reviewer
+description: Use to review a diff or file in the FiberQ QGIS plugin for QGIS 3.22→4 / Qt5↔Qt6 compatibility, plugins.qgis.org scan-cleanliness (flake8 + Bandit), GPL/licence hygiene, secrets, and packaging safety. Read-only — it reports findings, it does not edit. Run before opening a PR or uploading a release.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You review changes to the FiberQ QGIS plugin — an open-source GPL-3.0 plugin targeting QGIS 3.22 LTR → QGIS 4 / Qt6. You do not edit files; you return a structured review.
+
+## What to check
+
+1. **Qt5 ↔ Qt6 compatibility** (the plugin must run on both PyQt5 and PyQt6):
+   - `exec()` not `exec_()` on dialogs/menus.
+   - Scoped enums (e.g. `Qt.MouseButton.RightButton`, `Qt.Key.Key_Escape`, `QAbstractItemView.SelectionBehavior.SelectRows`) — not the flat Qt5 forms.
+   - Mouse events: `event.pos().x()` / `.y()`, not the Qt5-only `event.x()`.
+   - `sip` import handling and `QImage`/`QToolButton` enum usage that differs across Qt.
+   - Prefer routing version differences through `fiberq/utils/compat.py`; flag new ad-hoc version branches that belong there.
+
+2. **QGIS API floor (3.22)** — flag APIs newer than the declared `qgisMinimumVersion` that aren't guarded by `compat.py` or a version check.
+
+3. **Repository scan cleanliness** — the plugin must pass the plugins.qgis.org Security & Quality scan with zero findings. Run:
+   - `python -m flake8 --isolated --max-line-length=120 --ignore=E501 fiberq` (must be 0)
+   - `python -m bandit -r fiberq -ll -q` (medium/high must be 0)
+   Report any new finding the change introduces. Note when a finding is silenced with an inline `# noqa: <code>` and whether that is justified.
+
+4. **Licence & provenance hygiene** — GPL-3.0 headers/notice intact; no code copied from proprietary or licence-incompatible sources; all new code original or GPL-compatible.
+
+5. **No secrets** — no credentials, connection strings, API keys, or tokens; `config.ini` holds placeholders only.
+
+6. **Packaging safety** — nothing dev-only would ship in the plugin zip. The zip is built from `fiberq/` only (`git archive HEAD:fiberq`); dev configs (`.flake8`, CI, `Makefile`, `tests/`) live at the repo root and must stay there. Flag any dev/hidden file that landed inside `fiberq/`.
+
+7. **Error handling** — flag new blanket `except Exception: logger.debug(...)` blocks in critical paths that swallow errors; prefer targeted handling with surfaced errors.
+
+## Output
+A concise structured review: a one-line verdict, then findings grouped by severity (blocker / major / minor / nit), each with `file:line`, what is wrong, and the concrete fix. End with the exact scan numbers you measured.

--- a/.claude/agents/schema-mapper.md
+++ b/.claude/agents/schema-mapper.md
@@ -1,0 +1,28 @@
+---
+name: schema-mapper
+description: Use to extract the FiberQ plugin data model into a structured inventory — every element/layer type and every field (name, type, units, relations, the fiberq_uuid id) — from the models and manager code. Read-only. Useful for WP1 schema finalisation and any schema-diff work. Re-run whenever the model changes.
+tools: Read, Grep, Glob
+model: inherit
+---
+
+You build a precise, structured inventory of the FiberQ plugin's data model. You read; you do not edit.
+
+## Sources of truth (read these first)
+- `fiberq/models/element_defs.py` — element/layer type definitions.
+- `fiberq/models/color_catalogs.py` — colour catalogues (fiber/tube/cable colour domains).
+- `fiberq/utils/field_aliases.py` — field-name aliases / legacy ↔ current mapping (incl. legacy names).
+- `fiberq/utils/uuid_utils.py` — the `fiberq_uuid` identity field.
+- `fiberq/core/` managers (layer, data, cable, route, …) — how layers/fields are created and related at runtime.
+
+## What to produce
+For every element / layer type, list:
+- the canonical type name (and any legacy/alias names),
+- geometry type and CRS expectations,
+- every field: name, data type, units (if any), allowed values / domain (e.g. colour catalogue, route/cable type options), required vs optional, default,
+- relations to other types (foreign keys, parent/child, the `fiberq_uuid` linkage),
+- anything structured/nested or stored as JSON.
+
+Then list gaps/ambiguities: fields with unclear type/units, alias collisions, anything that looks like dead or duplicated schema.
+
+## Output
+A structured table per element type (markdown, or the schema the caller requests), followed by the gaps list. Cite `file:line` for each non-obvious item so it can be verified. Do not invent fields — report only what the code actually defines.

--- a/.claude/agents/test-author.md
+++ b/.claude/agents/test-author.md
@@ -1,0 +1,24 @@
+---
+name: test-author
+description: Use to write or extend pytest tests for the FiberQ plugin using the repo's harness (pytest + pytest-qgis, root conftest.py, tests/). Good for adding coverage as logic is extracted from the monolith and for new core managers. Can create/edit test files and run the suite.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: inherit
+---
+
+You add tests to the FiberQ plugin test suite.
+
+## Harness conventions
+- Tests live in `tests/`, named `test_*.py`. Shared fixtures go in the repo-root `conftest.py`.
+- `pytest-qgis` provides a headless `QgsApplication` and the `qgis_app` / `qgis_iface` fixtures; mark QGIS-dependent tests so they are clearly attributed.
+- The repo root is importable (`pythonpath = ["."]` in `pyproject.toml`), so `import fiberq` works.
+- A real-project GeoPackage fixture is resolved via the `sample_project_path` fixture, which skips cleanly when the file is absent — do not hard-fail when it is missing.
+- Run with `QT_QPA_PLATFORM=offscreen python -m pytest` (QGIS bindings come from the QGIS install / Docker image, not pip).
+
+## How to work
+- Prefer testing pure, extracted logic over GUI paths. If the logic you need to test is buried in `main_plugin.py` or tangled with Qt, propose the smallest extraction into a testable module/function, then test that.
+- Cover the behaviour, the edge cases, and at least one failure path. Keep tests deterministic and isolated (no network, no user QGIS profile).
+- Keep new test code scan-clean: `flake8 --isolated --max-line-length=120 --ignore=E501` (note: `assert` in tests is fine — Bandit scans `fiberq/`, not `tests/`).
+- After writing, run the suite (or the new tests) and report pass/fail.
+
+## Output
+The new/updated test files, a one-line summary of what each test asserts, and the run result.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make:*)",
+      "Bash(python -m flake8:*)",
+      "Bash(python -m bandit:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(docker run --rm:*)",
+      "Bash(docker version)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git ls-tree:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git archive:*)"
+    ]
+  }
+}

--- a/.claude/skills/green/SKILL.md
+++ b/.claude/skills/green/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: green
+description: Run the FiberQ lint+test gate inside the official QGIS Docker images (the same thing CI runs) and report pass/fail per image. Use to make the build green locally before pushing or opening a PR. Requires Docker.
+---
+
+Run the project's lint + test gate inside the QGIS containers, exactly as CI does, and report the result for each image.
+
+## Procedure
+1. Confirm Docker is available (`docker version`). If not, stop and tell the user to start Docker Desktop (or run the `scan-check` skill for a fast lint-only check).
+2. For each image in the CI matrix — `qgis/qgis:3.44-trixie` (Qt5) and `qgis/qgis:4.0-trixie` (Qt6) — run from the repo root, via Git Bash (the Makefile needs a POSIX shell):
+   ```bash
+   docker run --rm -v "$PWD:/src" -w /src \
+     -e QT_QPA_PLATFORM=offscreen -e PIP_FLAGS=--break-system-packages \
+     qgis/qgis:<tag> \
+     bash -c "apt-get update -qq && apt-get install -y --no-install-recommends make >/dev/null && make deps && make lint && make test"
+   ```
+3. Report per image: lint result, test result (pass/fail with the failing test names), and overall green/red.
+4. If something fails, summarise the root cause and the smallest fix — do not just dump logs.
+
+## Notes
+- This mirrors `.github/workflows/ci.yml`. Keep the image tags in sync with the CI matrix.
+- For a fast lint-only check without Docker, use `scan-check`.

--- a/.claude/skills/green/SKILL.md
+++ b/.claude/skills/green/SKILL.md
@@ -7,9 +7,19 @@ Run the project's lint + test gate inside the QGIS containers, exactly as CI doe
 
 ## Procedure
 1. Confirm Docker is available (`docker version`). If not, stop and tell the user to start Docker Desktop (or run the `scan-check` skill for a fast lint-only check).
-2. For each image in the CI matrix — `qgis/qgis:3.44-trixie` (Qt5) and `qgis/qgis:4.0-trixie` (Qt6) — run from the repo root, via Git Bash (the Makefile needs a POSIX shell):
+2. For each image in the CI matrix — `qgis/qgis:3.44-trixie` (Qt5) and `qgis/qgis:4.0-trixie` (Qt6) — run from the repo root. The Makefile needs a POSIX shell, so on Windows use **Git Bash** (not PowerShell).
+
+   Linux / macOS:
    ```bash
    docker run --rm -v "$PWD:/src" -w /src \
+     -e QT_QPA_PLATFORM=offscreen -e PIP_FLAGS=--break-system-packages \
+     qgis/qgis:<tag> \
+     bash -c "apt-get update -qq && apt-get install -y --no-install-recommends make >/dev/null && make deps && make lint && make test"
+   ```
+
+   Windows (Git Bash) — `MSYS_NO_PATHCONV=1` stops MSYS mangling `/src`, and `$(pwd -W)` gives Docker a Windows path:
+   ```bash
+   MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/src" -w /src \
      -e QT_QPA_PLATFORM=offscreen -e PIP_FLAGS=--break-system-packages \
      qgis/qgis:<tag> \
      bash -c "apt-get update -qq && apt-get install -y --no-install-recommends make >/dev/null && make deps && make lint && make test"
@@ -19,4 +29,6 @@ Run the project's lint + test gate inside the QGIS containers, exactly as CI doe
 
 ## Notes
 - This mirrors `.github/workflows/ci.yml`. Keep the image tags in sync with the CI matrix.
+- `make deps` installs with `pip --ignore-installed` because the QGIS images ship some tools (e.g. pytest) via apt without a RECORD file (a plain `-U` upgrade fails to uninstall them).
+- The headless run writes a disposable `.qgis-settings/` profile into the repo; it's gitignored.
 - For a fast lint-only check without Docker, use `scan-check`.

--- a/.claude/skills/prepublish/SKILL.md
+++ b/.claude/skills/prepublish/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: prepublish
+description: Run the FiberQ pre-publish checklist for a release (version sync, changelog, scan-clean, tests green, package builds, GenAI disclosure, secrets, manual-test reminder). Use right before tagging/publishing a version. Reports a readiness status; never pushes or uploads.
+---
+
+Walk the release checklist and report status for each item. Do NOT push, tag, or upload — this is a readiness check only.
+
+## Checklist (report ✓ / ✗ / N/A with evidence for each)
+1. **Version sync** — `version=` in `fiberq/metadata.txt` equals `__version__` in `fiberq/__init__.py` (the smoke test enforces this).
+2. **Changelog** — `changelog=` in `fiberq/metadata.txt` has an entry for this version.
+3. **Scan clean** — run the `scan-check` gate: flake8 0 + Bandit medium/high 0.
+4. **Tests green** — `green` passes on both QGIS images (or CI is green on the pushed commit).
+5. **Package builds** — `make package` produces `dist/fiberq-<version>.zip`; verify a single top-level `fiberq/`, that it includes `metadata.txt`/`__init__.py`, and that it contains no `__pycache__` and no dev/hidden files.
+6. **GenAI disclosure** — the "Use of Generative AI" section is present/current in both `fiberq/README.md` (shipped) and the repo-root `README.md` (public landing page).
+7. **No secrets** — `fiberq/config.ini` has placeholders only; no credentials anywhere in the diff.
+8. **Manual QGIS test** — remind the maintainer to install the built zip in a clean QGIS profile and test old + new projects before publishing (a human gate, not automated).
+9. **Provenance** — AI-assisted commits in the release carry the agreed commit trailer.
+
+## Output
+A pass/fail table, then the remaining manual steps (push, tag, upload to plugins.qgis.org, publish docs) listed for the maintainer — never execute them here.

--- a/.claude/skills/scan-check/SKILL.md
+++ b/.claude/skills/scan-check/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: scan-check
+description: Predict the plugins.qgis.org Security & Quality scan locally (flake8 + Bandit), no Docker needed. Use before any upload/release, or after a change, to confirm the plugin still scans with zero findings.
+---
+
+Run the same checks the plugins.qgis.org scanner runs, locally and fast, and report the counts.
+
+## Procedure (from the repo root)
+1. flake8 in isolated mode — mirrors the scanner exactly (config files are ignored):
+   ```bash
+   python -m flake8 --isolated --max-line-length=120 --ignore=E501 fiberq
+   ```
+2. Bandit, medium/high only (the scan policy):
+   ```bash
+   python -m bandit -r fiberq -ll -q
+   ```
+3. Report: flake8 finding count and Bandit medium/high count. **The gate is 0 / 0.**
+4. If anything fires, list each finding with `file:line` and the code, and say whether it should be fixed or (rarely, with a stated reason) silenced with an inline `# noqa: <code>` / Bandit annotation.
+
+## Notes
+- "0 findings" today rests partly on intentional inline `# noqa`s for style codes that are tracked debt — do not strip those as "cleanup".
+- This is lint-only. For the full gate including running tests in QGIS, use `green`.

--- a/.claude/skills/wp-status/SKILL.md
+++ b/.claude/skills/wp-status/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: wp-status
+description: Summarise where the FiberQ build is — current work package / phase, what's done, what's next, and the per-task definition of done. Use to orient at the start of a session or before starting a new task.
+---
+
+Give a short, accurate status of the FiberQ build plan and the per-task definition of done.
+
+## How
+1. Read the build plan (the planning doc under `docs/private/`, if present) and any project memory for the phase/version map (WP1→v1.3, WP2→v1.4, WP3→v1.5, WP4→v1.6; WP5 tests/CI is cross-cutting; WP6 docs ship per release).
+2. Check git state: current branch, latest tag, recent commits, and open PRs (if `gh` is available).
+3. Read `fiberq/metadata.txt` for the current plugin version.
+
+## Report
+- Current plugin version and what's released.
+- Which WP/phase is in progress and what is left in it.
+- The next task and its definition of done:
+  - feature branch merged to main,
+  - tagged release with a changelog entry,
+  - tests added/updated and green in CI,
+  - docs/spec/demo published and linkable,
+  - the deliverable is the new increment (not pre-existing code).
+- Any blockers or decisions waiting on the maintainer.
+
+Keep it to a tight summary, not a wall of text.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Keep line endings deterministic across Windows/Linux. The Makefile's recipe
+# lines break when `make` runs with CRLF inside the Linux QGIS containers, so
+# force LF for build/shell files regardless of the checkout platform.
+Makefile text eol=lf
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+# Thin CI wrapper. It does NOT contain build/test logic - it only runs the
+# Makefile targets inside an official QGIS container. The same `make` commands
+# run locally and on any other forge; porting to GitLab/Codeberg means rewriting
+# this YAML wrapper only, not the logic.
+#
+# Pattern: checkout runs on the host runner (which has git), then we mount the
+# workspace into the qgis/qgis image and run `make` there, so QGIS Python
+# bindings are available. We install `make` in the container first because the
+# image ships QGIS + Python but not necessarily make.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    name: QGIS ${{ matrix.qgis }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pin to tags that exist on https://hub.docker.com/r/qgis/qgis/tags .
+        # Two images cover both binding stacks the plugin supports:
+        #   3.44-trixie -> QGIS 3 line (Qt5)
+        #   4.0-trixie  -> QGIS 4 (Qt6)
+        # Re-pin these as the LTR/stable lines advance.
+        qgis:
+          - "3.44-trixie"
+          - "4.0-trixie"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint and test inside the QGIS container
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/src" -w /src \
+            -e QT_QPA_PLATFORM=offscreen \
+            -e PIP_FLAGS=--break-system-packages \
+            "qgis/qgis:${{ matrix.qgis }}" \
+            bash -c "apt-get update -qq && apt-get install -y --no-install-recommends make >/dev/null && make deps && make lint && make test"
+
+  # Build the plugin zip on every push so packaging breakage is caught early.
+  # Does not publish - publishing is a manual, tag-driven step (see RELEASE.md).
+  package:
+    name: Package (build zip)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so `git archive HEAD` works
+      - name: Build plugin zip
+        run: make package
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fiberq-plugin
+          path: dist/*.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -208,10 +208,18 @@ __marimo__/
 
 # FiberQ — internal/agent/grant docs. NEVER publish to the public repo
 # (CLAUDE.md references the private Designer repo; the MoU has budget/day-rates;
-#  the build plan has commercial-boundary notes). Keep these local only.
+#  the build plan has commercial-boundary notes; intake notes hold meeting
+#  strategy). Private planning material lives in docs/private/ — keep it local.
+# Public WP deliverable docs (docs/schema.md, docs/releasing.md, …) ARE tracked.
 /CLAUDE.md
-/docs/FiberQ-MoU-project-plan.md
-/docs/FiberQ-plugin-build-plan.md
+/docs/private/
+
+# Plugin build artifact + QGIS/OS local cruft (the packaged zip lands in dist/,
+# already ignored above; this also guards stray zips and editor/OS backups)
+*.zip
+*.qgs~
+*.qgz~
+.DS_Store
 
 # Local dev helpers (not shipped in the plugin zip)
 /dev/

--- a/.gitignore
+++ b/.gitignore
@@ -221,5 +221,8 @@ __marimo__/
 *.qgz~
 .DS_Store
 
+# QGIS profile written by headless pytest-qgis runs (test artifact, not source)
+.qgis-settings/
+
 # Local dev helpers (not shipped in the plugin zip)
 /dev/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,116 @@
+# FiberQ - forge-agnostic automation. ALL real logic lives here.
+# CI on any forge (GitHub, GitLab, Codeberg) is a thin wrapper that only
+# calls these targets, so everything below also runs on a bare laptop.
+#
+# Assumed repo layout (set up in Phase 0):
+#   repo/
+#     fiberq/        <- the QGIS plugin package (metadata.txt, __init__.py, core/, ...)
+#     tests/         <- pytest suite
+#     Makefile  RELEASE.md  pyproject.toml  .flake8  .gitignore  conftest.py
+#
+# Requirements: python3 + git locally. For `make test`, QGIS Python bindings must
+# be importable - use the qgis/qgis Docker image, or a venv created with
+# --system-site-packages on a machine that has QGIS installed. QGIS itself is
+# NOT pip-installable.
+
+PLUGIN_NAME := fiberq
+PKG := $(PLUGIN_NAME)
+
+# Version comes from metadata.txt, NOT a git tag, so every target is self-contained
+# and identical locally and in CI. `tr -d` strips the trailing CR on CRLF files.
+VERSION := $(shell grep -E '^version=' $(PKG)/metadata.txt 2>/dev/null | head -n1 | cut -d= -f2 | tr -d '[:space:]')
+
+PYTHON ?= python3
+# PEP 668 systems (recent Debian/Ubuntu, incl. the QGIS images) need this for pip.
+# Set PIP_FLAGS= (empty) when installing into a virtualenv.
+PIP_FLAGS ?= --break-system-packages
+
+DIST_DIR := dist
+ZIP := $(DIST_DIR)/$(PLUGIN_NAME)-$(VERSION).zip
+
+.DEFAULT_GOAL := help
+
+.PHONY: help deps lint flake8 bandit test test-cov package install uninstall clean tag release version
+
+help:
+	@echo "FiberQ - make targets (current version: $(VERSION))"
+	@echo "  deps      install lint/test tooling (flake8, bandit, pytest, pytest-qgis)"
+	@echo "  lint      flake8 + bandit  (mirrors the plugins.qgis.org scan gate)"
+	@echo "  test      run the pytest suite (needs QGIS bindings - see header)"
+	@echo "  package   build $(ZIP) for upload to the QGIS plugin repository"
+	@echo "  install   copy the plugin into your local QGIS profile (manual testing)"
+	@echo "  clean     remove dist/ and caches"
+	@echo "  release   lint + test + package + tag v$(VERSION)  (see RELEASE.md)"
+
+version:
+	@echo $(VERSION)
+
+# ---- tooling ----------------------------------------------------------------
+deps:
+	$(PYTHON) -m pip install $(PIP_FLAGS) -U pytest pytest-cov "pytest-qgis>=3.0,<5" flake8 "bandit[toml]"
+
+# ---- lint (mirror of the repository Security & Quality scan) ----------------
+lint: flake8 bandit
+
+flake8:
+	$(PYTHON) -m flake8 --isolated --max-line-length=120 --ignore=E501 $(PKG) tests conftest.py
+
+bandit:
+	# Medium/high severity only (-ll), matching the scan policy. Config in pyproject.toml.
+	$(PYTHON) -m bandit -r $(PKG) -ll -q -c pyproject.toml
+
+# ---- tests ------------------------------------------------------------------
+# QT_QPA_PLATFORM=offscreen runs Qt without a display. The qgis/qgis image also
+# ships xvfb if a real X server is ever needed: `xvfb-run make test`.
+test:
+	QT_QPA_PLATFORM=offscreen $(PYTHON) -m pytest
+
+test-cov:
+	QT_QPA_PLATFORM=offscreen $(PYTHON) -m pytest --cov=$(PKG) --cov-report=term-missing --cov-report=xml
+
+# ---- package (reproducible plugin zip) --------------------------------------
+# Archives ONLY the fiberq/ subtree, prefixed so the zip contains fiberq/...
+# Dev/CI files live at the repo root and are therefore never shipped.
+# Uses git (local; no GitHub needed) and packages committed state.
+package:
+	@rm -rf $(DIST_DIR)
+	@mkdir -p $(DIST_DIR)
+	git archive --format=zip --prefix=$(PLUGIN_NAME)/ -o $(ZIP) HEAD:$(PKG)
+	@echo "Built $(ZIP)"
+
+# ---- local install for manual QGIS testing ---------------------------------
+# Override QGIS_PROFILE for your OS, e.g.:
+#   macOS:   ~/Library/Application Support/QGIS/QGIS3/profiles/default
+#   Windows: %APPDATA%/QGIS/QGIS3/profiles/default
+QGIS_PROFILE ?= $(HOME)/.local/share/QGIS/QGIS3/profiles/default
+PLUGIN_DEST := $(QGIS_PROFILE)/python/plugins/$(PLUGIN_NAME)
+
+install:
+	@mkdir -p "$(dir $(PLUGIN_DEST))"
+	@rm -rf "$(PLUGIN_DEST)"
+	@cp -r "$(PKG)" "$(PLUGIN_DEST)"
+	@find "$(PLUGIN_DEST)" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+	@echo "Installed to $(PLUGIN_DEST)  (restart QGIS or use the Plugin Reloader)"
+
+uninstall:
+	@rm -rf "$(PLUGIN_DEST)"
+	@echo "Removed $(PLUGIN_DEST)"
+
+# ---- release ----------------------------------------------------------------
+# Intentionally does NOT bump the version or upload anything. See RELEASE.md.
+release: lint test package tag
+	@echo ""
+	@echo "Artifact: $(ZIP)"
+	@echo "Next (manual, see RELEASE.md): git push && git push --tags, then upload the zip."
+
+tag:
+	@if [ -z "$(VERSION)" ]; then echo "No version found in $(PKG)/metadata.txt"; exit 1; fi
+	@if git rev-parse "v$(VERSION)" >/dev/null 2>&1; then \
+		echo "Tag v$(VERSION) already exists - bump 'version=' in $(PKG)/metadata.txt first."; exit 1; \
+	fi
+	git tag -a "v$(VERSION)" -m "FiberQ $(VERSION)"
+	@echo "Created tag v$(VERSION) (not pushed)."
+
+clean:
+	@rm -rf $(DIST_DIR) .pytest_cache .coverage coverage.xml
+	@find . -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ version:
 
 # ---- tooling ----------------------------------------------------------------
 deps:
-	$(PYTHON) -m pip install $(PIP_FLAGS) -U pytest pytest-cov "pytest-qgis>=3.0,<5" flake8 "bandit[toml]"
+	$(PYTHON) -m pip install $(PIP_FLAGS) --ignore-installed pytest pytest-cov "pytest-qgis>=3.0,<5" flake8 "bandit[toml]"
 
 # ---- lint (mirror of the repository Security & Quality scan) ----------------
 lint: flake8 bandit

--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
-fiberq
+# FiberQ
 
-New realase v1.2.3 - 23.06.2026.
+Open-source QGIS plugin for fiber optic network design (FTTH / GPON / FTTx).
 
-Check out the new version (v1.2.3)
+**Latest release: v1.2.3 — 23.06.2026.** Added on GitHub as a new release.
 
-I just added on GitHub as a new realase.
-
-You can also auto update in QGIS or download manually folder from GitHub realase.
+You can auto-update in QGIS, or download the folder manually from the GitHub release.
 
 Download User Guide:
 https://www.fiberq.net/documentation/
+
+For the full feature list and install instructions, see [fiberq/README.md](fiberq/README.md).
 
 ## Community & Feedback
 
 - 💡 **Feature requests & voting (Discussions → Ideas):** https://github.com/vukovicvl/fiberq/discussions/categories/ideas
 - 🐛 **Bug reports (GitHub Issues):** https://github.com/vukovicvl/fiberq/issues
 - 📊 **Polls (priorities & decisions):** https://github.com/vukovicvl/fiberq/discussions/categories/polls
+
+## Use of Generative AI
+
+Parts of FiberQ are developed with the help of generative AI tools (Anthropic's
+Claude) — for example code, tests, refactoring, and documentation. All AI-assisted
+changes are reviewed and tested by the maintainer before release, and AI-assisted
+commits carry an `Assisted-by:` trailer. FiberQ remains human-authored and
+human-reviewed software, released under GPL-3.0-or-later.
+
+## License
+
+GPL-3.0-or-later

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,107 @@
+# Releasing FiberQ
+
+The documented release process for the FiberQ QGIS plugin. All steps use the
+forge-agnostic `Makefile`; none require GitHub specifically.
+
+## Versioning
+
+FiberQ uses semantic-style versioning `MAJOR.MINOR.PATCH` (e.g. `1.3.0`).
+
+- The **single source of truth** is `version=` in `fiberq/metadata.txt`.
+- `fiberq/__init__.py` also carries `__version__`; keep it identical. A smoke
+  test (`tests/test_smoke.py`) fails the build if the two drift apart.
+- The **schema version** is tracked separately (see WP1) inside the project's
+  `_fiberq_metadata` table. Plugin version and schema version are deliberately
+  decoupled: most releases bump the plugin version only.
+
+When to bump which part:
+- **PATCH** — bug fixes, cleanup, no behaviour change.
+- **MINOR** — new backward-compatible features (a new capability delivery, typically).
+- **MAJOR** — breaking changes to the data model or public behaviour.
+
+## Pre-release checklist
+
+- [ ] `make lint` is clean (flake8 + Bandit medium/high = 0 findings).
+- [ ] `make test` passes (and CI is green on both QGIS images).
+- [ ] `version=` bumped in `fiberq/metadata.txt`, and `__version__` in
+      `fiberq/__init__.py` matches.
+- [ ] `changelog=` block in `fiberq/metadata.txt` updated for this version.
+- [ ] `fiberq/config.ini` contains no credentials or machine-specific paths.
+- [ ] "Use of Generative AI" section present/current in `fiberq/README.md`
+      (shipped) and the repo-root `README.md` (public landing page).
+- [ ] AI-assisted commits carry the `Assisted-by:` trailer.
+- [ ] Manual QGIS test done: install the built zip in a clean profile and open
+      both an older project and a new one.
+
+## Build, tag, push
+
+```bash
+make package          # builds dist/fiberq-<version>.zip from committed state
+make release          # runs lint + test + package, then creates tag v<version>
+git push && git push --tags
+```
+
+Notes:
+- `make package` uses `git archive HEAD:fiberq`, so it packages **committed**
+  state and the zip contains a single top-level `fiberq/` folder (what
+  plugins.qgis.org requires). Commit before packaging a real release.
+- `make release` refuses to create a tag that already exists — bump the version
+  in `metadata.txt` first. It does not push or upload anything automatically;
+  push and upload are deliberate, manual steps.
+
+## Local development (Windows)
+
+The maintainer's box is Windows; the `Makefile` is POSIX shell, so run `make`
+either inside the QGIS container (as CI does) or from **Git Bash** (not
+PowerShell/cmd):
+
+- **Lint only, native and fast** (no Docker needed):
+  ```bash
+  python -m flake8 --isolated --max-line-length=120 --ignore=E501 fiberq tests conftest.py
+  python -m bandit -r fiberq -ll -q -c pyproject.toml
+  ```
+- **Full gate (lint + tests) in the QGIS image** — from Git Bash, with Docker Desktop running:
+  ```bash
+  docker run --rm -v "$PWD:/src" -w /src -e QT_QPA_PLATFORM=offscreen \
+    -e PIP_FLAGS=--break-system-packages qgis/qgis:4.0-trixie \
+    bash -c "apt-get update -qq && apt-get install -y --no-install-recommends make >/dev/null && make deps && make lint && make test"
+  ```
+  Repeat with `qgis/qgis:3.44-trixie`. For a local non-Debian/venv run, set
+  `PIP_FLAGS=` (empty).
+- `make install` targets a Linux profile by default; on Windows override it, e.g.
+  `make install QGIS_PROFILE="$APPDATA/QGIS/QGIS3/profiles/default"` (run from Git Bash).
+
+CI is the authoritative green check for the test/package steps.
+
+## Upload to the QGIS plugin repository
+
+`dist/fiberq-<version>.zip` is the artifact to upload.
+
+1. Sign in at <https://plugins.qgis.org/> with the OSGEO account.
+2. Open the FiberQ plugin page → **Add version** → upload the zip.
+3. plugins.qgis.org runs its Security & Quality scan (flake8 + Bandit). The local
+   `make lint` mirrors that gate, so a clean local run should mean a clean scan.
+4. Verify the new version appears in the QGIS Plugin Manager (it can take a few
+   minutes to propagate).
+
+Keep any upload credentials out of the repo — use environment variables or a forge
+secret if the upload is ever scripted. The manual web upload is the documented default.
+
+## After release (dissemination)
+
+For each released task/version, publish: a summary of what was done plus updated
+documentation / user guide on the project website; the tagged release and zip on
+GitHub; video guide(s) where relevant; and a note to the mailing list.
+
+## Tested QGIS versions
+
+CI builds against `qgis/qgis:3.44-trixie` (QGIS 3, Qt5) and `qgis/qgis:4.0-trixie`
+(QGIS 4, Qt6). `metadata.txt` declares `qgisMinimumVersion=3.22` and
+`qgisMaximumVersion=4.99`.
+
+Note: CI does **not** run a 3.22 image (old images are pruned upstream, and
+`pytest-qgis` itself requires QGIS ≥ 3.34, so 3.34 is the realistic CI floor). The
+3.22 LTR floor is held by careful API usage and the Qt5/Qt6 compatibility layer
+(`fiberq/utils/compat.py`), **not** by CI — verify it manually before any release
+that touches Qt/QGIS APIs. Re-pin the CI tags in `.github/workflows/ci.yml` as the
+LTR/stable lines move.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,35 @@
+"""Shared pytest fixtures for FiberQ.
+
+Lives at the repo root so pytest makes the root importable (`import fiberq`
+resolves to the fiberq/ package). pytest-qgis bootstraps a headless
+QgsApplication automatically and exposes fixtures such as `qgis_app` and
+`qgis_iface` to every test. Add project-wide fixtures here as the suite grows
+(WP5).
+
+Note: this file is loaded very early, so it avoids importing `fiberq` at module
+top level; fixtures resolve paths from __file__ instead.
+"""
+import os
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(scope="session")
+def fiberq_dir():
+    """Absolute path to the fiberq/ plugin package."""
+    return os.path.join(REPO_ROOT, "fiberq")
+
+
+@pytest.fixture(scope="session")
+def sample_project_path():
+    """Path to the demo GeoPackage fixture (added in Phase 0 / WP6).
+
+    Tests that need a real project skip cleanly until the fixture exists, so
+    the suite stays green before the demo dataset lands.
+    """
+    path = os.path.join(REPO_ROOT, "tests", "fixtures", "sample_project.gpkg")
+    if not os.path.exists(path):
+        pytest.skip("tests/fixtures/sample_project.gpkg not present yet")
+    return path

--- a/fiberq/README.md
+++ b/fiberq/README.md
@@ -144,6 +144,14 @@ v1.2 maintains full backward compatibility with v1.0 and v1.1 projects:
 - Repository: https://github.com/vukovicvl/fiberq
 - Issues: https://github.com/vukovicvl/fiberq/issues
 
+## Use of Generative AI
+
+Parts of FiberQ are developed with the help of generative AI tools (Anthropic's
+Claude) — for example code, tests, refactoring, and documentation. All AI-assisted
+changes are reviewed and tested by the maintainer before release, and AI-assisted
+commits carry an `Assisted-by:` trailer. FiberQ remains human-authored and
+human-reviewed software, released under GPL-3.0-or-later.
+
 ## License
 
 GPL-3.0-or-later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+# Tool configuration for FiberQ dev tooling.
+# NOTE: flake8 does NOT read pyproject.toml - its config lives in .flake8.
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+# Make the repo root importable so `import fiberq` works (plugin package is fiberq/).
+pythonpath = ["."]
+addopts = "-ra"
+markers = [
+    "qgis: test needs a running QgsApplication (provided by pytest-qgis)",
+]
+
+[tool.coverage.run]
+source = ["fiberq"]
+omit = [
+    "fiberq/__init__.py",
+    "*/resources/*",
+    "*/styles/*",
+    "*/icons/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+
+[tool.bandit]
+# Severity threshold is set on the CLI (-ll = medium/high), matching the
+# plugins.qgis.org scan. List B-IDs here only if a finding ever needs skipping.
+exclude_dirs = ["tests", "build", "dist", ".venv"]

--- a/tests/fixtures/README.txt
+++ b/tests/fixtures/README.txt
@@ -1,0 +1,2 @@
+# Demo GeoPackage fixtures go here (sample_project.gpkg).
+# Created in Phase 0 / WP6; reused by WP4 benchmark, WP3 round-trip, WP5 integration.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke tests - the first safety net for Phase 0 CI.
+
+They prove the harness works end to end: QGIS bindings load (via pytest-qgis),
+the `fiberq` package imports, and the declared version is internally consistent.
+Real unit/integration coverage (WP5) builds on top of this.
+"""
+import os
+
+import fiberq
+
+
+def _metadata_version():
+    meta = os.path.join(os.path.dirname(fiberq.__file__), "metadata.txt")
+    with open(meta, encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("version="):
+                return line.split("=", 1)[1].strip()
+    return None
+
+
+def test_package_imports():
+    assert fiberq.__version__
+
+
+def test_version_matches_metadata():
+    """metadata.txt and __init__.py must agree (guards the release checklist)."""
+    assert _metadata_version() == fiberq.__version__
+
+
+def test_qgis_bindings_available(qgis_app):
+    """pytest-qgis provides qgis_app; a Qgis-dependent module must import and
+    expose its expected constants."""
+    from fiberq.utils import constants
+
+    assert len(constants.ROUTE_TYPE_OPTIONS) == 3


### PR DESCRIPTION
## What this is
Development groundwork: a test / build / CI harness so the project is testable and the
plugins.qgis.org Security & Quality scan is predictable locally. **No plugin code changes** —
the plugin stays at **v1.2.3** and is **not** uploaded to the QGIS repository. Not a release.

## Contents (by commit)
- `.claude/` developer tooling — review/schema/test/migration helper agents + skills
  (green, scan-check, prepublish, wp-status) + a shared settings allowlist.
- docs layout — internal planning notes moved under `docs/private/` (ignored); public docs under `docs/` stay trackable.
- harness — `Makefile`, `pyproject.toml`, `conftest.py`, `tests/` smoke tests, and a GitHub Actions
  workflow that runs `make` inside the official QGIS containers.
- docs — "Use of Generative AI" disclosure in both READMEs, `RELEASE.md`, `.gitattributes` LF guard.
- fixes — `make deps` uses `pip --ignore-installed` (QGIS images ship pytest via apt); ignore the
  headless-test `.qgis-settings/` profile.

## Verified
- `make lint` = 0/0 (flake8 `--isolated --max-line-length=120 --ignore=E501` + Bandit `-ll`).
- `make test` green in both `qgis/qgis:3.44-trixie` (Qt5) and `qgis/qgis:4.0-trixie` (Qt6): 3 smoke tests pass.
- `make package` → `dist/fiberq-1.2.3.zip`: single top-level `fiberq/`, no cruft, no internal files.
- `metadata.txt` version == `__init__.__version__` (enforced by a smoke test).

## Notes
- Dev/CI configs live at the repo root and are not shipped in the plugin zip.
- CI runs on this PR (workflow triggers on `pull_request`).