### PR TITLE
release: v1.3.0

### DIFF
--- a/docs/project-versioning-guide.md
+++ b/docs/project-versioning-guide.md
@@ -1,0 +1,110 @@
+# FiberQ 1.3.0 — Project versioning, safe migrations, and stable feature IDs
+
+A user guide to the project-versioning features introduced in **FiberQ 1.3.0**.
+For the field-by-field data model, see the [schema reference](schema.md).
+
+FiberQ 1.3.0 gives every project a **version marker**, upgrades **older projects
+automatically and safely** when you open them, and gives every feature a **stable
+identity** (`fiberq_uuid`) that survives edits, exports, and round-trips between
+tools and systems. Together these make FiberQ projects forward-compatible: today's
+data can be recognised and migrated by future releases without losing anything.
+
+---
+
+## 1. The project schema version
+
+Each FiberQ project now records which **data schema** it was built against — the
+current schema version is **`1.0`**. This is separate from the plugin version you
+see in the QGIS Plugin Manager; the two advance independently.
+
+The marker is:
+
+- **saved into the QGIS project** when you save, and
+- **mirrored into the GeoPackage** (a small `_fiberq_metadata` table) on a full
+  project export, so the version travels with the data file itself.
+
+You don't have to do anything to opt in — new projects are stamped automatically,
+and older ones are upgraded on load (next section).
+
+## 2. Opening an older project (automatic migration)
+
+When you open a project created by an **earlier** FiberQ version, FiberQ detects
+the older (or missing) schema marker and upgrades it in place. You'll see a message
+such as:
+
+```
+FiberQ: Upgraded project schema 0 -> 1.0 (assigned 50 UUIDs across 15 layers)
+```
+
+and a per-layer summary in the QGIS **Log Messages** panel (the *FiberQ UUID*
+tab). What the upgrade guarantees:
+
+- **Lossless** — it only *adds* the identity field and fills it in. Your existing
+  attributes and geometry are never modified or removed.
+- **Idempotent** — running it again does nothing. Once a project is at `1.0`,
+  re-opening it shows no upgrade message.
+- **Safe on non-FiberQ / blank projects** — an empty QGIS project, or one with no
+  FiberQ layers, is left completely untouched.
+- **Never downgrades** — a project stamped *newer* than your installed plugin is
+  left alone, so a newer project can't be silently rewritten by an older plugin.
+- **Only stamps on success** — if the upgrade can't be written (for example a
+  read-only or locked GeoPackage), the marker is left unchanged and the upgrade
+  simply retries next time. The version never claims a migration that didn't
+  actually reach disk.
+
+> **Tip:** the upgrade becomes permanent only when you **save** the project (or
+> export it to GeoPackage). If you open an old project and close without saving,
+> it just upgrades again harmlessly next time.
+
+## 3. Stable feature identity: `fiberq_uuid`
+
+Every FiberQ feature now carries a **`fiberq_uuid`** — a stable, globally-unique
+identifier that stays with the feature no matter what happens to it:
+
+- It is **added automatically** to every FiberQ layer and **filled on creation**
+  for every element, across every drawing tool (routes, cables, optical slack,
+  pipes, service areas, objects, poles, manholes, and all the enclosure/termination
+  layers).
+- It **survives edits and exports**, so a feature keeps the same identity across
+  operations and between the plugin and any external system that consumes FiberQ
+  data. This is the anchor for interoperability and for the open
+  interchange-format work.
+- It is a **standing invariant**, not a one-time conversion: an idempotent backfill
+  runs on **every** project load, so features that appear later (imports, external
+  edits, interchange round-trips) are healed and given an identity too.
+- Splitting a feature (for example **Cut infrastructure**) gives each resulting
+  half a **fresh** `fiberq_uuid` — the two parts are genuinely distinct features,
+  not two copies sharing one identity.
+
+`fiberq_uuid` is shown in the attribute table under the display alias
+**"FiberQ UUID"**.
+
+## 4. What to check
+
+- Open an existing FiberQ project → confirm the upgrade message appears once, and
+  that every layer now has a **FiberQ UUID** column populated for all features.
+- Save, close, and re-open → confirm **no** second upgrade message (the marker is
+  now `1.0`).
+- Create new elements with any tool → confirm each gets a `fiberq_uuid`
+  immediately.
+
+## 5. Quality assurance & compatibility
+
+- **Full manual source review.** Ahead of the 1.3.0 release, the maintainer
+  manually reviewed the **entire plugin source — every Python module** — in
+  addition to the automated checks below.
+- **Clean repository scan.** The plugin continues to report **zero findings** on
+  the plugins.qgis.org Security & Quality scan (flake8 with
+  `--max-line-length=120 --ignore=E501`, and Bandit at medium/high severity).
+- **Automated tests on both Qt generations.** The pytest suite (including the new
+  schema-version, migration, and `fiberq_uuid` invariant tests) runs green against
+  **QGIS 3 / Qt5** and **QGIS 4 / Qt6**.
+- **Backward compatibility.** FiberQ 1.3.0 targets QGIS 3.22 LTR through QGIS 4 /
+  Qt6, and opens projects from earlier FiberQ versions via the migration described
+  above.
+
+---
+
+*FiberQ is free software under the GPL-3.0-or-later licence. Source, issues, and
+releases: <https://github.com/vukovicvl/fiberq>. This release was developed with
+support from the NLnet NGI0 Commons Fund.*

--- a/fiberq/__init__.py
+++ b/fiberq/__init__.py
@@ -123,7 +123,7 @@ class _FiberQStub:
 # PACKAGE INFO
 # =============================================================================
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 __author__ = "Vladimir Vukovic"
 __email__ = "vukovicvl@fiberq.net"
 __license__ = "GPL-3.0-or-later"

--- a/fiberq/metadata.txt
+++ b/fiberq/metadata.txt
@@ -3,7 +3,7 @@ name=FiberQ
 description=Open-source fiber network design tools for QGIS (FTTH/GPON/FTTx)
 about=FiberQ helps telecom engineers and GIS professionals design, analyze, and document fiber optic networks inside QGIS. FiberQ supports QGIS 4 / Qt6 while keeping support for QGIS 3.22 LTR and later, and clears all findings from the QGIS repository security scan. Some advanced features may require an activation key.
 
-version=1.2.3
+version=1.3.0
 qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 
@@ -23,6 +23,33 @@ license=GPL-3.0-or-later
 class_name=FiberQPlugin
 
 changelog=
+    1.3.0 - Project schema versioning, safe migrations, and stable feature IDs
+        * New: every FiberQ project now carries a schema-version marker, also
+          mirrored into the GeoPackage, so future releases can recognise and
+          upgrade older projects safely.
+        * New: a versioned migration runner upgrades older projects automatically
+          on load (e.g. schema 0 -> 1.0) - losslessly and idempotently - and
+          reports a summary in the QGIS log. Blank or non-FiberQ projects are
+          left untouched.
+        * New: the fiberq_uuid identity invariant. Every FiberQ feature carries a
+          stable, cross-system UUID. Loading an older project assigns UUIDs to all
+          existing features; new features receive one on creation across every
+          tool (routes, cables, slack, pipes, service areas, objects, ...).
+        * Fix: the cable "Number of fibers" field now follows the computed total
+          instead of freezing at an intermediate value while typing.
+        * Fix: the Objects draw tools (3-point / N-point / ortho / digitize) no
+          longer raise an ImportError after the module split.
+        * Fix: "Cut infrastructure" no longer fails to save on a duplicate primary
+          key; the two halves get fresh feature ids and fresh fiberq_uuids.
+        * Fix: the Optical Schematic View now draws pipes in the legend orange for
+          English-named layers (previously grey), matching the "Pipes" legend.
+        * Fix: renamed the mislabeled "FiberQ web browser" action to "Preview Map".
+        * Quality: the maintainer manually reviewed the entire plugin source -
+          every Python module - prior to this release. Lint (flake8 + Bandit)
+          remains at zero findings on the plugins.qgis.org scan, and the pytest
+          suite runs green on QGIS 3 (Qt5) and QGIS 4 (Qt6).
+        (This release was developed with support from the NLnet NGI0 Commons Fund.)
+
     1.2.3 - Repository scan: zero findings (code hygiene, no functional change)
         * The plugin now scans clean on the plugins.qgis.org Security & Quality
           scan: flake8 (--max-line-length=120 --ignore=E501) and Bandit


### PR DESCRIPTION
Release prep for **v1.3.0** — the WP1 deliverable (project schema versioning + migration runner + `fiberq_uuid` identity invariant), plus the manual-test bug fixes, now merged to `main` via #21, #22, #23.

## This PR
- Bump version **1.2.3 → 1.3.0** (`metadata.txt` + `__init__.py`).
- Add the **1.3.0 changelog** entry (features + fixes + QA note).
- Add a user-facing **project-versioning guide** (`docs/project-versioning-guide.md`) for publication alongside the release.

## What ships in 1.3.0
- **WP1a** — project `schema_version` marker + GeoPackage mirror.
- **WP1b** — versioned, lossless, idempotent on-load migration runner; `fiberq_uuid` identity invariant across every layer/tool.
- **Fixes** — cable fiber count, Objects draw-tool imports, Cut-infrastructure fid/uuid, schematic pipe colour, Preview Map rename.

## QA
- Maintainer **manually reviewed the entire plugin source (every Python module)** before release.
- Lint **0/0** (flake8 + Bandit), verified locally on Python 3.14 via an isolated venv.
- Migration validated in QGIS on **new and old** projects (schema 0 → 1.0; all layers get `fiberq_uuid`, no data loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)