### PR TITLE
WP1a — canonical schema model + project schema_version marker (no behaviour change, stays v1.2.3)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,278 @@
+# FiberQ data schema
+
+This document describes the FiberQ project data model: the layer types, their
+fields, units and value domains, the CRS expectations, and the project
+**schema version** marker. It is generated from the single source of truth in
+[`fiberq/models/schema.py`](../fiberq/models/schema.py).
+
+> **Status:** this is the *as-built* schema for FiberQ **1.x**, schema version
+> **1.0**. It faithfully reflects what the plugin creates today. A small number
+> of known inconsistencies are listed under [Notes & limitations](#notes--limitations);
+> they are preserved as-is in 1.0 and will be reconciled by the open
+> interchange-format work, where changing stored data is safe to coordinate.
+
+## Conventions
+
+- **Field names are the stored schema.** They are mostly the original
+  (Serbian) database names. The English text shown in the QGIS attribute table
+  is a display **alias** only — renaming a stored field is a data migration, not
+  a cosmetic change.
+- **`fiberq_uuid`** is the per-feature **identity** field. It is present on every
+  FiberQ layer (appended automatically when the layer is created) and is what
+  links features across operations and exports.
+- **Geometry & CRS.** Layers are created in memory. Most layers use the map
+  canvas destination CRS (falling back to `EPSG:3857`); the polygon layers
+  *Service Area* and *Objects* use the **project** CRS.
+- **Type legend:** `text` (string), `int` (integer), `double` (real),
+  `enum` (string with a fixed option list), `year` (4-digit, stored as integer),
+  `bool` (boolean).
+- **Value maps** let a field show an English label while storing a different
+  (often Serbian) value — noted per field below.
+
+## Schema versioning
+
+The project schema version is the string **`SCHEMA_VERSION`** in
+`fiberq/models/schema.py` (currently `1.0`). It is:
+
+- **tracked separately from the plugin version** in `metadata.txt` — the two
+  bump independently;
+- **persisted into the project** when you save (a QGIS project entry), and
+  **mirrored into the GeoPackage** `_fiberq_metadata` table on a full project
+  export, so the version travels with the data file;
+- **absent in pre-1.0 projects** — those are treated as the pre-marker baseline
+  (version `0`) and are upgraded by the migration framework (see WP1b).
+
+## Layer types
+
+### Point elements (shared roster)
+
+These 12 element layers share one 15-field roster (one QGIS layer per type):
+**ODF, TB, Patch panel, OTB, Indoor OTB, Outdoor OTB, Pole OTB, TO, Indoor TO,
+Outdoor TO, Pole TO, Joint Closure TO**. Geometry: Point. The only per-layer
+variation: an "OD cabinet" (`od ormar`) layer defaults `kapacitet` to 24.
+
+| field | type | units | domain / default | attribute alias |
+|---|---|---|---|---|
+| naziv | text | | "" | Name |
+| proizvodjac | text | | "" | Manufacturer |
+| oznaka | text | | "" | Label |
+| kapacitet | int | ports | 0 (24 for OD cabinets) | Capacity |
+| ukupno_kj | int | | 0 | Total SCs |
+| zahtev_kapaciteta | int | | 0 | Required capacity |
+| zahtev_rezerve | int | | 0 | Reserve capacity |
+| oznaka_izvoda | text | | "" | Port label |
+| numeracija | text | | "" | Numbering |
+| naziv_objekta | text | | "" | Site name |
+| adresa_ulica | text | | "" | Street |
+| adresa_broj | text | | "" | Street No. |
+| address_id | text | | "" | Address ID |
+| stanje | enum | | [Planned, Built, Existing], default Planned | Status |
+| godina_ugradnje | year | | 2025 | Install year |
+| fiberq_uuid | text | | identity | FiberQ UUID |
+
+### Joint Closures
+Point. Legacy name: `Nastavci`.
+
+| field | type | alias |
+|---|---|---|
+| naziv | text | Name |
+| fiberq_uuid | text | FiberQ UUID |
+
+### Poles
+Point. Legacy name: `Stubovi`.
+
+| field | type | units | alias |
+|---|---|---|---|
+| tip | text | | Type |
+| podtip | text | | Subtype |
+| visina | double | m | Height (m) |
+| materijal | text | | Material |
+| fiberq_uuid | text | | FiberQ UUID |
+
+### Manholes
+Point. Legacy name: `OKNA`.
+
+| field | type | units | alias |
+|---|---|---|---|
+| broj_okna | text | | Manhole ID |
+| tip_okna | text | | Manhole type |
+| vrsta_okna | text | | Construction type |
+| polozaj_okna | text | | Position |
+| adresa | text | | Address |
+| stanje | text | | Status (free text) |
+| god_ugrad | int | | Installation year |
+| opis | text | | Description |
+| dimenzije | text | cm | Dimensions (cm) |
+| mat_zida | text | | Wall material |
+| mat_poklop | text | | Cover material |
+| odvodnj | text | | Drainage |
+| poklop_tes | bool | | Heavy cover |
+| poklop_lak | bool | | Light cover |
+| br_nosaca | int | | Number of steps |
+| debl_zida | double | cm | Wall thickness (cm) |
+| lestve | text | | Ladder |
+| fiberq_uuid | text | | FiberQ UUID |
+
+### Route
+LineString. Legacy name: `Trasa`.
+
+| field | type | units | value map | alias |
+|---|---|---|---|---|
+| naziv | text | | | Route name |
+| duzina | double | m | | Length (m) |
+| duzina_km | double | km | | Length (km) |
+| tip_trase | text | | Aerial→vazdusna, Underground→podzemna, Through the object→kroz objekat | Route type |
+| fiberq_uuid | text | | | FiberQ UUID |
+
+### Optical slack
+Point. Canonical name `Optical slack`; legacy `Optical slacks`, `Opticke_rezerve`.
+
+| field | type | units | value map | alias |
+|---|---|---|---|---|
+| tip | text | | | Type |
+| duzina_m | double | m | | Length (m) |
+| lokacija | text | | Manhole→OKNO, Pole→Stub, Object→Objekat | Location |
+| cable_layer_id | text | | FK → cable layer | Cable layer ID |
+| cable_fid | int | | FK → cable feature | Cable feature ID |
+| strana | text | | FROM→od, TO→do, MID SPAN→sredina | Side |
+| napomena | text | | | Note |
+| fiberq_uuid | text | | | FiberQ UUID |
+
+### PE pipes / Transition pipes
+LineString. Same roster. Legacy names `PE cevi` / `Prelazne cevi`.
+
+| field | type | units | alias |
+|---|---|---|---|
+| materijal | text | | Material |
+| kapacitet | text | | Capacity |
+| fi | int | mm | Diameter (mm) |
+| od | text | | From |
+| do | text | | To |
+| duzina_m | double | m | Length (m) |
+| fiberq_uuid | text | | FiberQ UUID |
+
+### Service Area
+Polygon, **project CRS**. Legacy names `Service area`, `Rejon`. Fields are
+already English.
+
+| field | type | units | notes |
+|---|---|---|---|
+| name | text | | |
+| created_at | text | | timestamp |
+| area_m2 | double | m² | ellipsoidal area |
+| perim_m | double | m | |
+| count | int | | source feature count |
+| fiberq_uuid | text | | identity |
+
+### Objects
+Polygon, **project CRS**. Legacy name `Objekti`.
+
+| field | type | alias |
+|---|---|---|
+| tip | text | Type |
+| spratova | int | Floors above ground |
+| podzemnih | int | Floors below ground |
+| ulica | text | Street |
+| broj | text | Number |
+| naziv | text | Name |
+| napomena | text | Note |
+| fiberq_uuid | text | FiberQ UUID |
+
+### Aerial cables / Underground cables
+LineString. Both share one roster. Legacy names `Kablovi_vazdusni` /
+`Kablovi_podzemni`. (`branch_index` is added on demand when a cable is branched
+and is therefore not part of the base roster.)
+
+| field | type | units | value map | alias |
+|---|---|---|---|---|
+| tip | text | | Optical→opticki, Copper→bakarnI | Cable type |
+| podtip | text | | Backbone→glavni, Distribution→distributivni, Drop→razvodni | Segment type |
+| color_code | text | | | Color code |
+| broj_cevcica | int | | | Number of ducts |
+| broj_vlakana | int | | | Number of fibers |
+| tip_kabla | text | | | Cable model |
+| vrsta_vlakana | text | | | Fiber type |
+| vrsta_omotaca | text | | | Sheath type |
+| vrsta_armature | text | | | Armour type |
+| talasno_podrucje | text | | | Wavelength band |
+| naziv | text | | | Name |
+| slabljenje_dbkm | double | dB/km | | Attenuation [dB/km] |
+| hrom_disp_ps_nmxkm | double | ps/nm/km | | Chromatic dispersion [ps/nm/km] |
+| stanje_kabla | text | | Planned→Projektovano, Existing→Postojeće, Under construction→U izgradnji | Status |
+| cable_laying | text | | Underground→Podzemno, Aerial→Vazdusno | Installation type |
+| vrsta_mreze | text | | | Network type |
+| godina_ugradnje | int | year | | Installation year |
+| konstr_vlakna_u_cevcicama | int | | construction flag (0/1) | Fibers in ducts |
+| konstr_sa_uzlepljenim_elementom | int | | 0/1 | With bonded element |
+| konstr_punjeni_kabl | int | | 0/1 | Gel-filled cable |
+| konstr_sa_arm_vlaknima | int | | 0/1 | Aramid yarn armouring |
+| konstr_bez_metalnih | int | | 0/1 | Non-metallic |
+| od | text | | | From |
+| do | text | | | To |
+| duzina_m | double | m | | Length [m] |
+| slack_m | double | m | | Slack [m] |
+| total_len_m | double | m | | Total length [m] |
+| fibers_per_tube | int | | fiber-schema (interchange) | Fibers per tube |
+| total_fibers | int | | fiber-schema (interchange) | Total fibers |
+| color_standard | text | | fiber-schema (interchange), e.g. TIA-598-C | Color standard |
+| fiberq_uuid | text | | identity | FiberQ UUID |
+
+### Fiber break
+Point. Legacy name `Prekid vlakna`.
+
+| field | type | units | alias |
+|---|---|---|---|
+| naziv | text | | Name |
+| cable_layer_id | text | | Cable layer ID |
+| cable_fid | int | | Cable feature ID |
+| distance_m | double | m | Distance (m) |
+| segments_hit | int | | Segments hit |
+| vreme | text | | Time |
+| fiberq_uuid | text | | FiberQ UUID |
+
+## Colour catalogues
+
+Fibre/tube colours follow an ordered 12-colour ANSI/TIA-598-C sequence
+(`position → colour = (position − 1) mod tube_count`, default `tube_count = 12`).
+The seeded catalogue is **TIA-598-C**; catalogues are stored as JSON in a project
+entry and referenced by name per cable (`color_standard`). See
+`fiberq/models/color_catalogs.py`.
+
+## Layer-name aliases (legacy → canonical)
+
+Older projects use the original names; FiberQ recognises them as the same type:
+
+| canonical | legacy / alternate |
+|---|---|
+| Poles | Stubovi |
+| Manholes | OKNA |
+| Patch panel | Patch Panel |
+| Joint Closures | Nastavci |
+| Optical slack | Optical slacks, Opticke_rezerve |
+| Fiber break | Prekid vlakna |
+| Route | Trasa |
+| Aerial cables | Kablovi_vazdusni |
+| Underground cables | Kablovi_podzemni |
+| PE pipes | PE cevi |
+| Transition pipes | Prelazne cevi |
+| Objects | Objekti |
+| Service Area | Service area, Rejon |
+
+## Notes & limitations
+
+These are known as-built inconsistencies, preserved unchanged in schema 1.0 and
+scheduled for reconciliation by the interchange-format work (so that any change
+to stored values is coordinated and lossless):
+
+- **Status vocabulary differs by layer:** element `stanje` =
+  [Planned, Built, Existing] (stored English); cable `stanje_kabla` =
+  [Planned, Existing, Under construction] (stored Serbian via value map);
+  manhole `stanje` is free text.
+- **`kapacitet` type differs:** integer on elements, text on pipes.
+- **Manhole `poklop_tes` / `poklop_lak` are boolean** — booleans may not round-trip
+  cleanly through some GeoPackage/OGR paths.
+- **Cable `tip` storage direction:** the value map expects Serbian stored values,
+  but a one-off migration rewrites them to English; the canonical direction will
+  be fixed by the interchange work (the stored typo `bakarnI` is preserved for now).
+- **Mixed field naming:** a few keys are English in an otherwise Serbian roster
+  (e.g. element `address_id`, the cable fibre-schema fields). These are kept as-is.

--- a/fiberq/core/data_manager.py
+++ b/fiberq/core/data_manager.py
@@ -15,6 +15,9 @@ import json
 import os
 from qgis.core import QgsProject, QgsVectorLayer, QgsWkbTypes
 
+# WP1a: schema version marker
+from .schema_version import write_project_schema_version
+
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
 logger = get_logger(__name__)
@@ -363,7 +366,19 @@ class DataManager:
                 results["color_catalogs"] = False
                 logger.debug(f"Error restoring color catalogs: {e}")
 
-        # 4. Log other metadata (informational, not restored to project storage)
+        # 4. Restore the schema version into the project marker (WP1a). Prefer the
+        #    dedicated schema_version key; fall back to legacy project_version.
+        version = metadata.get("schema_version") or metadata.get("project_version")
+        if version:
+            try:
+                write_project_schema_version(version, prj)
+                results["schema_version"] = True
+                logger.debug(f"Restored schema_version = {version} from GPKG metadata")
+            except Exception as e:
+                results["schema_version"] = False
+                logger.debug(f"Error restoring schema_version: {e}")
+
+        # 5. Log other metadata (informational, not restored to project storage)
         for key in ("project_version", "crs_epsg", "export_timestamp", "color_standard"):
             if key in metadata:
                 logger.debug(f"GPKG metadata: {key} = {metadata[key]}")

--- a/fiberq/core/export_manager.py
+++ b/fiberq/core/export_manager.py
@@ -21,6 +21,10 @@ from qgis.core import (
 )
 from qgis.PyQt.QtWidgets import QFileDialog, QMessageBox, QInputDialog
 
+# WP1a: canonical schema version + project marker
+from ..models.schema import SCHEMA_VERSION
+from .schema_version import mark_project_current
+
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
 logger = get_logger(__name__)
@@ -446,8 +450,10 @@ class ExportManager:
         prj = QgsProject.instance()
         metadata = {}
 
-        # 1. Project version
-        metadata["project_version"] = "1.3.0"
+        # 1. Schema version (canonical). project_version is kept in sync for
+        # backward-compat of the metadata table; both now track SCHEMA_VERSION.
+        metadata["schema_version"] = SCHEMA_VERSION
+        metadata["project_version"] = SCHEMA_VERSION
 
         # 2. Relations data
         try:
@@ -556,6 +562,13 @@ class ExportManager:
             return False
 
         metadata = self._collect_metadata()
+
+        # WP1a: also stamp the in-memory project so the schema version lives in
+        # the .qgs project too (the metadata table below carries it in the GPKG).
+        try:
+            mark_project_current()
+        except Exception as e:
+            logger.debug(f"Could not stamp project schema version: {e}")
 
         try:
             conn = sqlite3.connect(gpkg_path)

--- a/fiberq/core/layer_manager.py
+++ b/fiberq/core/layer_manager.py
@@ -89,27 +89,9 @@ def _default_fields_for(layer_name: str):
     Return a list of (key, label, kind, default, options) for element dialogs.
     kind: 'text' | 'int' | 'double' | 'enum' | 'year'
     """
-    base = [
-        ("naziv", "Name", "text", "", None),
-        ("proizvodjac", "Manufacturer", "text", "", None),
-        ("oznaka", "Label", "text", "", None),
-        ("kapacitet", "Capacity", "int", 0, None),
-        ("ukupno_kj", "Total", "int", 0, None),
-        ("zahtev_kapaciteta", "Capacity Requirement", "int", 0, None),
-        ("zahtev_rezerve", "Slack Requirement", "int", 0, None),
-        ("oznaka_izvoda", "Outlet Label", "text", "", None),
-        ("numeracija", "Numbering", "text", "", None),
-        ("naziv_objekta", "Object Name", "text", "", None),
-        ("adresa_ulica", "Address Street", "text", "", None),
-        ("adresa_broj", "Address Number", "text", "", None),
-        ("address_id", "Address ID", "text", "", None),
-        ("stanje", "Status", "enum", "Planned", ["Planned", "Built", "Existing"]),
-        ("godina_ugradnje", "Year of Installation", "year", 2025, None),
-    ]
-    ln = (layer_name or "").lower()
-    if "od ormar" in ln:
-        base = [(k, l, kind, (24 if k == "kapacitet" else d), opt) for (k, l, kind, d, opt) in base]
-    return base
+    # Delegates to the canonical schema (single source of truth, WP1a).
+    from ..models.schema import get_default_fields_for_layer as _schema_fields
+    return _schema_fields(layer_name)
 
 
 def _apply_fixed_text_label(layer, field_name='naziv', size_mu=8.0, yoff_mu=5.0):

--- a/fiberq/core/schema_version.py
+++ b/fiberq/core/schema_version.py
@@ -1,0 +1,65 @@
+"""FiberQ project schema-version marker (WP1a).
+
+Reads and writes the project ``SCHEMA_VERSION`` to a durable ``QgsProject`` entry
+so it survives a normal project save/reopen (QGIS serialises project entries into
+the ``.qgs``/``.qgz`` file). The version is also mirrored into the GeoPackage
+``_fiberq_metadata`` table on export (see ``ExportManager``) so it travels with
+the data file.
+
+Projects created before this marker existed read back as the baseline version
+``"0"``. The migration framework (WP1b) is responsible for detecting an old
+version on load, upgrading, and stamping the current one.
+
+The marker value comes from the single source of truth,
+``fiberq.models.schema.SCHEMA_VERSION``; it is tracked separately from the plugin
+version in ``metadata.txt``.
+"""
+from qgis.core import QgsProject
+
+from ..models.schema import SCHEMA_VERSION
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: QgsProject entry scope (current branding; matches other FiberQPlugin entries).
+SCHEMA_VERSION_SCOPE = "FiberQPlugin"
+#: QgsProject entry key for the schema version.
+SCHEMA_VERSION_KEY = "schema/schema_version"
+#: Version reported for projects that predate the marker.
+BASELINE_VERSION = "0"
+
+
+def _project(project=None):
+    return project if project is not None else QgsProject.instance()
+
+
+def read_project_schema_version(project=None) -> str:
+    """Return the project's stored schema version, or ``BASELINE_VERSION`` if absent."""
+    prj = _project(project)
+    try:
+        value, ok = prj.readEntry(SCHEMA_VERSION_SCOPE, SCHEMA_VERSION_KEY, "")
+        if ok and value:
+            return value
+    except Exception as e:
+        logger.debug(f"read_project_schema_version failed: {e}")
+    return BASELINE_VERSION
+
+
+def write_project_schema_version(version, project=None) -> bool:
+    """Write an explicit schema version into the project entry. Returns success."""
+    prj = _project(project)
+    try:
+        return bool(prj.writeEntry(SCHEMA_VERSION_SCOPE, SCHEMA_VERSION_KEY, str(version)))
+    except Exception as e:
+        logger.debug(f"write_project_schema_version failed: {e}")
+        return False
+
+
+def mark_project_current(project=None) -> bool:
+    """Stamp the project with the current ``SCHEMA_VERSION``. Returns success."""
+    return write_project_schema_version(SCHEMA_VERSION, project)
+
+
+def needs_upgrade(project=None) -> bool:
+    """True if the project's schema version differs from the current one."""
+    return read_project_schema_version(project) != SCHEMA_VERSION

--- a/fiberq/dialogs/base.py
+++ b/fiberq/dialogs/base.py
@@ -56,29 +56,9 @@ def default_fields_for(layer_name: str):
         List of tuples: (field_key, label, kind, default_value, options)
         kind: 'text' | 'int' | 'double' | 'enum' | 'year'
     """
-    base = [
-        ("naziv", "Name", "text", "", None),
-        ("proizvodjac", "Manufacturer", "text", "", None),
-        ("oznaka", "Label", "text", "", None),
-        ("kapacitet", "Capacity", "int", 0, None),
-        ("ukupno_kj", "Total", "int", 0, None),
-        ("zahtev_kapaciteta", "Capacity Requirement", "int", 0, None),
-        ("zahtev_rezerve", "Slack Requirement", "int", 0, None),
-        ("oznaka_izvoda", "Outlet Label", "text", "", None),
-        ("numeracija", "Numbering", "text", "", None),
-        ("naziv_objekta", "Object Name", "text", "", None),
-        ("adresa_ulica", "Address Street", "text", "", None),
-        ("adresa_broj", "Address Number", "text", "", None),
-        ("address_id", "Address ID", "text", "", None),
-        ("stanje", "Status", "enum", "Planned", ["Planned", "Built", "Existing"]),
-        ("godina_ugradnje", "Year of Installation", "year", 2025, None),
-    ]
-
-    ln = (layer_name or "").lower()
-    if "od ormar" in ln:
-        base = [(k, l, kind, (24 if k == "kapacitet" else d), opt)
-                for (k, l, kind, d, opt) in base]
-    return base
+    # Delegates to the canonical schema (single source of truth, WP1a).
+    from ..models.schema import get_default_fields_for_layer as _schema_fields
+    return _schema_fields(layer_name)
 
 
 def get_current_year():

--- a/fiberq/models/element_defs.py
+++ b/fiberq/models/element_defs.py
@@ -301,20 +301,9 @@ def get_default_fields_for_layer(layer_name: str) -> List[Tuple[str, str, str, A
     Returns:
         List of tuples: (key, label, field_type, default, options)
     """
-    fields = [
-        (f.key, f.label, f.field_type, f.default, f.options)
-        for f in DEFAULT_ELEMENT_FIELDS
-    ]
-
-    # Adjust default capacity for OD cabinets
-    layer_name_lower = (layer_name or "").lower()
-    if "od ormar" in layer_name_lower:
-        fields = [
-            (key, label, ftype, (24 if key == "kapacitet" else default), opts)
-            for (key, label, ftype, default, opts) in fields
-        ]
-
-    return fields
+    # Delegates to the canonical schema (single source of truth, WP1a).
+    from .schema import get_default_fields_for_layer as _schema_fields
+    return _schema_fields(layer_name)
 
 
 # =============================================================================

--- a/fiberq/models/schema.py
+++ b/fiberq/models/schema.py
@@ -1,0 +1,566 @@
+"""FiberQ canonical data-model schema — the single source of truth (WP1a).
+
+This is a **pure-data** module: no QGIS imports, no filesystem side effects. It
+describes every FiberQ layer type, its fields (name / type / units / domain /
+default), the legacy<->canonical layer-name map, the per-layer field aliases and
+value maps, and the project ``SCHEMA_VERSION`` marker.
+
+Important invariants (do not break without a migration):
+
+* **Field NAMES are the stored database schema** (legacy, mostly Serbian). The
+  English strings here are display-only *aliases* / labels. Renaming a stored
+  field is a data migration, not a cosmetic change.
+* ``fiberq_uuid`` is the per-feature **identity** field; it is present on every
+  layer (appended at layer creation by ``utils.uuid_utils``).
+* The plugin version (``metadata.txt``) and the project ``SCHEMA_VERSION`` are
+  tracked **separately** and bump independently.
+
+This module is authored to match what the plugin creates today; the existing
+modules (``element_defs``, ``field_aliases``, ``dialogs.base``, ``legacy_bridge``)
+delegate to it so there is one definition. The human-readable reference generated
+from this model lives in ``docs/schema.md``.
+
+Known as-built inconsistencies are preserved here verbatim (not "fixed") and are
+documented as deferred items for the interchange work — see ``docs/schema.md``.
+"""
+from dataclasses import dataclass, field as _dc_field
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Version marker
+# ---------------------------------------------------------------------------
+
+#: FiberQ project schema version. Decoupled from the plugin version in
+#: metadata.txt. Persisted into a project on save (see core/schema_version.py).
+#: Projects created before this marker existed read back as absent -> treated as
+#: the pre-marker baseline (schema version 0).
+SCHEMA_VERSION = "1.0"
+
+#: The per-feature identity field appended to every FiberQ layer.
+IDENTITY_FIELD = "fiberq_uuid"
+
+#: Accepted logical field types (stored representation in parentheses):
+#: text(String), int(Int), double(Double), enum(String), year(Int), bool(Bool).
+FIELD_TYPES = ("text", "int", "double", "enum", "year", "bool")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FieldDefinition:
+    """One attribute field of a FiberQ layer.
+
+    ``key`` is the stored field name (immutable schema). ``label`` is the
+    English label used by the placement dialogs. ``options`` lists the choices
+    for ``enum`` fields. ``value_map`` (when set) maps an English display value
+    to the value actually stored (QGIS ValueMap widget).
+    """
+    key: str
+    label: str
+    field_type: str  # one of FIELD_TYPES
+    default: Any = ""
+    options: Optional[List[str]] = None
+    units: str = ""
+    value_map: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class LayerSchema:
+    """A FiberQ layer type: its canonical name, geometry, CRS source and fields."""
+    canonical_name: str
+    geometry: str            # 'Point' | 'LineString' | 'Polygon'
+    crs_source: str          # 'canvas' (canvas destination CRS) | 'project'
+    fields: List[FieldDefinition]
+    legacy_names: List[str] = _dc_field(default_factory=list)
+    aliases: Dict[str, str] = _dc_field(default_factory=dict)  # field key -> attribute-table alias
+    identity_field: str = IDENTITY_FIELD
+    notes: str = ""
+
+
+def _uuid_field() -> FieldDefinition:
+    """The identity field, as it is appended on every layer."""
+    return FieldDefinition(IDENTITY_FIELD, "FiberQ UUID", "text", "")
+
+
+# ---------------------------------------------------------------------------
+# Value maps (English display label -> stored value). Verbatim as-built.
+# ---------------------------------------------------------------------------
+
+ROUTE_TYPE_VALUE_MAP: Dict[str, str] = {
+    "Aerial": "vazdusna",
+    "Underground": "podzemna",
+    "Through the object": "kroz objekat",
+}
+SLACK_LOCATION_VALUE_MAP: Dict[str, str] = {
+    "Manhole": "OKNO",
+    "Pole": "Stub",
+    "Object": "Objekat",
+}
+SLACK_SIDE_VALUE_MAP: Dict[str, str] = {
+    "FROM": "od",
+    "TO": "do",
+    "MID SPAN": "sredina",
+}
+CABLE_TYPE_VALUE_MAP: Dict[str, str] = {
+    "Optical": "opticki",
+    "Copper": "bakarnI",  # NOTE: as-built typo (capital I); preserved, see docs/schema.md
+}
+CABLE_SUBTYPE_VALUE_MAP: Dict[str, str] = {
+    "Backbone": "glavni",
+    "Distribution": "distributivni",
+    "Drop": "razvodni",
+}
+CABLE_STATUS_VALUE_MAP: Dict[str, str] = {
+    "Planned": "Projektovano",
+    "Existing": "Postojeće",
+    "Under construction": "U izgradnji",
+}
+CABLE_LAYING_VALUE_MAP: Dict[str, str] = {
+    "Underground": "Podzemno",
+    "Aerial": "Vazdusno",
+}
+
+
+# ---------------------------------------------------------------------------
+# Field-alias maps (stored field name -> attribute-table display alias).
+# Layer-scoped: the same key maps to different labels on different layers.
+# ---------------------------------------------------------------------------
+
+ELEMENT_FIELD_ALIASES: Dict[str, str] = {
+    "naziv": "Name",
+    "proizvodjac": "Manufacturer",
+    "oznaka": "Label",
+    "kapacitet": "Capacity",
+    "ukupno_kj": "Total SCs",
+    "zahtev_kapaciteta": "Required capacity",
+    "zahtev_rezerve": "Reserve capacity",
+    "oznaka_izvoda": "Port label",
+    "numeracija": "Numbering",
+    "naziv_objekta": "Site name",
+    "adresa_ulica": "Street",
+    "adresa_broj": "Street No.",
+    "address_id": "Address ID",
+    "stanje": "Status",
+    "godina_ugradnje": "Install year",
+    "fiberq_uuid": "FiberQ UUID",
+}
+POLES_FIELD_ALIASES: Dict[str, str] = {
+    "tip": "Type",
+    "podtip": "Subtype",
+    "visina": "Height (m)",
+    "materijal": "Material",
+    "fiberq_uuid": "FiberQ UUID",
+}
+ROUTE_FIELD_ALIASES: Dict[str, str] = {
+    "naziv": "Route name",
+    "duzina": "Length (m)",
+    "duzina_km": "Length (km)",
+    "tip_trase": "Route type",
+    "fiberq_uuid": "FiberQ UUID",
+}
+CABLE_FIELD_ALIASES: Dict[str, str] = {
+    "tip": "Cable type",
+    "podtip": "Segment type",
+    "color_code": "Color code",
+    "broj_cevcica": "Number of ducts",
+    "broj_vlakana": "Number of fibers",
+    "tip_kabla": "Cable model",
+    "vrsta_vlakana": "Fiber type",
+    "vrsta_omotaca": "Sheath type",
+    "vrsta_armature": "Armour type",
+    "talasno_podrucje": "Wavelength band",
+    "naziv": "Name",
+    "slabljenje_dbkm": "Attenuation [dB/km]",
+    "hrom_disp_ps_nmxkm": "Chromatic dispersion [ps/nm/km]",
+    "stanje_kabla": "Status",
+    "cable_laying": "Installation type",
+    "vrsta_mreze": "Network type",
+    "godina_ugradnje": "Installation year",
+    "konstr_vlakna_u_cevcicama": "Fibers in ducts",
+    "konstr_sa_uzlepljenim_elementom": "With bonded element",
+    "konstr_punjeni_kabl": "Gel-filled cable",
+    "konstr_sa_arm_vlaknima": "Aramid yarn armouring",
+    "konstr_bez_metalnih": "Non-metallic",
+    "od": "From",
+    "do": "To",
+    "duzina_m": "Length [m]",
+    "slack_m": "Slack [m]",
+    "total_len_m": "Total length [m]",
+    "fiberq_uuid": "FiberQ UUID",
+    "fibers_per_tube": "Fibers per tube",
+    "total_fibers": "Total fibers",
+    "color_standard": "Color standard",
+}
+MANHOLE_FIELD_ALIASES: Dict[str, str] = {
+    "broj_okna": "Manhole ID",
+    "tip_okna": "Manhole type",
+    "vrsta_okna": "Construction type",
+    "polozaj_okna": "Position",
+    "adresa": "Address",
+    "stanje": "Status",
+    "god_ugrad": "Installation year",
+    "opis": "Description",
+    "dimenzije": "Dimensions (cm)",
+    "mat_zida": "Wall material",
+    "mat_poklop": "Cover material",
+    "odvodnj": "Drainage",
+    "poklop_tes": "Heavy cover",
+    "poklop_lak": "Light cover",
+    "br_nosaca": "Number of steps",
+    "debl_zida": "Wall thickness (cm)",
+    "lestve": "Ladder",
+    "fiberq_uuid": "FiberQ UUID",
+}
+SLACK_FIELD_ALIASES: Dict[str, str] = {
+    "tip": "Type",
+    "duzina_m": "Length (m)",
+    "lokacija": "Location",
+    "cable_layer_id": "Cable layer ID",
+    "cable_fid": "Cable feature ID",
+    "strana": "Side",
+    "napomena": "Note",
+    "fiberq_uuid": "FiberQ UUID",
+}
+PIPE_FIELD_ALIASES: Dict[str, str] = {
+    "materijal": "Material",
+    "kapacitet": "Capacity",
+    "fi": "Diameter (mm)",
+    "od": "From",
+    "do": "To",
+    "duzina_m": "Length (m)",
+    "fiberq_uuid": "FiberQ UUID",
+}
+JOINT_CLOSURE_FIELD_ALIASES: Dict[str, str] = {
+    "naziv": "Name",
+    "fiberq_uuid": "FiberQ UUID",
+}
+FIBER_BREAK_FIELD_ALIASES: Dict[str, str] = {
+    "naziv": "Name",
+    "cable_layer_id": "Cable layer ID",
+    "cable_fid": "Cable feature ID",
+    "distance_m": "Distance (m)",
+    "segments_hit": "Segments hit",
+    "vreme": "Time",
+    "fiberq_uuid": "FiberQ UUID",
+}
+OBJECTS_FIELD_ALIASES: Dict[str, str] = {
+    "tip": "Type",
+    "spratova": "Floors above ground",
+    "podzemnih": "Floors below ground",
+    "ulica": "Street",
+    "broj": "Number",
+    "naziv": "Name",
+    "napomena": "Note",
+    "fiberq_uuid": "FiberQ UUID",
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared element roster (the 15-field point-element schema).
+# fiberq_uuid is NOT part of the roster; it is appended separately at creation.
+# This is the single definition; element_defs / dialogs.base / legacy_bridge /
+# layer_manager delegate to get_default_fields_for_layer().
+# ---------------------------------------------------------------------------
+
+SHARED_ELEMENT_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("naziv", "Name", "text", ""),
+    FieldDefinition("proizvodjac", "Manufacturer", "text", ""),
+    FieldDefinition("oznaka", "Label", "text", ""),
+    FieldDefinition("kapacitet", "Capacity", "int", 0, units="ports"),
+    FieldDefinition("ukupno_kj", "Total", "int", 0),
+    FieldDefinition("zahtev_kapaciteta", "Capacity Requirement", "int", 0),
+    FieldDefinition("zahtev_rezerve", "Slack Requirement", "int", 0),
+    FieldDefinition("oznaka_izvoda", "Outlet Label", "text", ""),
+    FieldDefinition("numeracija", "Numbering", "text", ""),
+    FieldDefinition("naziv_objekta", "Object Name", "text", ""),
+    FieldDefinition("adresa_ulica", "Address Street", "text", ""),
+    FieldDefinition("adresa_broj", "Address Number", "text", ""),
+    FieldDefinition("address_id", "Address ID", "text", ""),
+    FieldDefinition("stanje", "Status", "enum", "Planned", options=["Planned", "Built", "Existing"]),
+    FieldDefinition("godina_ugradnje", "Year of Installation", "year", 2025, units="year"),
+]
+
+#: Element layer names that share SHARED_ELEMENT_FIELDS (one QGIS layer each).
+ELEMENT_LAYER_NAMES: List[str] = [
+    "ODF", "TB", "Patch panel", "OTB", "Indoor OTB", "Outdoor OTB", "Pole OTB",
+    "TO", "Indoor TO", "Outdoor TO", "Pole TO", "Joint Closure TO",
+]
+
+#: Default capacity for OD cabinet ("od ormar") element layers.
+OD_CABINET_CAPACITY_DEFAULT = 24
+
+
+def get_default_fields_for_layer(
+    layer_name: str,
+) -> List[Tuple[str, str, str, Any, Optional[List[str]]]]:
+    """Return the element default fields as ``(key, label, field_type, default, options)`` tuples.
+
+    Mirrors the historical ``element_defs.get_default_fields_for_layer`` contract
+    exactly (5-tuples, no ``fiberq_uuid`` — that is appended separately). The only
+    per-layer variation is the OD-cabinet capacity default.
+    """
+    fields = [
+        (f.key, f.label, f.field_type, f.default, f.options)
+        for f in SHARED_ELEMENT_FIELDS
+    ]
+    if "od ormar" in (layer_name or "").lower():
+        fields = [
+            (key, label, ftype, (OD_CABINET_CAPACITY_DEFAULT if key == "kapacitet" else default), opts)
+            for (key, label, ftype, default, opts) in fields
+        ]
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Non-element layer field rosters
+# ---------------------------------------------------------------------------
+
+POLES_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("tip", "Type", "text", ""),
+    FieldDefinition("podtip", "Subtype", "text", ""),
+    FieldDefinition("visina", "Height", "double", 0.0, units="m"),
+    FieldDefinition("materijal", "Material", "text", ""),
+    _uuid_field(),
+]
+
+MANHOLE_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("broj_okna", "Manhole ID", "text", ""),
+    FieldDefinition("tip_okna", "Manhole type", "text", ""),
+    FieldDefinition("vrsta_okna", "Construction type", "text", ""),
+    FieldDefinition("polozaj_okna", "Position", "text", ""),
+    FieldDefinition("adresa", "Address", "text", ""),
+    FieldDefinition("stanje", "Status", "text", ""),  # free text on manholes (no enum)
+    FieldDefinition("god_ugrad", "Installation year", "int", 0),
+    FieldDefinition("opis", "Description", "text", ""),
+    FieldDefinition("dimenzije", "Dimensions", "text", "", units="cm"),
+    FieldDefinition("mat_zida", "Wall material", "text", ""),
+    FieldDefinition("mat_poklop", "Cover material", "text", ""),
+    FieldDefinition("odvodnj", "Drainage", "text", ""),
+    FieldDefinition("poklop_tes", "Heavy cover", "bool", False),
+    FieldDefinition("poklop_lak", "Light cover", "bool", False),
+    FieldDefinition("br_nosaca", "Number of steps", "int", 0),
+    FieldDefinition("debl_zida", "Wall thickness", "double", 0.0, units="cm"),
+    FieldDefinition("lestve", "Ladder", "text", ""),
+    _uuid_field(),
+]
+
+ROUTE_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("naziv", "Route name", "text", ""),
+    FieldDefinition("duzina", "Length", "double", 0.0, units="m"),
+    FieldDefinition("duzina_km", "Length", "double", 0.0, units="km"),
+    FieldDefinition("tip_trase", "Route type", "text", "", value_map=ROUTE_TYPE_VALUE_MAP),
+    _uuid_field(),
+]
+
+SLACK_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("tip", "Type", "text", ""),
+    FieldDefinition("duzina_m", "Length", "double", 0.0, units="m"),
+    FieldDefinition("lokacija", "Location", "text", "", value_map=SLACK_LOCATION_VALUE_MAP),
+    FieldDefinition("cable_layer_id", "Cable layer ID", "text", ""),
+    FieldDefinition("cable_fid", "Cable feature ID", "int", 0),
+    FieldDefinition("strana", "Side", "text", "", value_map=SLACK_SIDE_VALUE_MAP),
+    FieldDefinition("napomena", "Note", "text", ""),
+    _uuid_field(),
+]
+
+PIPE_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("materijal", "Material", "text", ""),
+    FieldDefinition("kapacitet", "Capacity", "text", ""),  # text on pipes (int on elements) - as-built
+    FieldDefinition("fi", "Diameter", "int", 0, units="mm"),
+    FieldDefinition("od", "From", "text", ""),
+    FieldDefinition("do", "To", "text", ""),
+    FieldDefinition("duzina_m", "Length", "double", 0.0, units="m"),
+    _uuid_field(),
+]
+
+SERVICE_AREA_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("name", "Name", "text", ""),
+    FieldDefinition("created_at", "Created at", "text", ""),
+    FieldDefinition("area_m2", "Area", "double", 0.0, units="m²"),
+    FieldDefinition("perim_m", "Perimeter", "double", 0.0, units="m"),
+    FieldDefinition("count", "Count", "int", 0),
+    _uuid_field(),
+]
+
+OBJECTS_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("tip", "Type", "text", ""),
+    FieldDefinition("spratova", "Floors above ground", "int", 0),
+    FieldDefinition("podzemnih", "Floors below ground", "int", 0),
+    FieldDefinition("ulica", "Street", "text", ""),
+    FieldDefinition("broj", "Number", "text", ""),
+    FieldDefinition("naziv", "Name", "text", ""),
+    FieldDefinition("napomena", "Note", "text", ""),
+    _uuid_field(),
+]
+
+# Underground and Aerial cables share this roster (created identically).
+# NOTE: branch_index (int) is added on demand when a cable is branched; it is not
+# part of the freshly-created roster and is intentionally omitted here.
+CABLE_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("tip", "Cable type", "text", "", value_map=CABLE_TYPE_VALUE_MAP),
+    FieldDefinition("podtip", "Segment type", "text", "", value_map=CABLE_SUBTYPE_VALUE_MAP),
+    FieldDefinition("color_code", "Color code", "text", ""),
+    FieldDefinition("broj_cevcica", "Number of ducts", "int", 0),
+    FieldDefinition("broj_vlakana", "Number of fibers", "int", 0),
+    FieldDefinition("tip_kabla", "Cable model", "text", ""),
+    FieldDefinition("vrsta_vlakana", "Fiber type", "text", ""),
+    FieldDefinition("vrsta_omotaca", "Sheath type", "text", ""),
+    FieldDefinition("vrsta_armature", "Armour type", "text", ""),
+    FieldDefinition("talasno_podrucje", "Wavelength band", "text", ""),
+    FieldDefinition("naziv", "Name", "text", ""),
+    FieldDefinition("slabljenje_dbkm", "Attenuation", "double", 0.0, units="dB/km"),
+    FieldDefinition("hrom_disp_ps_nmxkm", "Chromatic dispersion", "double", 0.0, units="ps/nm/km"),
+    FieldDefinition("stanje_kabla", "Status", "text", "", value_map=CABLE_STATUS_VALUE_MAP),
+    FieldDefinition("cable_laying", "Installation type", "text", "", value_map=CABLE_LAYING_VALUE_MAP),
+    FieldDefinition("vrsta_mreze", "Network type", "text", ""),
+    FieldDefinition("godina_ugradnje", "Installation year", "int", 0, units="year"),
+    FieldDefinition("konstr_vlakna_u_cevcicama", "Fibers in ducts", "int", 0),
+    FieldDefinition("konstr_sa_uzlepljenim_elementom", "With bonded element", "int", 0),
+    FieldDefinition("konstr_punjeni_kabl", "Gel-filled cable", "int", 0),
+    FieldDefinition("konstr_sa_arm_vlaknima", "Aramid yarn armouring", "int", 0),
+    FieldDefinition("konstr_bez_metalnih", "Non-metallic", "int", 0),
+    FieldDefinition("od", "From", "text", ""),
+    FieldDefinition("do", "To", "text", ""),
+    FieldDefinition("duzina_m", "Length", "double", 0.0, units="m"),
+    FieldDefinition("slack_m", "Slack", "double", 0.0, units="m"),
+    FieldDefinition("total_len_m", "Total length", "double", 0.0, units="m"),
+    FieldDefinition("fibers_per_tube", "Fibers per tube", "int", 0),
+    FieldDefinition("total_fibers", "Total fibers", "int", 0),
+    FieldDefinition("color_standard", "Color standard", "text", ""),
+    _uuid_field(),
+]
+
+FIBER_BREAK_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("naziv", "Name", "text", ""),
+    FieldDefinition("cable_layer_id", "Cable layer ID", "text", ""),
+    FieldDefinition("cable_fid", "Cable feature ID", "int", 0),
+    FieldDefinition("distance_m", "Distance", "double", 0.0, units="m"),
+    FieldDefinition("segments_hit", "Segments hit", "int", 0),
+    FieldDefinition("vreme", "Time", "text", ""),
+    _uuid_field(),
+]
+
+JOINT_CLOSURE_FIELDS: List[FieldDefinition] = [
+    FieldDefinition("naziv", "Name", "text", ""),
+    _uuid_field(),
+]
+
+
+def _element_fields() -> List[FieldDefinition]:
+    """Element layer fields = the shared roster plus the identity field."""
+    return list(SHARED_ELEMENT_FIELDS) + [_uuid_field()]
+
+
+# ---------------------------------------------------------------------------
+# Canonical layer catalogue
+# ---------------------------------------------------------------------------
+
+#: Legacy / accepted alternate names per canonical layer name. Used to recognise
+#: older projects (Serbian names, plural/singular drift) as the same layer type.
+LAYER_NAME_ALIASES: Dict[str, List[str]] = {
+    "Poles": ["Stubovi"],
+    "Manholes": ["OKNA"],
+    "Patch panel": ["Patch Panel"],
+    "Joint Closures": ["Nastavci"],
+    "Optical slack": ["Optical slacks", "Opticke_rezerve"],
+    "Fiber break": ["Prekid vlakna"],
+    "Route": ["Trasa"],
+    "Aerial cables": ["Kablovi_vazdusni"],
+    "Underground cables": ["Kablovi_podzemni"],
+    "PE pipes": ["PE cevi"],
+    "Transition pipes": ["Prelazne cevi"],
+    "Objects": ["Objekti"],
+    "Service Area": ["Service area", "Rejon"],
+}
+
+
+def _build_layer_schemas() -> Dict[str, LayerSchema]:
+    schemas: Dict[str, LayerSchema] = {}
+    # 12 point-element layers sharing the roster
+    for name in ELEMENT_LAYER_NAMES:
+        schemas[name] = LayerSchema(
+            canonical_name=name, geometry="Point", crs_source="canvas",
+            fields=_element_fields(), aliases=ELEMENT_FIELD_ALIASES,
+        )
+    schemas["Joint Closures"] = LayerSchema(
+        "Joint Closures", "Point", "canvas", JOINT_CLOSURE_FIELDS,
+        legacy_names=["Nastavci"], aliases=JOINT_CLOSURE_FIELD_ALIASES,
+    )
+    schemas["Poles"] = LayerSchema(
+        "Poles", "Point", "canvas", POLES_FIELDS,
+        legacy_names=["Stubovi"], aliases=POLES_FIELD_ALIASES,
+    )
+    schemas["Manholes"] = LayerSchema(
+        "Manholes", "Point", "canvas", MANHOLE_FIELDS,
+        legacy_names=["OKNA"], aliases=MANHOLE_FIELD_ALIASES,
+    )
+    schemas["Route"] = LayerSchema(
+        "Route", "LineString", "canvas", ROUTE_FIELDS,
+        legacy_names=["Trasa"], aliases=ROUTE_FIELD_ALIASES,
+    )
+    schemas["Optical slack"] = LayerSchema(
+        "Optical slack", "Point", "canvas", SLACK_FIELDS,
+        legacy_names=["Optical slacks", "Opticke_rezerve"], aliases=SLACK_FIELD_ALIASES,
+    )
+    schemas["PE pipes"] = LayerSchema(
+        "PE pipes", "LineString", "canvas", PIPE_FIELDS,
+        legacy_names=["PE cevi"], aliases=PIPE_FIELD_ALIASES,
+    )
+    schemas["Transition pipes"] = LayerSchema(
+        "Transition pipes", "LineString", "canvas", PIPE_FIELDS,
+        legacy_names=["Prelazne cevi"], aliases=PIPE_FIELD_ALIASES,
+    )
+    schemas["Service Area"] = LayerSchema(
+        "Service Area", "Polygon", "project", SERVICE_AREA_FIELDS,
+        legacy_names=["Service area", "Rejon"],
+    )
+    schemas["Objects"] = LayerSchema(
+        "Objects", "Polygon", "project", OBJECTS_FIELDS,
+        legacy_names=["Objekti"], aliases=OBJECTS_FIELD_ALIASES,
+    )
+    schemas["Aerial cables"] = LayerSchema(
+        "Aerial cables", "LineString", "canvas", CABLE_FIELDS,
+        legacy_names=["Kablovi_vazdusni"], aliases=CABLE_FIELD_ALIASES,
+    )
+    schemas["Underground cables"] = LayerSchema(
+        "Underground cables", "LineString", "canvas", CABLE_FIELDS,
+        legacy_names=["Kablovi_podzemni"], aliases=CABLE_FIELD_ALIASES,
+    )
+    schemas["Fiber break"] = LayerSchema(
+        "Fiber break", "Point", "canvas", FIBER_BREAK_FIELDS,
+        legacy_names=["Prekid vlakna"], aliases=FIBER_BREAK_FIELD_ALIASES,
+    )
+    return schemas
+
+
+#: The canonical catalogue of every FiberQ layer type, keyed by canonical name.
+LAYER_SCHEMAS: Dict[str, LayerSchema] = _build_layer_schemas()
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+def canonical_layer_name(name: str) -> Optional[str]:
+    """Return the canonical layer name for ``name`` (canonical or legacy), or None."""
+    if not name:
+        return None
+    if name in LAYER_SCHEMAS:
+        return name
+    for canonical, legacy in LAYER_NAME_ALIASES.items():
+        if name in legacy:
+            return canonical
+    return None
+
+
+def get_layer_schema(name: str) -> Optional[LayerSchema]:
+    """Return the LayerSchema for a canonical or legacy layer name, or None."""
+    canonical = canonical_layer_name(name)
+    return LAYER_SCHEMAS.get(canonical) if canonical else None
+
+
+def is_element_layer(name: str) -> bool:
+    """True if ``name`` is one of the shared-roster point-element layers."""
+    return name in ELEMENT_LAYER_NAMES

--- a/fiberq/utils/legacy_bridge.py
+++ b/fiberq/utils/legacy_bridge.py
@@ -140,27 +140,9 @@ def _default_fields_for(layer_name: str):
     """Return a list of (key, label, kind, default, options) for the dialog.
     kind: 'text' | 'int' | 'double' | 'enum' | 'year'
     """
-    base = [
-        ("naziv", "Name", "text", "", None),
-        ("proizvodjac", "Manufacturer", "text", "", None),
-        ("oznaka", "Label", "text", "", None),
-        ("kapacitet", "Capacity", "int", 0, None),
-        ("ukupno_kj", "Total", "int", 0, None),
-        ("zahtev_kapaciteta", "Capacity Requirement", "int", 0, None),
-        ("zahtev_rezerve", "Slack Requirement", "int", 0, None),
-        ("oznaka_izvoda", "Outlet Label", "text", "", None),
-        ("numeracija", "Numbering", "text", "", None),
-        ("naziv_objekta", "Object Name", "text", "", None),
-        ("adresa_ulica", "Address Street", "text", "", None),
-        ("adresa_broj", "Address Number", "text", "", None),
-        ("address_id", "Address ID", "text", "", None),
-        ("stanje", "Status", "enum", "Planned", ["Planned", "Built", "Existing"]),
-        ("godina_ugradnje", "Year of Installation", "year", 2025, None),
-    ]
-    ln = (layer_name or "").lower()
-    if "od ormar" in ln:
-        base = [(k, l, kind, (24 if k == "kapacitet" else d), opt) for (k, l, kind, d, opt) in base]
-    return base
+    # Delegates to the canonical schema (single source of truth, WP1a).
+    from ..models.schema import get_default_fields_for_layer as _schema_fields
+    return _schema_fields(layer_name)
 
 
 def _apply_element_aliases(layer):

--- a/fiberq/utils/uuid_utils.py
+++ b/fiberq/utils/uuid_utils.py
@@ -27,7 +27,10 @@ FIBERQ_UUID_FIELD = "fiberq_uuid"
 
 def _log(msg):
     """Log to both FiberQ logger and QGIS Message Log panel."""
-    _log(msg)
+    try:
+        logger.debug(msg)
+    except Exception:
+        pass
     try:
         QgsMessageLog.logMessage(msg, "FiberQ UUID", Qgis.MessageLevel.Info)
     except Exception:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,139 @@
+"""Unit tests for the canonical schema model (WP1a).
+
+These are pure-Python tests — they exercise ``fiberq.models.schema`` (no QGIS
+needed). They lock the as-built data model so any accidental drift is caught,
+and they guard the contract that the de-dup delegations rely on.
+"""
+import importlib.util
+import os
+
+# Load schema.py standalone (it has no intra-package imports), so these tests run
+# without QGIS bindings / the package __init__ chain.
+_SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fiberq", "models", "schema.py",
+)
+_spec = importlib.util.spec_from_file_location("fiberq_schema_under_test", _SCHEMA_PATH)
+schema = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(schema)
+
+
+# Golden copy of the element roster: (key, label, field_type, default, options).
+# If this drifts, it is a deliberate schema change — update intentionally.
+EXPECTED_ELEMENT_ROSTER = [
+    ("naziv", "Name", "text", "", None),
+    ("proizvodjac", "Manufacturer", "text", "", None),
+    ("oznaka", "Label", "text", "", None),
+    ("kapacitet", "Capacity", "int", 0, None),
+    ("ukupno_kj", "Total", "int", 0, None),
+    ("zahtev_kapaciteta", "Capacity Requirement", "int", 0, None),
+    ("zahtev_rezerve", "Slack Requirement", "int", 0, None),
+    ("oznaka_izvoda", "Outlet Label", "text", "", None),
+    ("numeracija", "Numbering", "text", "", None),
+    ("naziv_objekta", "Object Name", "text", "", None),
+    ("adresa_ulica", "Address Street", "text", "", None),
+    ("adresa_broj", "Address Number", "text", "", None),
+    ("address_id", "Address ID", "text", "", None),
+    ("stanje", "Status", "enum", "Planned", ["Planned", "Built", "Existing"]),
+    ("godina_ugradnje", "Year of Installation", "year", 2025, None),
+]
+
+
+def test_schema_version_is_nonempty_string():
+    assert isinstance(schema.SCHEMA_VERSION, str)
+    assert schema.SCHEMA_VERSION
+    # MAJOR.MINOR style, decoupled from the plugin version
+    assert schema.SCHEMA_VERSION[0].isdigit()
+
+
+def test_all_field_types_are_valid():
+    for name, ls in schema.LAYER_SCHEMAS.items():
+        for f in ls.fields:
+            assert f.field_type in schema.FIELD_TYPES, f"{name}.{f.key}={f.field_type}"
+
+
+def test_every_layer_has_identity_field_last():
+    for name, ls in schema.LAYER_SCHEMAS.items():
+        keys = [f.key for f in ls.fields]
+        assert schema.IDENTITY_FIELD in keys, f"{name} missing {schema.IDENTITY_FIELD}"
+        assert keys[-1] == schema.IDENTITY_FIELD, f"{name}: identity field not last"
+        assert ls.identity_field == schema.IDENTITY_FIELD
+
+
+def test_no_duplicate_field_keys_per_layer():
+    for name, ls in schema.LAYER_SCHEMAS.items():
+        keys = [f.key for f in ls.fields]
+        assert len(keys) == len(set(keys)), f"{name} has duplicate field keys"
+
+
+def test_shared_element_roster_is_15_without_uuid():
+    assert len(schema.SHARED_ELEMENT_FIELDS) == 15
+    keys = [f.key for f in schema.SHARED_ELEMENT_FIELDS]
+    assert schema.IDENTITY_FIELD not in keys
+
+
+def test_get_default_fields_shape_and_content():
+    fields = schema.get_default_fields_for_layer("ODF")
+    assert len(fields) == 15
+    for tup in fields:
+        assert len(tup) == 5  # (key, label, field_type, default, options)
+    assert fields == EXPECTED_ELEMENT_ROSTER
+
+
+def test_od_cabinet_capacity_override():
+    normal = dict((k, d) for (k, _, _, d, _) in schema.get_default_fields_for_layer("ODF"))
+    cabinet = dict((k, d) for (k, _, _, d, _) in schema.get_default_fields_for_layer("OD ormar 1"))
+    assert normal["kapacitet"] == 0
+    assert cabinet["kapacitet"] == schema.OD_CABINET_CAPACITY_DEFAULT == 24
+    # only kapacitet differs
+    assert {k: v for k, v in cabinet.items() if k != "kapacitet"} == \
+        {k: v for k, v in normal.items() if k != "kapacitet"}
+
+
+def test_element_layers_use_roster_plus_uuid():
+    expected = [k for (k, *_rest) in EXPECTED_ELEMENT_ROSTER] + [schema.IDENTITY_FIELD]
+    for name in schema.ELEMENT_LAYER_NAMES:
+        ls = schema.LAYER_SCHEMAS[name]
+        assert [f.key for f in ls.fields] == expected, name
+
+
+def test_cables_share_identical_roster():
+    aerial = [f.key for f in schema.LAYER_SCHEMAS["Aerial cables"].fields]
+    under = [f.key for f in schema.LAYER_SCHEMAS["Underground cables"].fields]
+    assert aerial == under
+    assert "fibers_per_tube" in aerial and "color_standard" in aerial
+
+
+def test_joint_closures_minimal():
+    keys = [f.key for f in schema.LAYER_SCHEMAS["Joint Closures"].fields]
+    assert keys == ["naziv", "fiberq_uuid"]
+
+
+def test_aliases_reference_existing_fields():
+    for name, ls in schema.LAYER_SCHEMAS.items():
+        field_keys = {f.key for f in ls.fields}
+        for alias_key in ls.aliases:
+            assert alias_key in field_keys, f"{name}: alias for unknown field {alias_key}"
+
+
+def test_legacy_names_resolve_to_canonical():
+    assert schema.canonical_layer_name("Stubovi") == "Poles"
+    assert schema.canonical_layer_name("OKNA") == "Manholes"
+    assert schema.canonical_layer_name("Trasa") == "Route"
+    assert schema.canonical_layer_name("Kablovi_podzemni") == "Underground cables"
+    assert schema.canonical_layer_name("Rejon") == "Service Area"
+    assert schema.canonical_layer_name("Optical slacks") == "Optical slack"
+    assert schema.canonical_layer_name("ODF") == "ODF"  # canonical passes through
+    assert schema.canonical_layer_name("does-not-exist") is None
+
+
+def test_get_layer_schema_via_legacy_name():
+    ls = schema.get_layer_schema("Trasa")
+    assert ls is not None and ls.canonical_name == "Route"
+
+
+def test_value_maps_present_where_expected():
+    cable = {f.key: f for f in schema.LAYER_SCHEMAS["Underground cables"].fields}
+    assert cable["tip"].value_map == {"Optical": "opticki", "Copper": "bakarnI"}
+    route = {f.key: f for f in schema.LAYER_SCHEMAS["Route"].fields}
+    assert route["tip_trase"].value_map["Aerial"] == "vazdusna"

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -1,0 +1,62 @@
+"""Parity tests for the WP1a de-dup.
+
+The legacy roster functions now delegate to the canonical schema, and the
+remaining legacy data copies (element_defs roster, field_aliases maps) are
+asserted equal to the schema. These lock the single-source-of-truth so any
+future drift fails CI. Require QGIS (pytest-qgis) because the modules under test
+import qgis.
+"""
+from fiberq.models import schema
+
+
+def test_roster_functions_delegate_to_schema(qgis_app):
+    from fiberq.models.element_defs import get_default_fields_for_layer as ed
+    from fiberq.dialogs.base import default_fields_for as db
+    from fiberq.utils.legacy_bridge import _default_fields_for as lb
+    from fiberq.core.layer_manager import _default_fields_for as lm
+    for name in ("ODF", "OD ormar 1", "TO", "Patch panel"):
+        expected = schema.get_default_fields_for_layer(name)
+        assert ed(name) == expected, name
+        assert db(name) == expected, name
+        assert lb(name) == expected, name
+        assert lm(name) == expected, name
+
+
+def test_element_defs_roster_data_matches_schema(qgis_app):
+    from fiberq.models import element_defs
+    legacy = [(f.key, f.label, f.field_type, f.default, f.options)
+              for f in element_defs.DEFAULT_ELEMENT_FIELDS]
+    canonical = [(f.key, f.label, f.field_type, f.default, f.options)
+                 for f in schema.SHARED_ELEMENT_FIELDS]
+    assert legacy == canonical
+
+
+def test_field_alias_maps_match_schema(qgis_app):
+    from fiberq.utils import field_aliases as fa
+    for name, canonical in [
+        ("ELEMENT_FIELD_ALIASES", schema.ELEMENT_FIELD_ALIASES),
+        ("POLES_FIELD_ALIASES", schema.POLES_FIELD_ALIASES),
+        ("ROUTE_FIELD_ALIASES", schema.ROUTE_FIELD_ALIASES),
+        ("CABLE_FIELD_ALIASES", schema.CABLE_FIELD_ALIASES),
+        ("MANHOLE_FIELD_ALIASES", schema.MANHOLE_FIELD_ALIASES),
+        ("SLACK_FIELD_ALIASES", schema.SLACK_FIELD_ALIASES),
+        ("PIPE_FIELD_ALIASES", schema.PIPE_FIELD_ALIASES),
+        ("JOINT_CLOSURE_FIELD_ALIASES", schema.JOINT_CLOSURE_FIELD_ALIASES),
+        ("FIBER_BREAK_FIELD_ALIASES", schema.FIBER_BREAK_FIELD_ALIASES),
+        ("OBJECTS_FIELD_ALIASES", schema.OBJECTS_FIELD_ALIASES),
+    ]:
+        assert getattr(fa, name) == canonical, name
+
+
+def test_value_maps_match_schema(qgis_app):
+    from fiberq.utils import field_aliases as fa
+    for name, canonical in [
+        ("ROUTE_TYPE_VALUE_MAP", schema.ROUTE_TYPE_VALUE_MAP),
+        ("SLACK_LOCATION_VALUE_MAP", schema.SLACK_LOCATION_VALUE_MAP),
+        ("SLACK_SIDE_VALUE_MAP", schema.SLACK_SIDE_VALUE_MAP),
+        ("CABLE_TYPE_VALUE_MAP", schema.CABLE_TYPE_VALUE_MAP),
+        ("CABLE_SUBTYPE_VALUE_MAP", schema.CABLE_SUBTYPE_VALUE_MAP),
+        ("CABLE_STATUS_VALUE_MAP", schema.CABLE_STATUS_VALUE_MAP),
+        ("CABLE_LAYING_VALUE_MAP", schema.CABLE_LAYING_VALUE_MAP),
+    ]:
+        assert getattr(fa, name) == canonical, name

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -1,0 +1,34 @@
+"""Tests for the project schema-version marker (WP1a).
+
+These need a QgsApplication (provided by pytest-qgis) because they read/write a
+QgsProject entry. They use fresh QgsProject() instances so the singleton project
+is never touched.
+"""
+from qgis.core import QgsProject
+
+from fiberq.core import schema_version as sv
+
+
+def test_absent_reads_baseline(qgis_app):
+    p = QgsProject()
+    assert sv.read_project_schema_version(p) == sv.BASELINE_VERSION
+
+
+def test_mark_then_read_current(qgis_app):
+    p = QgsProject()
+    assert sv.mark_project_current(p) is True
+    assert sv.read_project_schema_version(p) == sv.SCHEMA_VERSION
+
+
+def test_needs_upgrade_transitions(qgis_app):
+    p = QgsProject()
+    assert sv.needs_upgrade(p) is True   # absent -> baseline != current
+    sv.mark_project_current(p)
+    assert sv.needs_upgrade(p) is False
+
+
+def test_explicit_version_roundtrip(qgis_app):
+    p = QgsProject()
+    assert sv.write_project_schema_version("0.9", p) is True
+    assert sv.read_project_schema_version(p) == "0.9"
+    assert sv.needs_upgrade(p) is True   # 0.9 != current


### PR DESCRIPTION
## What this is
Groundwork for schema migrations and the open interchange format: one canonical,
declarative data-model definition plus a durable project schema-version marker.
**No behaviour change and no version bump** — the plugin stays v1.2.3. Pure-additive,
plus one safe de-dup refactor and one bug fix.

## Changes
- **`fiberq/models/schema.py`** — single source of truth for every layer type (fields,
  types, units, value domains, defaults), field-alias and value maps, the legacy↔canonical
  layer-name map, the `fiberq_uuid` identity field, and `SCHEMA_VERSION = "1.0"` (tracked
  separately from the plugin version). Pure data — no QGIS imports.
- **`fiberq/core/schema_version.py`** — read/write the schema version as a durable
  `QgsProject` entry (survives save/reopen), mirrored into the GeoPackage `_fiberq_metadata`
  table on export and restored on import; replaces a stale hardcoded `"1.3.0"`. Projects
  with no marker read back as baseline `"0"`.
- **De-dup** — the element-field roster existed verbatim in four places; the three inline
  copies now delegate to `schema`, and the remaining data copies are parity-locked by tests
  so the source of truth can't silently drift.
- **Bug fix** — `utils/uuid_utils._log()` recursed into itself (RecursionError on any
  UUID/migration log path); it now delegates to the module logger.
- **`docs/schema.md`** — human-readable schema reference.

## Tests
`test_schema.py` (golden + structural, pure-Python), `test_schema_version.py` (marker
read/write), `test_schema_parity.py` (de-dup locks). Full gate green: lint 0/0, 25 tests
pass on `qgis/qgis:3.44-trixie` (Qt5) and `4.0-trixie` (Qt6).

## Not in this PR
- The migration runner that upgrades older projects (reads this marker, migrates, stamps) — next (WP1b).
- Reconciliation of a few documented as-built inconsistencies (status vocabulary, cable type
  direction, colour palettes) — deferred to the interchange work.