### PR TITLE
WP1b — versioned schema migration runner + uuid identity invariant

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig — https://editorconfig.org
+# Stops the repo from ever picking up Windows CRLF again by telling the editor
+# to write LF (and UTF-8) regardless of the host OS. Works with VS Code,
+# PyCharm, and most editors (VS Code needs the EditorConfig extension).
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,28 @@
-# Keep line endings deterministic across Windows/Linux. The Makefile's recipe
-# lines break when `make` runs with CRLF inside the Linux QGIS containers, so
-# force LF for build/shell files regardless of the checkout platform.
+# Keep line endings deterministic across Windows/Linux.
+#
+# All text files are normalized to LF in the repository AND checked out as LF on
+# every platform (eol=lf), so a Windows editor can no longer introduce CRLF
+# churn: whatever a checkout looks like, `git add` stores LF. Binary types are
+# listed explicitly so git never applies text/eol conversion to them.
+
+# Default: treat everything as text, store LF, check out LF everywhere.
+* text=auto eol=lf
+
+# Build/shell files must stay LF — Makefile recipe lines and POSIX scripts break
+# when `make` runs with CRLF inside the Linux QGIS containers. Redundant with the
+# rule above, kept explicit for clarity.
 Makefile text eol=lf
 *.sh text eol=lf
+
+# Binary assets — never apply line-ending or text conversion. (None are tracked
+# today; listed defensively so future icons/translations/fixtures stay intact.)
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.qm   binary
+*.qgz  binary
+*.gpkg binary
+*.zip  binary
+*.pdf  binary

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -40,7 +40,37 @@ The project schema version is the string **`SCHEMA_VERSION`** in
   **mirrored into the GeoPackage** `_fiberq_metadata` table on a full project
   export, so the version travels with the data file;
 - **absent in pre-1.0 projects** — those are treated as the pre-marker baseline
-  (version `0`) and are upgraded by the migration framework (see WP1b).
+  (version `0`) and are upgraded by the migration framework.
+
+### Migrations (on load)
+
+When a project is opened, FiberQ runs `fiberq/core/migrations.py:run_migrations`:
+
+1. It reads the stored version. A **malformed / foreign** marker (anything that
+   is not a dotted run of integers, e.g. `v2.0`) is left untouched — never
+   coerced, so a genuinely newer project can't be silently downgraded.
+2. If the project is **older**, it runs the ordered chain of migration steps in
+   the half-open range `(stored, current]`. The only step today, `uuid-identity`
+   (baseline `0` → `1.0`), adds and backfills the `fiberq_uuid` field.
+3. The current version is stamped **only if every step succeeded**. If a step
+   cannot persist (a locked or read-only GeoPackage), the marker is left
+   unchanged so the next load retries — the marker never claims a migration that
+   didn't reach disk.
+4. A project stamped **newer** than the running plugin is left untouched (never
+   downgraded).
+
+Each step is **idempotent**: re-running on an up-to-date project does nothing.
+Because a project entry only becomes durable when the project is saved (or
+exported to GeoPackage, which also stamps the marker), an on-load upgrade that
+isn't saved simply re-runs — harmlessly — next time.
+
+### The `fiberq_uuid` identity invariant
+
+`fiberq_uuid` must exist and be populated on **every** FiberQ feature. Adding it
+is the `0 → 1.0` migration, but keeping it filled is a standing invariant, not a
+one-time step: an idempotent backfill runs on **every** load regardless of the
+marker, so features introduced later (imports, external edits, interchange
+round-trips) are healed too.
 
 ## Layer types
 

--- a/fiberq/core/layer_manager.py
+++ b/fiberq/core/layer_manager.py
@@ -33,7 +33,7 @@ from ..utils.logger import get_logger
 logger = get_logger(__name__)
 
 # Phase 0.1: UUID support for FiberQ Designer
-from ..utils.uuid_utils import FIBERQ_UUID_FIELD, ensure_uuid_field  # noqa: E402
+from ..utils.uuid_utils import FIBERQ_UUID_FIELD, ensure_uuid_field, set_feature_uuid  # noqa: E402
 
 
 # =============================================================================
@@ -552,6 +552,13 @@ def _create_region_from_selection(core, name: str, buf_m: float):
             f['area_m2'] = float(area)
             f['perim_m'] = float(peri)
             f['count'] = len(geoms)
+            # WP1b identity invariant: stamp a uuid on each part before adding it,
+            # matching the manual-draw path (the from-selection path previously
+            # persisted Service Area features with a NULL fiberq_uuid).
+            try:
+                set_feature_uuid(f)
+            except Exception as e:
+                logger.debug(f"Error in _create_region_from_selection: {e}")
             region.addFeature(f)
             added += 1
         region.commitChanges()

--- a/fiberq/core/migrations.py
+++ b/fiberq/core/migrations.py
@@ -199,6 +199,17 @@ def run_migrations(project=None) -> MigrationReport:
     stored = read_project_schema_version(project)
     report = MigrationReport(from_version=stored, to_version=SCHEMA_VERSION)
 
+    if stored == BASELINE_VERSION:
+        # An unmarked project with no FiberQ content is not a FiberQ project:
+        # leave it completely alone (no stamp, no dirty flag, no "Upgraded"
+        # message). Without this, the blank startup project -- or any unrelated
+        # project the user opens -- would get our marker written into it and a
+        # phantom upgrade toast. A project that already carries a marker, or that
+        # actually contains FiberQ layers, still migrates below.
+        from ..utils.uuid_utils import project_has_fiberq_layers
+        if not project_has_fiberq_layers(project):
+            return report
+
     if not _is_valid_version(stored):
         # A foreign / decorated marker we can't order -- refuse to touch it rather
         # than coerce it and risk downgrading a genuinely newer project.

--- a/fiberq/core/migrations.py
+++ b/fiberq/core/migrations.py
@@ -1,0 +1,250 @@
+"""FiberQ schema migration runner (WP1b).
+
+Upgrades a project's data and its schema-version marker from an older schema to
+the current :data:`fiberq.models.schema.SCHEMA_VERSION`, then stamps the marker.
+
+Design
+------
+* The marker is read/written via :mod:`fiberq.core.schema_version` (WP1a). A
+  project with no marker reads back as the baseline version ``"0"``.
+* Migrations are an ordered chain of :class:`Migration` steps. Each declares the
+  schema version it brings a project *up to* and an idempotent ``apply`` callable.
+* :func:`run_migrations` reads the stored version, runs every step whose target
+  is ``> stored`` and ``<= SCHEMA_VERSION`` in ascending order, and -- only if all
+  steps succeed -- stamps the project with the current version. Re-running on an
+  already-current project is a no-op.
+* Version strings (``"0"``, ``"1.0"``, future ``"1.1"``/``"2.0"``) are compared
+  with an ordered numeric parse. WP1a's :func:`schema_version.needs_upgrade` is
+  only an equality check, so the *ordering* lives here. A project stamped *newer*
+  than the plugin understands is left untouched (never downgraded).
+
+Persistence note: the marker is a ``QgsProject`` entry, so an on-load stamp only
+becomes durable once the user saves the project (or exports to GeoPackage, which
+also stamps it). Until then a re-open simply re-runs the idempotent migration.
+"""
+import functools
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+from ..models.schema import SCHEMA_VERSION
+from ..utils.logger import get_logger
+from .schema_version import (
+    BASELINE_VERSION,
+    mark_project_current,
+    read_project_schema_version,
+)
+
+logger = get_logger(__name__)
+
+#: A well-formed schema version is a dotted run of integers ("0", "1.0", "1.10").
+#: Anything else (a foreign / decorated / hand-edited marker like "v2.0" or
+#: "1.0-rc1") is treated as UNKNOWN rather than silently coerced -- coercion
+#: would neutralise the newer-than-plugin downgrade guard.
+_VERSION_RE = re.compile(r"^\d+(\.\d+)*$")
+
+
+# ---------------------------------------------------------------------------
+# Ordered version comparison (WP1a only offers equality via needs_upgrade)
+# ---------------------------------------------------------------------------
+
+def _is_valid_version(version) -> bool:
+    """True if ``version`` is a dotted run of integers we can order/compare."""
+    return bool(_VERSION_RE.match(str(version).strip()))
+
+
+def _version_key(version) -> tuple:
+    """Parse a dotted version string into a tuple of ints for ordered compare.
+
+    Non-numeric or empty parts collapse to ``0`` so ``"0"`` -> ``(0,)`` and
+    ``"1.0"`` -> ``(1, 0)``. Callers pad to equal length before comparing, so
+    ``"1"`` and ``"1.0"`` compare equal. Only call on values that pass
+    :func:`_is_valid_version`; malformed input is handled up front in
+    :func:`run_migrations`.
+    """
+    parts = []
+    for chunk in str(version).split("."):
+        try:
+            parts.append(int(chunk))
+        except (TypeError, ValueError):
+            parts.append(0)
+    return tuple(parts) or (0,)
+
+
+def _padded(a, b):
+    ka, kb = _version_key(a), _version_key(b)
+    n = max(len(ka), len(kb))
+    return ka + (0,) * (n - len(ka)), kb + (0,) * (n - len(kb))
+
+
+def _version_lt(a, b) -> bool:
+    """True if version ``a`` is strictly older than version ``b``."""
+    ka, kb = _padded(a, b)
+    return ka < kb
+
+
+def _version_eq(a, b) -> bool:
+    """True if versions ``a`` and ``b`` are equal (``"1"`` == ``"1.0"``)."""
+    ka, kb = _padded(a, b)
+    return ka == kb
+
+
+#: Sort key aligned to _version_lt/_version_eq (padding-consistent, not raw
+#: tuple length), so the chain orders identically to how versions compare.
+_by_version = functools.cmp_to_key(
+    lambda a, b: -1 if _version_lt(a, b) else (1 if _version_lt(b, a) else 0)
+)
+
+
+# ---------------------------------------------------------------------------
+# Migration steps
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Migration:
+    """One ordered, idempotent upgrade step.
+
+    ``to_version`` is the schema version a project is at *after* this step runs.
+    ``apply(project)`` performs the (idempotent) upgrade and returns a small
+    detail dict for reporting, e.g. ``{layer_name: uuids_assigned}``.
+    """
+    to_version: str
+    name: str
+    description: str
+    apply: Callable[..., dict]
+
+
+def _apply_uuid_identity(project=None) -> dict:
+    """0 -> 1.0: ensure the ``fiberq_uuid`` identity field exists and is filled.
+
+    Delegates to the existing, idempotent UUID migrator. Pre-1.0 projects have no
+    ``fiberq_uuid`` column; this adds it and assigns a UUID to every feature.
+    Running again once every feature has one is a no-op (returns ``{}``).
+    """
+    from ..utils.uuid_utils import migrate_project_uuids
+    return migrate_project_uuids(project)
+
+
+#: The ordered migration chain. Append new steps as the schema evolves; keep each
+#: one idempotent so a partially-migrated project can be re-run safely.
+MIGRATIONS: List[Migration] = [
+    Migration(
+        to_version="1.0",
+        name="uuid-identity",
+        description="Add and backfill the fiberq_uuid identity field on all FiberQ layers.",
+        apply=_apply_uuid_identity,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MigrationReport:
+    """Outcome of a :func:`run_migrations` call. Falsy when nothing ran."""
+    from_version: str = BASELINE_VERSION
+    to_version: str = SCHEMA_VERSION
+    ran: bool = False
+    steps: List[str] = field(default_factory=list)
+    details: Dict[str, dict] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.ran
+
+    def _assigned(self) -> int:
+        return sum(
+            sum(d.values()) for d in self.details.values() if isinstance(d, dict)
+        )
+
+    def summary(self) -> str:
+        """Human-readable one-liner for the message bar / logs."""
+        if self.errors and not self.ran:
+            return (f"Schema migration skipped ({self.from_version} -> "
+                    f"{self.to_version}): {'; '.join(self.errors)}")
+        msg = f"Upgraded project schema {self.from_version} -> {self.to_version}"
+        assigned = self._assigned()
+        if assigned:
+            layers = sorted({
+                name
+                for d in self.details.values() if isinstance(d, dict)
+                for name in d
+            })
+            msg += f" (assigned {assigned} UUIDs across {len(layers)} layers)"
+        if self.errors:
+            msg += f" with warnings: {'; '.join(self.errors)}"
+        return msg
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run_migrations(project=None) -> MigrationReport:
+    """Upgrade ``project`` to the current schema version and stamp the marker.
+
+    Reads the stored schema version; runs every migration step whose target is
+    newer than the stored version (and no newer than the plugin's current
+    version), in ascending order; then -- only if all steps succeed -- stamps the
+    project with the current version. A project already at the current version, or
+    stamped *newer* than the plugin understands, is left untouched.
+
+    ``project`` defaults to the current ``QgsProject`` instance. Returns a
+    :class:`MigrationReport` (falsy if nothing ran). Never raises: a failing step
+    is captured in ``report.errors`` and the current version is not stamped, so a
+    later run retries.
+    """
+    stored = read_project_schema_version(project)
+    report = MigrationReport(from_version=stored, to_version=SCHEMA_VERSION)
+
+    if not _is_valid_version(stored):
+        # A foreign / decorated marker we can't order -- refuse to touch it rather
+        # than coerce it and risk downgrading a genuinely newer project.
+        report.errors.append(
+            f"unrecognised stored schema version {stored!r}; not migrating"
+        )
+        logger.warning(report.errors[-1])
+        return report
+
+    if _version_eq(stored, SCHEMA_VERSION):
+        # Already current. Converge an equal-but-non-identical marker ("1" ->
+        # "1.0") to the canonical string so schema_version.needs_upgrade() (a raw
+        # string compare) agrees with us. No data work, so ran stays False.
+        if str(stored) != str(SCHEMA_VERSION):
+            mark_project_current(project)
+        return report
+
+    if _version_lt(SCHEMA_VERSION, stored):
+        # Project was stamped by a newer plugin build; never downgrade it.
+        report.errors.append(
+            f"project schema {stored} is newer than plugin schema {SCHEMA_VERSION}"
+        )
+        logger.warning(report.errors[-1])
+        return report
+
+    for step in sorted(MIGRATIONS, key=lambda s: _by_version(s.to_version)):
+        # Only steps in the half-open range (stored, current].
+        if not _version_lt(stored, step.to_version):
+            continue
+        if _version_lt(SCHEMA_VERSION, step.to_version):
+            continue
+        try:
+            detail = step.apply(project) or {}
+            report.details[step.name] = detail if isinstance(detail, dict) else {}
+            report.steps.append(step.name)
+        except Exception as e:
+            # Capture, log, and stop the chain; the stamp is withheld below.
+            report.errors.append(f"{step.name}: {e}")
+            logger.warning(f"Schema migration step '{step.name}' failed: {e}")
+            break
+
+    if report.errors:
+        # A step failed to complete: do NOT stamp current, so the next load
+        # retries the migration rather than leaving the marker lying.
+        return report
+
+    mark_project_current(project)
+    report.ran = True
+    return report

--- a/fiberq/core/pipe_manager.py
+++ b/fiberq/core/pipe_manager.py
@@ -254,6 +254,13 @@ class PipeManager:
         ])
         layer.updateFields()
 
+        # WP1b identity invariant: ensure the fiberq_uuid column exists.
+        try:
+            from ..utils.uuid_utils import ensure_uuid_field
+            ensure_uuid_field(layer)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on pipe layer: {e}")
+
         try:
             layer.setMapTipTemplate(
                 "<b>[% \"materijal\" %] [% \"kapacitet\" %]</b><br/>Ø [% \"fi\" %] mm"

--- a/fiberq/core/route_manager.py
+++ b/fiberq/core/route_manager.py
@@ -190,6 +190,16 @@ class RouteManager:
             route_layer.updateFields()
         route_layer.commitChanges()
 
+        # WP1b identity invariant: ensure the fiberq_uuid column exists on the
+        # Route layer (both freshly created and found-existing layers reach here
+        # via _ensure_route_layer), so the set_feature_uuid() calls at feature
+        # creation actually stamp a value instead of silently no-opping.
+        try:
+            from ..utils.uuid_utils import ensure_uuid_field
+            ensure_uuid_field(route_layer)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on route layer: {e}")
+
     def _ask_route_type(self, title: str = "Route type",
                         label: str = "Select route type:") -> Optional[str]:
         """Show dialog to select route type. Returns type code or None if cancelled."""

--- a/fiberq/core/slack_manager.py
+++ b/fiberq/core/slack_manager.py
@@ -121,6 +121,12 @@ class SlackManager:
             QgsField("napomena", QVariant.String),
         ])
         vl.updateFields()
+        # WP1b identity invariant: ensure the fiberq_uuid column exists.
+        try:
+            from ..utils.uuid_utils import ensure_uuid_field
+            ensure_uuid_field(vl)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on slack layer: {e}")
         self.apply_slack_field_aliases(vl)
         self.set_slack_layer_alias(vl)
         QgsProject.instance().addMapLayer(vl)

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -1565,17 +1565,29 @@ class FiberQPlugin:
             logger.debug(f"Error creating Quick Toolbar: {e}")
             self.quick_toolbar = None
 
-        # Phase 0.1: UUID migration for FiberQ Designer compatibility
-        # Run after a short delay to ensure all layers are loaded,
-        # AND connect to projectRead so it runs on every project open
+        # WP1b: run the versioned schema-migration runner on project load.
+        # Deferred (~1s) so all layersAdded handlers (alias / name
+        # canonicalisation) finish first. The slot is stored on self so unload()
+        # can disconnect the *same* callable -- the previous code connected an
+        # inline lambda but disconnected a bound method, so it never disconnected.
+        # The one-shot at init covers a project already open when the plugin loads.
         try:
             from qgis.PyQt.QtCore import QTimer
-            QTimer.singleShot(2000, self._migrate_uuids)
-            QgsProject.instance().readProject.connect(
-                lambda *args: QTimer.singleShot(1000, self._migrate_uuids)
+            # Idempotent re-init: drop any slot from a previous initGui that ran
+            # without a clean unload, so we never accumulate connections.
+            prev_slot = getattr(self, "_schema_migration_slot", None)
+            if prev_slot is not None:
+                try:
+                    QgsProject.instance().readProject.disconnect(prev_slot)
+                except Exception:
+                    pass
+            self._schema_migration_slot = (
+                lambda *args: QTimer.singleShot(1000, self._run_schema_migrations)
             )
+            QgsProject.instance().readProject.connect(self._schema_migration_slot)
+            QTimer.singleShot(2000, self._run_schema_migrations)
         except Exception as e:
-            logger.debug(f"Error scheduling UUID migration: {e}")
+            logger.debug(f"Error scheduling schema migration: {e}")
 
     def _color_catalogs_key(self):
         """Get color catalogs storage key."""
@@ -1933,10 +1945,51 @@ class FiberQPlugin:
         except Exception as e:
             logger.debug(f"Error in UUID migration: {e}")
 
-    def unload(self):
-        # Phase 0.1: Disconnect UUID migration signal
+    def _run_schema_migrations(self):
+        """Run the versioned schema-migration runner (WP1b) on the current project.
+
+        Two responsibilities on every project load:
+        1. The version-gated migration runner: reads the stored schema marker,
+           upgrades an older project to the current version, and stamps the
+           marker (only on success -- a failed step is retried on the next load).
+        2. The fiberq_uuid identity invariant: an idempotent backfill that runs
+           regardless of the marker, because imports / external edits can add
+           NULL-uuid features to an already-migrated project. This keeps the old
+           always-on healing behaviour that the version gate would otherwise drop.
+        """
+        prj = QgsProject.instance()
+        steps_done = []
         try:
-            QgsProject.instance().readProject.disconnect(self._migrate_uuids)
+            from .core.migrations import run_migrations
+            report = run_migrations(prj)
+            steps_done = report.steps
+            if report.ran:
+                self.iface.messageBar().pushInfo("FiberQ", report.summary())
+                logger.debug(f"Schema migration: {report}")
+            elif report.errors:
+                logger.debug(f"Schema migration not applied: {report.summary()}")
+        except Exception as e:
+            logger.debug(f"Error running schema migrations: {e}")
+
+        # Standing identity invariant -- heal any features still lacking a UUID.
+        # Skipped when the migration above already ran the uuid step this load.
+        try:
+            from .utils.uuid_utils import migrate_project_uuids
+            if "uuid-identity" not in steps_done:
+                healed = migrate_project_uuids(prj)
+                if healed:
+                    total = sum(healed.values())
+                    logger.debug(f"UUID invariant backfilled {total} features: {healed}")
+        except Exception as e:
+            logger.debug(f"Error in UUID invariant backfill: {e}")
+
+    def unload(self):
+        # WP1b: disconnect the schema-migration slot -- the same callable we
+        # connected, so the disconnect actually succeeds.
+        try:
+            slot = getattr(self, "_schema_migration_slot", None)
+            if slot is not None:
+                QgsProject.instance().readProject.disconnect(slot)
         except Exception:
             pass  # May not be connected or already disconnected
 

--- a/fiberq/tools/element_tool.py
+++ b/fiberq/tools/element_tool.py
@@ -287,6 +287,16 @@ class PlaceElementTool(QgsMapToolEmitPoint):
         if 'prekid' in self.target_layer_name.lower():
             self._apply_prekid_style(elem_layer)
 
+        # WP1b identity invariant: ensure the fiberq_uuid column exists on the
+        # element layer (covers both the newly created and found-existing
+        # branches above) before building the feature, so set_feature_uuid()
+        # below actually stamps it instead of silently no-opping.
+        try:
+            from ..utils.uuid_utils import ensure_uuid_field
+            ensure_uuid_field(elem_layer)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on element layer: {e}")
+
         # Write point
         feat = QgsFeature(elem_layer.fields())
         feat.setGeometry(QgsGeometry.fromPointXY(final_point))

--- a/fiberq/tools/route_tool.py
+++ b/fiberq/tools/route_tool.py
@@ -242,6 +242,14 @@ class ManualRouteTool(QgsMapTool):
         route_layer.updateFields()
         route_layer.commitChanges()
 
+        # WP1b identity invariant: ensure the fiberq_uuid column exists before
+        # features are added, so set_feature_uuid() below actually stamps it.
+        try:
+            from ..utils.uuid_utils import ensure_uuid_field
+            ensure_uuid_field(route_layer)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on route layer: {e}")
+
         # Apply style
         if self.plugin:
             self.plugin.stylize_route_layer(route_layer)

--- a/fiberq/utils/legacy_bridge.py
+++ b/fiberq/utils/legacy_bridge.py
@@ -293,6 +293,11 @@ def _ensure_region_layer(core):
                             lyr.setName('Service Area')
                         except Exception as e:
                             logger.debug(f"Error in _ensure_region_layer: {e}")
+                    try:
+                        from .uuid_utils import ensure_uuid_field
+                        ensure_uuid_field(lyr)
+                    except Exception as e:
+                        logger.debug(f"Error ensuring fiberq_uuid on Service Area layer: {e}")
                     return lyr
             except Exception:
                 continue
@@ -309,6 +314,14 @@ def _ensure_region_layer(core):
             QgsField('count', QVariant.Int),
         ])
         region.updateFields()
+
+        # WP1b identity invariant: ensure the fiberq_uuid column exists on the
+        # freshly created Service Area layer.
+        try:
+            from .uuid_utils import ensure_uuid_field
+            ensure_uuid_field(region)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on Service Area layer: {e}")
 
         # Simple semi-transparent style
         try:
@@ -348,6 +361,11 @@ def _ensure_objects_layer(core):
                 ):
                     _apply_objects_field_aliases(lyr)
                     _set_objects_layer_alias(lyr)
+                    try:
+                        from .uuid_utils import ensure_uuid_field
+                        ensure_uuid_field(lyr)
+                    except Exception as e:
+                        logger.debug(f"Error ensuring fiberq_uuid on Objects layer: {e}")
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in _ensure_objects_layer: {e}")
@@ -366,6 +384,14 @@ def _ensure_objects_layer(core):
             QgsField("napomena", QVariant.String),
         ])
         layer.updateFields()
+
+        # WP1b identity invariant: ensure the fiberq_uuid column exists on the
+        # freshly created Objects layer.
+        try:
+            from .uuid_utils import ensure_uuid_field
+            ensure_uuid_field(layer)
+        except Exception as e:
+            logger.debug(f"Error ensuring fiberq_uuid on Objects layer: {e}")
 
         prj.addMapLayer(layer)
         _stylize_objects_layer(layer)

--- a/fiberq/utils/uuid_utils.py
+++ b/fiberq/utils/uuid_utils.py
@@ -24,6 +24,70 @@ logger = get_logger(__name__)
 # Field name constant — used everywhere
 FIBERQ_UUID_FIELD = "fiberq_uuid"
 
+# FiberQ layer recognition — the single source of truth shared by the uuid
+# backfill (which layers to touch) and the WP1b migration runner's
+# "is this a FiberQ project?" guard (project_has_fiberq_layers). Names cover the
+# English and Serbian-legacy variants; the field signatures also catch renamed or
+# custom layers that carry characteristic FiberQ fields.
+FIBERQ_LAYER_NAMES = frozenset({
+    # Point layers
+    "Poles", "Stubovi",
+    "Manholes", "OKNA",
+    "ODF", "TB", "Patch panel", "Patch Panel",
+    "OTB", "Indoor OTB", "Outdoor OTB", "Pole OTB",
+    "TO", "Indoor TO", "Outdoor TO", "Pole TO", "Joint Closure TO",
+    "Joint Closures", "Nastavci",
+    "Optical slacks", "Opticke_rezerve", "Optical slack",
+    "Fiber break", "Prekid vlakna",
+    # Line layers
+    "Route", "Trasa",
+    "Aerial cables", "Kablovi_vazdusni",
+    "Underground cables", "Kablovi_podzemni",
+    "PE pipes", "PE cevi",
+    "Transition pipes", "Prelazne cevi",
+    # Polygon layers
+    "Objects", "Objekti",
+    "Service Area", "Service area", "Rejon",
+})
+
+FIBERQ_FIELD_SIGNATURES = frozenset({
+    "naziv", "broj_okna", "tip_trase", "tip_kabla",
+    "cable_layer_id", "broj_cevcica", "kapacitet",
+    "fibers_per_tube", "total_fibers", "color_standard",
+})
+
+
+def layer_is_fiberq(layer) -> bool:
+    """True if ``layer`` is a FiberQ-managed vector layer.
+
+    Recognised by its (English or Serbian-legacy) name or by carrying
+    characteristic FiberQ fields -- the same test the uuid backfill uses to
+    decide which layers to touch. Non-vector layers are never FiberQ.
+    """
+    if not isinstance(layer, QgsVectorLayer):
+        return False
+    try:
+        if layer.name() in FIBERQ_LAYER_NAMES:
+            return True
+        field_names = {f.name() for f in layer.fields()}
+        return bool(field_names & FIBERQ_FIELD_SIGNATURES)
+    except Exception:
+        return False
+
+
+def project_has_fiberq_layers(project=None) -> bool:
+    """True if ``project`` contains at least one FiberQ-managed layer.
+
+    The WP1b migration runner uses this to avoid stamping / announcing on a blank
+    or non-FiberQ project: an unmarked project with no FiberQ layers is left
+    completely untouched (no marker written, no dirty flag, no message).
+    """
+    project = project if project is not None else QgsProject.instance()
+    try:
+        return any(layer_is_fiberq(lyr) for lyr in project.mapLayers().values())
+    except Exception:
+        return False
+
 
 def _log(msg):
     """Log to both FiberQ logger and QGIS Message Log panel."""
@@ -267,36 +331,6 @@ def migrate_project_uuids(project=None):
     field_added_layers = []
     failed_layers = []
 
-    # FiberQ layer names (English and Serbian legacy, all known variants)
-    fiberq_layer_names = {
-        # Point layers
-        "Poles", "Stubovi",
-        "Manholes", "OKNA",
-        "ODF", "TB", "Patch panel", "Patch Panel",
-        "OTB", "Indoor OTB", "Outdoor OTB", "Pole OTB",
-        "TO", "Indoor TO", "Outdoor TO", "Pole TO", "Joint Closure TO",
-        "Joint Closures", "Nastavci",
-        "Optical slacks", "Opticke_rezerve", "Optical slack",
-        "Fiber break", "Prekid vlakna",
-        # Line layers
-        "Route", "Trasa",
-        "Aerial cables", "Kablovi_vazdusni",
-        "Underground cables", "Kablovi_podzemni",
-        "PE pipes", "PE cevi",
-        "Transition pipes", "Prelazne cevi",
-        # Polygon layers
-        "Objects", "Objekti",
-        "Service Area", "Service area", "Rejon",
-    }
-
-    # Also detect FiberQ layers by checking for known FiberQ field names
-    # This catches layers that were renamed or custom layers with FiberQ fields
-    fiberq_field_signatures = {
-        "naziv", "broj_okna", "tip_trase", "tip_kabla",
-        "cable_layer_id", "broj_cevcica", "kapacitet",
-        "fibers_per_tube", "total_fibers", "color_standard",
-    }
-
     all_vector_layers = []
     for layer in project.mapLayers().values():
         try:
@@ -307,13 +341,9 @@ def migrate_project_uuids(project=None):
             field_names = {f.name() for f in layer.fields()}
             all_vector_layers.append(layer_name)
 
-            # Match by name OR by having FiberQ-characteristic fields
-            is_fiberq = (
-                layer_name in fiberq_layer_names
-                or bool(field_names & fiberq_field_signatures)  # noqa: W503
-            )
-
-            if not is_fiberq:
+            # Match by name OR by FiberQ-characteristic fields -- shared
+            # recognition, see layer_is_fiberq / FIBERQ_LAYER_NAMES above.
+            if not layer_is_fiberq(layer):
                 _log(f"UUID migration: SKIPPING '{layer_name}' (not recognized as FiberQ layer)")
                 continue
 
@@ -364,6 +394,10 @@ def migrate_project_uuids(project=None):
 
 __all__ = [
     'FIBERQ_UUID_FIELD',
+    'FIBERQ_LAYER_NAMES',
+    'FIBERQ_FIELD_SIGNATURES',
+    'layer_is_fiberq',
+    'project_has_fiberq_layers',
     'generate_uuid',
     'set_feature_uuid',
     'ensure_uuid_field',

--- a/fiberq/utils/uuid_utils.py
+++ b/fiberq/utils/uuid_utils.py
@@ -66,6 +66,17 @@ def set_feature_uuid(feature, force_new=False):
         _log(f"Error in set_feature_uuid: {e}")
 
 
+class UuidMigrationError(RuntimeError):
+    """A FiberQ layer's fiberq_uuid field could not be added or persisted.
+
+    Raised by :func:`migrate_project_uuids` (and :func:`migrate_layer_uuids`) so
+    the WP1b migration runner can withhold the schema-version stamp and retry on
+    the next project load, instead of marking a project migrated while some layer
+    never actually received its identity field on disk (a routine GPKG lock /
+    read-only / no-ALTER condition).
+    """
+
+
 def ensure_uuid_field(layer):
     """
     Ensure a layer has the fiberq_uuid field. Add it if missing.
@@ -170,20 +181,25 @@ def migrate_layer_uuids(layer):
 
     Returns:
         int: Number of features that were assigned new UUIDs
+
+    Raises:
+        UuidMigrationError: if the backfill could not be committed to the layer
+            (e.g. a locked / read-only GeoPackage). The caller must treat this as
+            a failed layer so the migration is retried rather than stamped done.
     """
     if not isinstance(layer, QgsVectorLayer):
         return 0
 
+    field_names = [f.name() for f in layer.fields()]
+    if FIBERQ_UUID_FIELD not in field_names:
+        return 0
+
+    field_idx = layer.fields().indexFromName(FIBERQ_UUID_FIELD)
+    if field_idx < 0:
+        return 0
+
+    # Scan for features missing a UUID. A scan error is non-fatal (return 0).
     try:
-        field_names = [f.name() for f in layer.fields()]
-        if FIBERQ_UUID_FIELD not in field_names:
-            return 0
-
-        field_idx = layer.fields().indexFromName(FIBERQ_UUID_FIELD)
-        if field_idx < 0:
-            return 0
-
-        # Find features missing UUID
         count = 0
         features_to_update = {}
         for feat in layer.getFeatures():
@@ -191,48 +207,65 @@ def migrate_layer_uuids(layer):
             if val is None or (hasattr(val, 'isNull') and val.isNull()) or str(val).strip() == '':
                 features_to_update[feat.id()] = generate_uuid()
                 count += 1
+    except Exception as e:
+        _log(f"Error scanning UUIDs in '{layer.name()}': {e}")
+        return 0
 
-        if count == 0:
-            return 0
+    if count == 0:
+        return 0
 
-        # Batch update
-        was_editing = layer.isEditable()
+    # Apply + persist. A failure here MUST propagate (not be swallowed): otherwise
+    # the runner would stamp the project migrated while the UUIDs never reached
+    # disk, and the marker gate would stop it ever retrying.
+    was_editing = layer.isEditable()
+    try:
         if not was_editing:
             layer.startEditing()
-
         for fid, new_uuid in features_to_update.items():
             layer.changeAttributeValue(fid, field_idx, new_uuid)
-
         if not was_editing:
-            layer.commitChanges()
-
-        _log(f"Migrated {count} features with UUID in layer '{layer.name()}'")
-        return count
+            if not layer.commitChanges():
+                errors = layer.commitErrors()
+                layer.rollBack()
+                raise UuidMigrationError(
+                    f"commit failed for '{layer.name()}': {errors}"
+                )
+    except UuidMigrationError:
+        raise
     except Exception as e:
-        _log(f"Error migrating UUIDs in '{layer.name()}': {e}")
+        _log(f"Error persisting UUIDs in '{layer.name()}': {e}")
         try:
             if layer.isEditable():
                 layer.rollBack()
         except Exception:
             pass
-        return 0
+        raise UuidMigrationError(f"error persisting UUIDs in '{layer.name()}': {e}")
+
+    _log(f"Migrated {count} features with UUID in layer '{layer.name()}'")
+    return count
 
 
-def migrate_project_uuids():
+def migrate_project_uuids(project=None):
     """
-    Run UUID migration on all FiberQ-managed layers in the current project.
+    Run UUID migration on all FiberQ-managed layers in a project.
 
     This should be called once on project load. It:
     1. Identifies all vector layers that are FiberQ-managed
     2. Adds fiberq_uuid field if missing
     3. Backfills UUIDs for features that don't have one
 
+    Args:
+        project: the QgsProject to migrate; defaults to the current instance.
+                 Explicit projects let the WP1b migration runner (and tests)
+                 target a project other than the singleton.
+
     Returns:
         dict: {layer_name: count_migrated} for layers that were updated
     """
-    project = QgsProject.instance()
+    project = project if project is not None else QgsProject.instance()
     results = {}
     field_added_layers = []
+    failed_layers = []
 
     # FiberQ layer names (English and Serbian legacy, all known variants)
     fiberq_layer_names = {
@@ -295,13 +328,18 @@ def migrate_project_uuids():
                     _log(f"UUID migration: added field to '{layer_name}'")
                 else:
                     _log(f"UUID migration: FAILED to add field to '{layer_name}'")
+                    failed_layers.append(layer_name)
                     continue
 
-            # Backfill missing UUIDs
+            # Backfill missing UUIDs (raises UuidMigrationError if it can't persist)
             count = migrate_layer_uuids(layer)
             if count > 0:
                 results[layer_name] = count
         except Exception as e:
+            try:
+                failed_layers.append(layer.name())
+            except Exception:
+                failed_layers.append("<unknown>")
             _log(f"Error migrating layer: {e}")
 
     if field_added_layers:
@@ -312,6 +350,14 @@ def migrate_project_uuids():
     if results:
         total = sum(results.values())
         _log(f"UUID migration complete: {total} features across {len(results)} layers")
+
+    if failed_layers:
+        # Surface partial failure so the migration runner does NOT stamp the
+        # project as migrated (it would otherwise never retry these layers).
+        raise UuidMigrationError(
+            "could not add/persist fiberq_uuid on %d layer(s): %s"
+            % (len(failed_layers), ", ".join(failed_layers))
+        )
 
     return results
 

--- a/fiberq/utils/uuid_utils.py
+++ b/fiberq/utils/uuid_utils.py
@@ -23,6 +23,10 @@ logger = get_logger(__name__)
 
 # Field name constant — used everywhere
 FIBERQ_UUID_FIELD = "fiberq_uuid"
+# Canonical display alias for the identity field. Applied consistently on every
+# FiberQ layer via ensure_uuid_field so the attribute table never shows the raw
+# column name on some layers and the alias on others.
+FIBERQ_UUID_ALIAS = "FiberQ UUID"
 
 # FiberQ layer recognition — the single source of truth shared by the uuid
 # backfill (which layers to touch) and the WP1b migration runner's
@@ -141,6 +145,20 @@ class UuidMigrationError(RuntimeError):
     """
 
 
+def _set_uuid_alias(layer):
+    """Apply the canonical 'FiberQ UUID' display alias to the identity column.
+
+    Only writes when the alias actually differs, so re-running on an already
+    aliased layer does not needlessly mark the project modified.
+    """
+    try:
+        idx = layer.fields().indexOf(FIBERQ_UUID_FIELD)
+        if idx >= 0 and layer.attributeAlias(idx) != FIBERQ_UUID_ALIAS:
+            layer.setFieldAlias(idx, FIBERQ_UUID_ALIAS)
+    except Exception:
+        pass
+
+
 def ensure_uuid_field(layer):
     """
     Ensure a layer has the fiberq_uuid field. Add it if missing.
@@ -160,6 +178,7 @@ def ensure_uuid_field(layer):
         # Check current fields
         current_fields = [f.name() for f in layer.fields()]
         if FIBERQ_UUID_FIELD in current_fields:
+            _set_uuid_alias(layer)
             return True
 
         provider_type = (layer.dataProvider().name() if layer.dataProvider() else "unknown")
@@ -182,6 +201,7 @@ def ensure_uuid_field(layer):
                         updated_fields = [f.name() for f in layer.fields()]
                         if FIBERQ_UUID_FIELD in updated_fields:
                             _log(f"  Method 1: SUCCESS - field added to '{layer.name()}'")
+                            _set_uuid_alias(layer)
                             return True
                         else:
                             _log(f"  Method 1: addAttributes ok but field not in layer.fields()! updated_fields={updated_fields}")
@@ -216,6 +236,7 @@ def ensure_uuid_field(layer):
             final_fields = [f.name() for f in layer.fields()]
             if FIBERQ_UUID_FIELD in final_fields:
                 _log(f"  Method 2: SUCCESS - field added to '{layer.name()}'")
+                _set_uuid_alias(layer)
                 return True
             else:
                 _log(f"  Method 2: field NOT found after commit. final_fields={final_fields}")
@@ -349,17 +370,18 @@ def migrate_project_uuids(project=None):
 
             _log(f"UUID migration: processing '{layer_name}' (fields: {sorted(field_names)})")
 
-            # Ensure field exists
+            # Ensure the field exists (idempotent) and stamp the display alias.
+            # Run unconditionally so layers that already have the column still get
+            # the 'FiberQ UUID' alias applied on load, not only at first creation.
             had_field = FIBERQ_UUID_FIELD in field_names
+            added = ensure_uuid_field(layer)
+            if not added:
+                _log(f"UUID migration: FAILED to add field to '{layer_name}'")
+                failed_layers.append(layer_name)
+                continue
             if not had_field:
-                added = ensure_uuid_field(layer)
-                if added:
-                    field_added_layers.append(layer_name)
-                    _log(f"UUID migration: added field to '{layer_name}'")
-                else:
-                    _log(f"UUID migration: FAILED to add field to '{layer_name}'")
-                    failed_layers.append(layer_name)
-                    continue
+                field_added_layers.append(layer_name)
+                _log(f"UUID migration: added field to '{layer_name}'")
 
             # Backfill missing UUIDs (raises UuidMigrationError if it can't persist)
             count = migrate_layer_uuids(layer)
@@ -394,6 +416,7 @@ def migrate_project_uuids(project=None):
 
 __all__ = [
     'FIBERQ_UUID_FIELD',
+    'FIBERQ_UUID_ALIAS',
     'FIBERQ_LAYER_NAMES',
     'FIBERQ_FIELD_SIGNATURES',
     'layer_is_fiberq',

--- a/tests/fixtures/make_sample_project.py
+++ b/tests/fixtures/make_sample_project.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Generate a *pre-1.0* (pre-``fiberq_uuid``) FiberQ GeoPackage fixture.
+
+This synthesises a GeoPackage that looks like a project saved by an older FiberQ
+build: legacy Serbian layer/table names, realistic field rosters, and real
+features -- but crucially WITHOUT the ``fiberq_uuid`` identity column and WITHOUT
+a ``schema_version`` row in ``_fiberq_metadata``. Loading it and running the WP1b
+migration runner therefore has real work to do (add + backfill ``fiberq_uuid``,
+stamp the marker), which is exactly what the migration tests exercise.
+
+It is written with ``osgeo.ogr`` + ``sqlite3`` directly (no QGIS needed), which
+matches how ``ExportManager`` writes GeoPackages: the GDAL GPKG driver for the
+spatial layers and raw ``sqlite3`` for the ``_fiberq_metadata`` key/value table.
+
+Usage (also importable):
+    python tests/fixtures/make_sample_project.py [output.gpkg]
+
+    from make_sample_project import build_pre_uuid_gpkg
+    build_pre_uuid_gpkg("/tmp/legacy_pre_uuid.gpkg")
+
+The rosters mirror ``fiberq/models/schema.py`` as-built, minus ``fiberq_uuid``
+(and minus the same-era cable "Designer" fields fibers_per_tube / total_fibers /
+color_standard) so the fixture is authentically pre-1.0.
+"""
+import os
+import sqlite3
+import sys
+
+#: A realistic projected CRS for the region (UTM zone 34N).
+EPSG = 32634
+
+#: Logical field type -> OGR field-type attribute name (resolved lazily so the
+#: module imports without GDAL until build time). int/year/bool all map to
+#: OFTInteger; the migration does not depend on the boolean subtype.
+_OGR_TYPE = {
+    "text": "OFTString",
+    "enum": "OFTString",
+    "int": "OFTInteger",
+    "year": "OFTInteger",
+    "bool": "OFTInteger",
+    "double": "OFTReal",
+}
+
+
+# Each layer: table name (legacy on-disk name), wkb geometry-type attr, the field
+# roster as (name, logical_type) minus fiberq_uuid, and a few real features as
+# (wkt, {attrs}). Coordinates sit in valid UTM 34N ranges.
+_LAYERS = [
+    {
+        "table": "ODF",  # canonical: ODF (element roster, schema.py:267-283)
+        "wkb": "wkbPoint",
+        "fields": [
+            ("naziv", "text"), ("proizvodjac", "text"), ("oznaka", "text"),
+            ("kapacitet", "int"), ("ukupno_kj", "int"), ("zahtev_kapaciteta", "int"),
+            ("zahtev_rezerve", "int"), ("oznaka_izvoda", "text"), ("numeracija", "text"),
+            ("naziv_objekta", "text"), ("adresa_ulica", "text"), ("adresa_broj", "text"),
+            ("address_id", "text"), ("stanje", "text"), ("godina_ugradnje", "year"),
+        ],
+        "features": [
+            ("POINT(455000 4965000)", {
+                "naziv": "ODF-01", "proizvodjac": "Corning", "oznaka": "A1",
+                "kapacitet": 24, "ukupno_kj": 24, "stanje": "Postojece",
+                "adresa_ulica": "Njegoseva", "adresa_broj": "12",
+                "godina_ugradnje": 2019,
+            }),
+            ("POINT(455120 4965080)", {
+                "naziv": "ODF-02", "proizvodjac": "Corning", "oznaka": "A2",
+                "kapacitet": 48, "ukupno_kj": 48, "stanje": "Projektovano",
+                "godina_ugradnje": 2021,
+            }),
+        ],
+    },
+    {
+        "table": "Kablovi_podzemni",  # canonical: Underground cables (schema.py:401-433)
+        "wkb": "wkbLineString",
+        "fields": [
+            ("tip", "text"), ("podtip", "text"), ("color_code", "text"),
+            ("broj_cevcica", "int"), ("broj_vlakana", "int"), ("tip_kabla", "text"),
+            ("vrsta_vlakana", "text"), ("vrsta_omotaca", "text"), ("vrsta_armature", "text"),
+            ("talasno_podrucje", "text"), ("naziv", "text"), ("slabljenje_dbkm", "double"),
+            ("hrom_disp_ps_nmxkm", "double"), ("stanje_kabla", "text"), ("cable_laying", "text"),
+            ("vrsta_mreze", "text"), ("godina_ugradnje", "int"),
+            ("konstr_vlakna_u_cevcicama", "int"), ("konstr_sa_uzlepljenim_elementom", "int"),
+            ("konstr_punjeni_kabl", "int"), ("konstr_sa_arm_vlaknima", "int"),
+            ("konstr_bez_metalnih", "int"), ("od", "text"), ("do", "text"),
+            ("duzina_m", "double"), ("slack_m", "double"), ("total_len_m", "double"),
+        ],
+        "features": [
+            ("LINESTRING(455000 4965000, 455100 4965050)", {
+                "tip": "opticki", "podtip": "glavni", "broj_cevcica": 1,
+                "broj_vlakana": 24, "tip_kabla": "TOSM-24", "naziv": "MC-01",
+                "stanje_kabla": "Projektovano", "cable_laying": "Podzemno",
+                "od": "ODF-01", "do": "OKNO-1", "duzina_m": 812.5,
+                "slack_m": 20.0, "total_len_m": 832.5,
+            }),
+            ("LINESTRING(455100 4965050, 455260 4965180)", {
+                "tip": "opticki", "podtip": "razvodni", "broj_cevcica": 1,
+                "broj_vlakana": 12, "tip_kabla": "TOSM-12", "naziv": "MC-02",
+                "stanje_kabla": "Postojece", "cable_laying": "Podzemno",
+                "duzina_m": 204.0, "total_len_m": 204.0,
+            }),
+        ],
+    },
+    {
+        "table": "Trasa",  # canonical: Route (schema.py:349-355)
+        "wkb": "wkbLineString",
+        "fields": [
+            ("naziv", "text"), ("duzina", "double"), ("duzina_km", "double"),
+            ("tip_trase", "text"),
+        ],
+        "features": [
+            ("LINESTRING(455000 4965000, 455100 4965050)", {
+                "naziv": "Trasa-1", "duzina": 812.5, "duzina_km": 0.8125,
+                "tip_trase": "podzemna",
+            }),
+        ],
+    },
+    {
+        "table": "OKNA",  # canonical: Manholes (schema.py:328-347)
+        "wkb": "wkbPoint",
+        "fields": [
+            ("broj_okna", "text"), ("tip_okna", "text"), ("vrsta_okna", "text"),
+            ("polozaj_okna", "text"), ("adresa", "text"), ("stanje", "text"),
+            ("god_ugrad", "int"), ("opis", "text"), ("dimenzije", "text"),
+            ("mat_zida", "text"), ("mat_poklop", "text"), ("odvodnj", "text"),
+            ("poklop_tes", "bool"), ("poklop_lak", "bool"), ("br_nosaca", "int"),
+            ("debl_zida", "double"), ("lestve", "text"),
+        ],
+        "features": [
+            ("POINT(455100 4965050)", {
+                "broj_okna": "O-1", "tip_okna": "D1", "stanje": "Postojece",
+                "god_ugrad": 2018, "poklop_tes": 1, "poklop_lak": 0, "br_nosaca": 2,
+            }),
+            ("POINT(455260 4965180)", {
+                "broj_okna": "O-2", "tip_okna": "D2", "stanje": "Projektovano",
+                "god_ugrad": 2021, "poklop_tes": 0, "poklop_lak": 1,
+            }),
+        ],
+    },
+    {
+        "table": "Objekti",  # canonical: Objects (schema.py:387-396)
+        "wkb": "wkbPolygon",
+        "fields": [
+            ("tip", "text"), ("spratova", "int"), ("podzemnih", "int"),
+            ("ulica", "text"), ("broj", "text"), ("naziv", "text"), ("napomena", "text"),
+        ],
+        "features": [
+            ("POLYGON((455000 4965000, 455050 4965000, 455050 4965050, "
+             "455000 4965050, 455000 4965000))", {
+                 "tip": "stambeni", "spratova": 4, "podzemnih": 1,
+                 "ulica": "Njegoseva", "broj": "12", "naziv": "Zgrada A",
+             }),
+        ],
+    },
+]
+
+#: Legacy ``_fiberq_metadata`` rows. Deliberately carries ``project_version`` but
+#: NOT ``schema_version`` -- the load-bearing "this project predates the marker"
+#: signal, alongside a plausible pre-WP1a plugin version.
+_LEGACY_METADATA = {
+    "project_version": "1.2.1",
+    "relations_json": '{"relations": []}',
+    "latent_elements_json": '{"cables": {}}',
+    "color_standard": "TIA-598-C",
+    "crs_epsg": str(EPSG),
+    "export_timestamp": "2025-11-01T09:30:00Z",
+}
+
+
+def build_pre_uuid_gpkg(path, with_metadata_table=True):
+    """Write a pre-1.0 FiberQ GeoPackage fixture at ``path`` and return ``path``.
+
+    Args:
+        path: output ``.gpkg`` path (overwritten if it exists).
+        with_metadata_table: if True, add a legacy ``_fiberq_metadata`` table
+            (with ``project_version`` but no ``schema_version``). Set False for a
+            "truly ancient" variant with no metadata table at all.
+    """
+    from osgeo import gdal, ogr, osr
+
+    # Fail fast on any OGR/GDAL error (and silence the GDAL 4.0 FutureWarning)
+    # instead of silently producing a malformed fixture.
+    gdal.UseExceptions()
+    ogr.UseExceptions()
+
+    if os.path.exists(path):
+        os.remove(path)
+
+    drv = ogr.GetDriverByName("GPKG")
+    if drv is None:
+        raise RuntimeError("GDAL GPKG driver unavailable")
+    ds = drv.CreateDataSource(path)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(EPSG)
+
+    for spec in _LAYERS:
+        lyr = ds.CreateLayer(spec["table"], srs, getattr(ogr, spec["wkb"]))
+        for fname, ftype in spec["fields"]:
+            lyr.CreateField(ogr.FieldDefn(fname, getattr(ogr, _OGR_TYPE[ftype])))
+        defn = lyr.GetLayerDefn()
+        for wkt, attrs in spec["features"]:
+            feat = ogr.Feature(defn)
+            for key, value in attrs.items():
+                feat.SetField(key, value)
+            feat.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
+            lyr.CreateFeature(feat)
+            feat = None
+        lyr = None
+    ds = None  # flush + close before opening with sqlite3
+
+    if with_metadata_table:
+        _write_legacy_metadata(path)
+    return path
+
+
+def _write_legacy_metadata(path):
+    """Add a pre-1.0 ``_fiberq_metadata`` table (no ``schema_version`` row)."""
+    conn = sqlite3.connect(path)
+    try:
+        cur = conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS _fiberq_metadata")
+        cur.execute(
+            "CREATE TABLE _fiberq_metadata (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        for key, value in _LEGACY_METADATA.items():
+            cur.execute(
+                "INSERT INTO _fiberq_metadata (key, value) VALUES (?, ?)",
+                (key, value),
+            )
+        # Register as a non-spatial attributes table, mirroring ExportManager.
+        cur.execute(
+            "INSERT OR IGNORE INTO gpkg_contents "
+            "(table_name, data_type, identifier, srs_id) "
+            "VALUES (?, 'attributes', ?, 0)",
+            ("_fiberq_metadata", "_fiberq_metadata"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    out = argv[0] if argv else os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "legacy_pre_uuid.gpkg"
+    )
+    build_pre_uuid_gpkg(out)
+    print(f"Wrote pre-1.0 fixture: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -220,6 +220,39 @@ def test_equal_but_aliased_marker_is_canonicalised(qgis_app):
 
 
 # ---------------------------------------------------------------------------
+# Non-FiberQ / blank projects: never stamped, dirtied, or announced
+# ---------------------------------------------------------------------------
+
+def test_blank_project_is_not_stamped_or_announced(qgis_app):
+    """An unmarked, empty project (the blank startup project) is not a FiberQ
+    project: the runner must leave it completely alone -- no stamp, no message."""
+    p = QgsProject()
+    report = m.run_migrations(p)
+    assert report.ran is False
+    assert report.steps == []
+    assert not report.errors
+    # Still unmarked -> nothing was written, so QGIS never marks it dirty for us.
+    assert sv.read_project_schema_version(p) == sv.BASELINE_VERSION
+
+
+def test_non_fiberq_project_is_left_alone(qgis_app):
+    """An unmarked project whose only layer is not a FiberQ layer must not be
+    stamped, and that foreign layer must not gain a fiberq_uuid field."""
+    p = QgsProject()
+    other = QgsVectorLayer("Point?crs=EPSG:4326&field=city:string", "Cities", "memory")
+    assert other.isValid()
+    p.addMapLayer(other)
+
+    report = m.run_migrations(p)
+
+    assert report.ran is False
+    assert report.steps == []
+    assert not report.errors
+    assert sv.read_project_schema_version(p) == sv.BASELINE_VERSION
+    assert other.fields().indexOf("fiberq_uuid") < 0   # foreign layer untouched
+
+
+# ---------------------------------------------------------------------------
 # Durability: prove the backfill reaches disk, not just the edit buffer
 # ---------------------------------------------------------------------------
 
@@ -262,6 +295,12 @@ def test_failed_step_withholds_stamp(qgis_app, monkeypatch):
     next load retries instead of leaving the marker lying."""
     p = QgsProject()
     sv.write_project_schema_version("0", p)
+    # A recognised FiberQ layer so the runner treats this as a FiberQ project --
+    # an unmarked project with no FiberQ layers is now a deliberate no-op and
+    # would never reach the (monkeypatched) failing step.
+    fq = QgsVectorLayer("Point?crs=EPSG:4326", "ODF", "memory")
+    assert fq.isValid()
+    p.addMapLayer(fq)
 
     def _boom(project=None):
         raise RuntimeError("simulated locked layer")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,300 @@
+"""Tests for the WP1b schema migration runner + versioning lifecycle.
+
+These need a QgsApplication (provided by pytest-qgis) because the runner
+reads/writes QgsProject entries and edits QgsVectorLayers. Fresh QgsProject()
+instances keep the singleton project untouched. The pre-1.0 GeoPackage fixture is
+generated on the fly into ``tmp_path`` by tests/fixtures/make_sample_project.py,
+so no binary blob is committed.
+"""
+import importlib.util
+import os
+
+import pytest
+from qgis.core import QgsProject, QgsVectorLayer
+
+from fiberq.core import migrations as m
+from fiberq.core import schema_version as sv
+
+_LAYER_NAMES = ["ODF", "Kablovi_podzemni", "Trasa", "OKNA", "Objekti"]
+
+# One pre-existing text field per layer, used to prove existing values survive.
+_CHECK_FIELD = {
+    "ODF": "naziv",
+    "Kablovi_podzemni": "naziv",
+    "Trasa": "naziv",
+    "OKNA": "broj_okna",
+    "Objekti": "naziv",
+}
+
+
+def _load_generator():
+    """Import tests/fixtures/make_sample_project.py (fixtures is not a package)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "fixtures", "make_sample_project.py")
+    spec = importlib.util.spec_from_file_location("make_sample_project", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _build_and_load(tmp_path, with_metadata_table=True):
+    """Build a pre-1.0 fixture and load its layers into a fresh QgsProject."""
+    gen = _load_generator()
+    gpkg = str(tmp_path / "legacy_pre_uuid.gpkg")
+    gen.build_pre_uuid_gpkg(gpkg, with_metadata_table=with_metadata_table)
+    project = QgsProject()
+    layers = {}
+    for name in _LAYER_NAMES:
+        vl = QgsVectorLayer(f"{gpkg}|layername={name}", name, "ogr")
+        assert vl.isValid(), f"fixture layer {name!r} failed to load"
+        project.addMapLayer(vl)
+        layers[name] = vl
+    return project, gpkg, layers
+
+
+def _counts(layers):
+    return {name: vl.featureCount() for name, vl in layers.items()}
+
+
+def _uuid_values(vl):
+    idx = vl.fields().indexOf("fiberq_uuid")
+    if idx < 0:
+        return None
+    return [f.attribute(idx) for f in vl.getFeatures()]
+
+
+# ---------------------------------------------------------------------------
+# Ordered version comparison
+# ---------------------------------------------------------------------------
+
+def test_version_ordering(qgis_app):
+    assert m._version_lt("0", "1.0")
+    assert m._version_lt("0.9", "1.0")
+    assert m._version_lt("1.0", "1.1")
+    assert m._version_lt("1.1", "2.0")
+    assert m._version_lt("1.9", "1.10")          # numeric, not lexical
+    assert not m._version_lt("1.0", "1.0")
+    assert not m._version_lt("1.0", "0")
+    assert not m._version_lt("2.0", "1.1")
+    assert m._version_eq("1", "1.0")             # padded equality
+    assert m._version_eq("1.0", "1.0")
+    assert not m._version_eq("1.0", "1.1")
+
+
+# ---------------------------------------------------------------------------
+# The fixture itself represents a genuine pre-1.0 project
+# ---------------------------------------------------------------------------
+
+def test_fixture_is_pre_uuid(qgis_app, tmp_path):
+    project, _gpkg, layers = _build_and_load(tmp_path)
+    for name, vl in layers.items():
+        assert vl.fields().indexOf("fiberq_uuid") < 0, f"{name} unexpectedly has uuid"
+        assert vl.featureCount() > 0, name
+    # No marker anywhere -> reads as baseline "0".
+    assert sv.read_project_schema_version(project) == sv.BASELINE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Upgrade: adds + backfills uuid on every layer and stamps the marker
+# ---------------------------------------------------------------------------
+
+def test_run_migrations_upgrades_old_project(qgis_app, tmp_path):
+    project, _gpkg, layers = _build_and_load(tmp_path)
+    before = _counts(layers)
+    assert sv.needs_upgrade(project) is True
+
+    report = m.run_migrations(project)
+
+    assert report.ran is True
+    assert report.from_version == sv.BASELINE_VERSION
+    assert report.to_version == sv.SCHEMA_VERSION
+    assert "uuid-identity" in report.steps
+    assert not report.errors
+
+    # Marker advanced to current.
+    assert sv.read_project_schema_version(project) == sv.SCHEMA_VERSION
+    assert sv.needs_upgrade(project) is False
+
+    # Every layer now has a fully-populated, unique fiberq_uuid.
+    for name, vl in layers.items():
+        idx = vl.fields().indexOf("fiberq_uuid")
+        assert idx >= 0, f"{name} missing uuid field after migration"
+        vals = _uuid_values(vl)
+        assert all(v not in (None, "") and str(v).strip() for v in vals), name
+        assert len(set(vals)) == len(vals), f"{name} uuids not unique"
+
+    # Lossless: no features gained or lost.
+    assert _counts(layers) == before
+
+
+def test_migration_preserves_existing_attributes(qgis_app, tmp_path):
+    """Adding the uuid column must not disturb existing attribute values."""
+    project, _gpkg, layers = _build_and_load(tmp_path)
+    watched = ("naziv", "kapacitet", "stanje")
+    odf = layers["ODF"]
+    before = {
+        f.id(): {k: f[k] for k in watched} for f in odf.getFeatures()
+    }
+
+    m.run_migrations(project)
+
+    after = {
+        f.id(): {k: f[k] for k in watched} for f in odf.getFeatures()
+    }
+    assert after == before
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+def test_run_migrations_is_idempotent(qgis_app, tmp_path):
+    project, _gpkg, layers = _build_and_load(tmp_path)
+    m.run_migrations(project)
+    first = {name: _uuid_values(vl) for name, vl in layers.items()}
+    # Guard against a vacuous pass: the values compared must actually be populated.
+    for name, vals in first.items():
+        assert vals and all(v not in (None, "") and str(v).strip() for v in vals), name
+
+    # Second run: marker already current -> no-op, no re-assignment.
+    report2 = m.run_migrations(project)
+    assert report2.ran is False
+    assert report2.details == {}
+    second = {name: _uuid_values(vl) for name, vl in layers.items()}
+    assert second == first
+
+
+def test_uuid_backfill_is_idempotent(qgis_app, tmp_path):
+    """The underlying uuid step is a no-op on a second pass (data-level)."""
+    from fiberq.utils.uuid_utils import migrate_project_uuids
+
+    project, _gpkg, _layers = _build_and_load(tmp_path)
+    first = migrate_project_uuids(project)
+    assert sum(first.values()) > 0          # real work the first time
+    second = migrate_project_uuids(project)
+    assert second == {}                      # nothing left to do
+
+
+# ---------------------------------------------------------------------------
+# Guards: current project is a no-op; a newer project is never downgraded
+# ---------------------------------------------------------------------------
+
+def test_current_project_is_noop(qgis_app):
+    p = QgsProject()
+    sv.mark_project_current(p)
+    report = m.run_migrations(p)
+    assert report.ran is False
+    assert report.details == {}
+    assert not report.errors
+
+
+def test_newer_project_is_not_downgraded(qgis_app):
+    p = QgsProject()
+    sv.write_project_schema_version("99.0", p)
+    report = m.run_migrations(p)
+    assert report.ran is False
+    assert report.errors                     # refused, with a reason
+    assert sv.read_project_schema_version(p) == "99.0"   # left untouched
+
+
+def test_malformed_marker_is_not_migrated(qgis_app):
+    """A foreign/decorated marker must not be coerced (which would bypass the
+    newer-than-plugin guard and silently downgrade a real newer project)."""
+    p = QgsProject()
+    sv.write_project_schema_version("v2.0", p)
+    report = m.run_migrations(p)
+    assert report.ran is False
+    assert report.errors
+    assert sv.read_project_schema_version(p) == "v2.0"   # untouched
+
+
+def test_equal_but_aliased_marker_is_canonicalised(qgis_app):
+    """A marker equal-but-not-identical to current ("1" vs "1.0") converges to
+    the canonical string so needs_upgrade() and the runner agree."""
+    p = QgsProject()
+    sv.write_project_schema_version("1", p)
+    report = m.run_migrations(p)
+    assert report.ran is False
+    assert not report.errors
+    assert sv.read_project_schema_version(p) == sv.SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Durability: prove the backfill reaches disk, not just the edit buffer
+# ---------------------------------------------------------------------------
+
+def test_migration_persists_to_disk(qgis_app, tmp_path):
+    project, gpkg, layers = _build_and_load(tmp_path)
+    before_counts = _counts(layers)
+    before_vals = {
+        name: sorted(str(f[_CHECK_FIELD[name]]) for f in layers[name].getFeatures())
+        for name in _LAYER_NAMES
+    }
+
+    report = m.run_migrations(project)
+    assert report.ran is True
+
+    # Release the live handles and read the file back with fresh layers -- only a
+    # disk re-read proves the commit actually persisted (a lost commit would still
+    # look complete through the original layers' edit buffer).
+    project.removeAllMapLayers()
+    for name in _LAYER_NAMES:
+        vl = QgsVectorLayer(f"{gpkg}|layername={name}", name, "ogr")
+        assert vl.isValid(), name
+        idx = vl.fields().indexOf("fiberq_uuid")
+        assert idx >= 0, f"{name}: fiberq_uuid not persisted to disk"
+        vals = [f.attribute(idx) for f in vl.getFeatures()]
+        assert vals, name
+        assert all(v not in (None, "") and str(v).strip() for v in vals), \
+            f"{name}: NULL/empty uuid on disk"
+        assert len(set(vals)) == len(vals), f"{name}: uuids not unique on disk"
+        assert vl.featureCount() == before_counts[name], f"{name}: feature count changed"
+        after = sorted(str(f[_CHECK_FIELD[name]]) for f in vl.getFeatures())
+        assert after == before_vals[name], f"{name}: existing values not preserved"
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure: a step that can't persist must NOT stamp the marker
+# ---------------------------------------------------------------------------
+
+def test_failed_step_withholds_stamp(qgis_app, monkeypatch):
+    """If a migration step fails, run_migrations must not stamp current, so the
+    next load retries instead of leaving the marker lying."""
+    p = QgsProject()
+    sv.write_project_schema_version("0", p)
+
+    def _boom(project=None):
+        raise RuntimeError("simulated locked layer")
+
+    monkeypatch.setattr(m, "MIGRATIONS",
+                        [m.Migration("1.0", "boom", "simulated failure", _boom)])
+    report = m.run_migrations(p)
+    assert report.ran is False
+    assert report.errors and "boom" in report.errors[0]
+    assert sv.read_project_schema_version(p) == "0"   # NOT stamped -> retried
+
+
+def test_uuid_migration_raises_on_failed_layer(qgis_app, tmp_path, monkeypatch):
+    """migrate_project_uuids surfaces a failed layer (no silent partial success)."""
+    from fiberq.utils import uuid_utils
+
+    project, _gpkg, _layers = _build_and_load(tmp_path)
+    monkeypatch.setattr(uuid_utils, "ensure_uuid_field", lambda layer: False)
+    with pytest.raises(uuid_utils.UuidMigrationError):
+        uuid_utils.migrate_project_uuids(project)
+
+
+# ---------------------------------------------------------------------------
+# The migration chain is well-formed (guards a future SCHEMA_VERSION bump)
+# ---------------------------------------------------------------------------
+
+def test_migration_chain_wellformed(qgis_app):
+    targets = [s.to_version for s in m.MIGRATIONS]
+    assert all(m._is_valid_version(t) for t in targets)
+    # No two steps target the same (semantic) version.
+    for i in range(len(targets)):
+        for j in range(i + 1, len(targets)):
+            assert not m._version_eq(targets[i], targets[j]), "duplicate step target"
+    # No step targets a version beyond the current schema.
+    for t in targets:
+        assert not m._version_lt(sv.SCHEMA_VERSION, t), f"step targets {t} > current"

--- a/tests/test_uuid_creation_invariant.py
+++ b/tests/test_uuid_creation_invariant.py
@@ -24,6 +24,19 @@ def _clear():
     QgsProject.instance().removeAllMapLayers()
 
 
+def test_ensure_uuid_field_sets_display_alias(qgis_app):
+    """ensure_uuid_field must also stamp the canonical 'FiberQ UUID' display alias
+    so every layer shows the identity field with the same label."""
+    from fiberq.utils.uuid_utils import (
+        ensure_uuid_field, FIBERQ_UUID_FIELD, FIBERQ_UUID_ALIAS,
+    )
+    vl = QgsVectorLayer("Point?crs=EPSG:4326&field=naziv:string", "ODF", "memory")
+    assert ensure_uuid_field(vl)
+    idx = vl.fields().indexOf(FIBERQ_UUID_FIELD)
+    assert idx >= 0
+    assert vl.attributeAlias(idx) == FIBERQ_UUID_ALIAS
+
+
 def test_route_layer_created_with_uuid(qgis_app, qgis_iface):
     from fiberq.core.route_manager import RouteManager
     _clear()

--- a/tests/test_uuid_creation_invariant.py
+++ b/tests/test_uuid_creation_invariant.py
@@ -1,0 +1,62 @@
+"""WP1b: FiberQ layer factories must add the fiberq_uuid identity column at
+layer-creation time, not only via the on-load migrator.
+
+Regression guard for the manual-test finding that Route / Service Area / Optical
+slacks / pipe layers were created WITHOUT fiberq_uuid (so set_feature_uuid then
+silently no-opped), while Poles/Manholes -- created through the field-complete
+LayerManager path -- had it. Each test drives the real factory and asserts the
+column exists on the returned layer.
+
+The element-placement tool (Route/TO/OTB/ODF/... via PlaceElementTool) uses the
+same ensure_uuid_field call but is driven by a canvas mouse event, so it is
+covered by manual QGIS testing rather than here.
+"""
+from qgis.core import QgsProject, QgsVectorLayer
+
+UUID = "fiberq_uuid"
+
+
+def _has_uuid(layer):
+    return isinstance(layer, QgsVectorLayer) and layer.fields().indexOf(UUID) >= 0
+
+
+def _clear():
+    QgsProject.instance().removeAllMapLayers()
+
+
+def test_route_layer_created_with_uuid(qgis_app, qgis_iface):
+    from fiberq.core.route_manager import RouteManager
+    _clear()
+    layer = RouteManager(qgis_iface)._ensure_route_layer()
+    assert _has_uuid(layer), "Route layer created without fiberq_uuid"
+
+
+def test_slack_layer_created_with_uuid(qgis_app, qgis_iface):
+    from fiberq.core.slack_manager import SlackManager
+    _clear()
+    # layer_manager=None forces the inline fallback factory (the field-less path).
+    layer = SlackManager(qgis_iface, layer_manager=None).ensure_slack_layer()
+    assert _has_uuid(layer), "Optical slacks layer created without fiberq_uuid"
+
+
+def test_pipe_layer_created_with_uuid(qgis_app, qgis_iface):
+    from fiberq.core.pipe_manager import PipeManager
+    _clear()
+    layer = PipeManager(qgis_iface, layer_manager=None).ensure_pipe_layer("PE cevi")
+    assert _has_uuid(layer), "Pipe layer created without fiberq_uuid"
+
+
+def test_service_area_layer_created_with_uuid(qgis_app, qgis_iface):
+    from fiberq.utils import legacy_bridge
+    _clear()
+    core = type("Core", (), {"iface": qgis_iface})()
+    layer = legacy_bridge._ensure_region_layer(core)
+    assert _has_uuid(layer), "Service Area layer created without fiberq_uuid"
+
+
+def test_objects_layer_created_with_uuid(qgis_app, qgis_iface):
+    from fiberq.utils import legacy_bridge
+    _clear()
+    core = type("Core", (), {"iface": qgis_iface})()
+    layer = legacy_bridge._ensure_objects_layer(core)
+    assert _has_uuid(layer), "Objects layer created without fiberq_uuid"


### PR DESCRIPTION
**Stacked on #21 (WP1a).** Base is `feat/wp1a-schema-versioning`, **not** `main` — GitHub will auto-retarget this PR to `main` once #21 merges. Review only the 5 commits below; the WP1a commits belong to #21.

## What this delivers (WP1b)

A versioned, idempotent schema-migration runner that upgrades an older FiberQ project to the current schema on load, plus a standing `fiberq_uuid` identity invariant.

- **Versioned migration runner** (`fiberq/core/migrations.py`): reads the project's stored schema marker, runs the ordered migration chain for every step newer than stored (and ≤ current), and stamps the current version only if every step succeeds. Ordered numeric version compare; a project stamped newer than the plugin is never downgraded; a malformed/foreign marker is left untouched.
- **Load-hook wiring** (`main_plugin.py`): runs the runner on `readProject` and once at init, and keeps the always-on `fiberq_uuid` backfill so imports/external edits still get an identity. Also fixes a connect/disconnect leak (the old code disconnected a different callable than it connected, so the slot accumulated across reloads).
- **UUID failure channel** (`uuid_utils.py`): a failed/locked layer now raises `UuidMigrationError` instead of silently partially succeeding, so the runner withholds the stamp and retries on the next load.
- **Fix — project guard** (`8b7216b`): the runner previously stamped the marker and toasted "Upgraded project schema 0 → 1.0" on **any** unmarked project — including the blank startup project and unrelated non-FiberQ projects, writing our marker into them and dirtying them. It's now gated on the project actually being a FiberQ project (has FiberQ layers, or already carries a marker). FiberQ-layer recognition is factored into one shared helper so the guard and the uuid backfill can't drift. Found during manual QGIS testing and adversarially verified.
- **Tests** (`tests/test_migrations.py`, `tests/fixtures/make_sample_project.py`): pre-1.0 fixture generator + migration lifecycle — upgrade, losslessness, idempotency, disk-persistence, newer/malformed/aliased markers, partial-failure withholds stamp, and blank / non-FiberQ projects left untouched.
- **Chore** (`02c7e45`): repo-wide LF line-ending enforcement (`.gitattributes` + `.editorconfig`); no tracked file content changed (`git add --renormalize .` stages only those two files).

## Testing

- Full suite: **41 passed** on `qgis/qgis:3.44-trixie` (Qt5); migration tests **16 passed** on `qgis/qgis:4.0-trixie` (Qt6).
- Lint (flake8 `--isolated --max-line-length=120 --ignore=E501` + Bandit `-ll`): **0 / 0**.

## Notes

- The schema version (`1.0`) is tracked separately from the plugin version; this PR does **not** bump the plugin version (stays v1.2.3). Version bump + changelog happen at release time (v1.3.0).
- AI-assisted; commits carry the `Assisted-by:` provenance trailer per the repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
