### PR TITLE
fix(scan): resolve Bandit B110/B112 scan block (v1.3.1)

### DIFF
--- a/.claude/skills/scan-check/SKILL.md
+++ b/.claude/skills/scan-check/SKILL.md
@@ -10,11 +10,11 @@ Run the same checks the plugins.qgis.org scanner runs, locally and fast, and rep
    ```bash
    python -m flake8 --isolated --max-line-length=120 --ignore=E501 fiberq
    ```
-2. Bandit, medium/high only (the scan policy):
+2. Bandit at ALL severities (the scanner flags LOW too — e.g. B110/B112 try/except/pass|continue — so `-ll` is not enough):
    ```bash
-   python -m bandit -r fiberq -ll -q
+   python -m bandit -r fiberq -q -c pyproject.toml
    ```
-3. Report: flake8 finding count and Bandit medium/high count. **The gate is 0 / 0.**
+3. Report: flake8 finding count and total Bandit count (all severities). **The gate is 0 / 0.**
 4. If anything fires, list each finding with `file:line` and the code, and say whether it should be fixed or (rarely, with a stated reason) silenced with an inline `# noqa: <code>` / Bandit annotation.
 
 ## Notes

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,9 @@ flake8:
 	$(PYTHON) -m flake8 --isolated --max-line-length=120 --ignore=E501 $(PKG) tests conftest.py
 
 bandit:
-	# Medium/high severity only (-ll), matching the scan policy. Config in pyproject.toml.
-	$(PYTHON) -m bandit -r $(PKG) -ll -q -c pyproject.toml
+	# ALL severities — the plugins.qgis.org scanner flags LOW too (e.g. B110/B112
+	# try/except/pass|continue), so -ll (medium/high only) is NOT enough. Config in pyproject.toml.
+	$(PYTHON) -m bandit -r $(PKG) -q -c pyproject.toml
 
 # ---- tests ------------------------------------------------------------------
 # QT_QPA_PLATFORM=offscreen runs Qt without a display. The qgis/qgis image also

--- a/fiberq/__init__.py
+++ b/fiberq/__init__.py
@@ -91,7 +91,8 @@ def classFactory(iface):  # pylint: disable=invalid-name
             Qgis.MessageLevel.Info
         )
     except Exception:
-        pass
+        # best-effort logging; nothing to fall back to
+        pass  # nosec B110
 
     # Import and return the actual plugin
     from .main_plugin import FiberQPlugin
@@ -123,7 +124,7 @@ class _FiberQStub:
 # PACKAGE INFO
 # =============================================================================
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "Vladimir Vukovic"
 __email__ = "vukovicvl@fiberq.net"
 __license__ = "GPL-3.0-or-later"

--- a/fiberq/addons/fiber_break.py
+++ b/fiberq/addons/fiber_break.py
@@ -97,8 +97,8 @@ class FiberBreakTool(QgsMapTool):
                 layer.loadNamedStyle(qml_path)
                 layer.triggerRepaint()
                 return
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"could not load Fiber break QML style: {e}")
 
         try:
             from qgis.PyQt.QtGui import QColor
@@ -163,11 +163,12 @@ class FiberBreakTool(QgsMapTool):
                     from ..utils.uuid_utils import ensure_uuid_field
 
                     ensure_uuid_field(lyr)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"could not ensure uuid field on Fiber break layer: {e}")
 
                 return lyr
-            except Exception:
+            except Exception as e:
+                logger.debug(f"skipping layer while locating Fiber break layer: {e}")
                 continue
 
         crs_authid = self.canvas.mapSettings().destinationCrs().authid()
@@ -200,7 +201,8 @@ class FiberBreakTool(QgsMapTool):
                     and lyr.isValid()  # noqa: W503
                 ):
                     yield lyr
-            except Exception:
+            except Exception as e:
+                logger.debug(f"skipping layer while iterating line layers: {e}")
                 continue
 
     def _flatten_polyline(self, geom: QgsGeometry):
@@ -258,7 +260,8 @@ class FiberBreakTool(QgsMapTool):
                     if geom is None:
                         continue
                     dist = geom.distance(map_pt_geom)
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"could not compute distance to feature: {e}")
                     continue
 
                 if nearest_dist is None or (dist is not None and dist < nearest_dist):
@@ -324,8 +327,8 @@ class FiberBreakTool(QgsMapTool):
             from ..utils.uuid_utils import set_feature_uuid
 
             set_feature_uuid(ev)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"could not set feature uuid: {e}")
 
         ev_layer.startEditing()
         ev_layer.addFeature(ev)

--- a/fiberq/addons/fiberq_preview.py
+++ b/fiberq/addons/fiberq_preview.py
@@ -49,8 +49,8 @@ def _http_get_json(url, user_agent, timeout_ms=15000):
     blocking = QgsBlockingNetworkRequest()
     try:
         blocking.setTimeout(timeout_ms)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Could not set network request timeout: {e}")
 
     err = blocking.get(request, forceRefresh=True)
     if err != QgsBlockingNetworkRequest.NoError:
@@ -781,7 +781,8 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                 item.setCheckState(QtCore.Qt.CheckState.Checked)
                 self.layersList.addItem(item)
 
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping preview layer that failed to load: {e}")
                 continue
 
         if layers_for_canvas:
@@ -963,7 +964,8 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                 continue
             try:
                 ext = layer.extent()
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Could not get layer extent: {e}")
                 continue
             if not ext or ext.isEmpty():
                 continue

--- a/fiberq/core/cable_manager.py
+++ b/fiberq/core/cable_manager.py
@@ -359,7 +359,8 @@ class CableManager:
                     line = g.asMultiPolyline()[0]
                 else:
                     line = g.asPolyline()
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping feature; could not read cable geometry: {e}")
                 continue
 
             if len(line) < 2:
@@ -546,7 +547,8 @@ class CableManager:
                     or lyr.name() not in candidate_names  # noqa: W503
                 ):
                     continue
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer; could not check cable layer type: {e}")
                 continue
 
             fields = lyr.fields()

--- a/fiberq/core/data_manager.py
+++ b/fiberq/core/data_manager.py
@@ -294,8 +294,8 @@ class DataManager:
             logger.debug(f"Error reading metadata from GPKG: {e}")
             try:
                 conn.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Error closing GPKG connection after read failure: {e}")
             return {}
 
     def restore_metadata_to_project(self, metadata):
@@ -414,7 +414,8 @@ class DataManager:
                     or lyr.name() not in candidate_names  # noqa: W503
                 ):
                     continue
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while listing cables: {e}")
                 continue
 
             fields = lyr.fields()
@@ -606,7 +607,8 @@ class DataManager:
                         "m": m,
                         "distance": float(d),
                     })
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while finding candidate elements: {e}")
                 continue
 
         # Sort and deduplicate

--- a/fiberq/core/drawing_manager.py
+++ b/fiberq/core/drawing_manager.py
@@ -219,7 +219,8 @@ class DrawingManager:
                 if target_base and target_base.lower() in src_norm.lower():
                     return True
 
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while checking if drawing is loaded: {e}")
                 continue
 
         return False

--- a/fiberq/core/export_manager.py
+++ b/fiberq/core/export_manager.py
@@ -617,8 +617,8 @@ class ExportManager:
             logger.debug(f"Error writing metadata table: {e}")
             try:
                 conn.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Could not close GPKG connection after error: {e}")
             return False
 
 

--- a/fiberq/core/layer_manager.py
+++ b/fiberq/core/layer_manager.py
@@ -364,7 +364,8 @@ def _ensure_region_layer(core):
                             logger.debug(f"Error in _ensure_region_layer: {e}")
                     ensure_uuid_field(lyr)
                     return lyr
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while locating region layer: {e}")
                 continue
 
         # Create new layer
@@ -422,7 +423,8 @@ def _collect_selected_geometries(core):
                     if not g or g.isEmpty():
                         continue
                     geoms.append((lyr, f, g))
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while collecting selected geometries: {e}")
                 continue
     except Exception as e:
         logger.debug(f"Error in _collect_selected_geometries: {e}")
@@ -466,7 +468,8 @@ def _create_region_from_selection(core, name: str, buf_m: float):
                     polys.append(g.buffer(buf_m, 8))
                 else:
                     polys.append(g)
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Skipping geometry while buffering selection: {e}")
             continue
 
     if not polys:
@@ -1123,7 +1126,8 @@ class LayerManager:
                     ensure_uuid_field(lyr)
                     self.move_layer_to_top(lyr)
                     return lyr
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while locating manholes layer: {e}")
                 continue
 
         # Create new layer
@@ -1361,7 +1365,8 @@ class LayerManager:
                                 logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
                         ensure_uuid_field(lyr)
                         return lyr
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"Skipping layer while locating region layer: {e}")
                     continue
 
             # Create new layer

--- a/fiberq/core/relations_manager.py
+++ b/fiberq/core/relations_manager.py
@@ -416,7 +416,8 @@ class RelationsManager:
                         "m": m,
                         "distance": float(d),
                     })
-            except Exception:
+            except Exception as e:
+                logger.debug(f"skipping layer while collecting relation candidates: {e}")
                 continue
 
         # Sort and remove duplicates

--- a/fiberq/core/route_manager.py
+++ b/fiberq/core/route_manager.py
@@ -282,8 +282,8 @@ class RouteManager:
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(route_feature)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Could not set feature uuid on route: {e}")
 
         route_layer.startEditing()
         route_layer.addFeature(route_feature)
@@ -413,8 +413,8 @@ class RouteManager:
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(feat)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Could not set feature uuid on merged route: {e}")
         route_layer.addFeature(feat)
         route_layer.commitChanges()
         self.stylize_route_layer(route_layer)
@@ -480,8 +480,8 @@ class RouteManager:
                             try:
                                 from ..utils.uuid_utils import set_feature_uuid
                                 set_feature_uuid(new_feat)
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug(f"Could not set feature uuid on imported route: {e}")
                             route_layer.addFeature(new_feat)
                             count_added += 1
             else:
@@ -502,8 +502,8 @@ class RouteManager:
                     try:
                         from ..utils.uuid_utils import set_feature_uuid
                         set_feature_uuid(new_feat)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"Could not set feature uuid on imported route: {e}")
                     route_layer.addFeature(new_feat)
                     count_added += 1
 

--- a/fiberq/core/slack_manager.py
+++ b/fiberq/core/slack_manager.py
@@ -322,8 +322,8 @@ class SlackManager:
                     try:
                         from ..utils.uuid_utils import set_feature_uuid
                         set_feature_uuid(f)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"Failed to set uuid on slack feature: {e}")
                     vl.startEditing()
                     vl.addFeature(f)
                     vl.commitChanges()

--- a/fiberq/core/undo_manager.py
+++ b/fiberq/core/undo_manager.py
@@ -117,7 +117,8 @@ def _make_description(op_type, layer_name, feature):
             if val and str(val).strip():
                 label = str(val).strip()
                 break
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Could not read field {field_name} for undo label: {e}")
             continue
 
     type_word = {

--- a/fiberq/dialogs/bom_dialog.py
+++ b/fiberq/dialogs/bom_dialog.py
@@ -142,7 +142,8 @@ class _BOMDialog(QDialog):
         for lyr in layers:
             try:
                 gtype = lyr.geometryType()
-            except Exception:
+            except Exception as e:
+                logger.debug(f"skipping layer without geometry type: {e}")
                 continue
 
             # Gather stats

--- a/fiberq/dialogs/locator_dialog.py
+++ b/fiberq/dialogs/locator_dialog.py
@@ -59,9 +59,9 @@ def _http_get_json(url, user_agent, timeout_ms=15000):
     blocking = QgsBlockingNetworkRequest()
     try:
         blocking.setTimeout(timeout_ms)
-    except Exception:
+    except Exception as e:
         # setTimeout was added later; ignore on old QGIS builds
-        pass
+        logger.debug(f"could not set network timeout: {e}")
 
     err = blocking.get(request, forceRefresh=True)
     if err != QgsBlockingNetworkRequest.NoError:

--- a/fiberq/dialogs/schematic_dialog.py
+++ b/fiberq/dialogs/schematic_dialog.py
@@ -337,7 +337,8 @@ class OpticalSchematicDialog(QDialog):
                                 "layer_name": lname,
                                 "fid": int(f.id()),
                             }
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while collecting schematic nodes: {e}")
                 continue
         return nodes
 
@@ -551,7 +552,8 @@ class OpticalSchematicDialog(QDialog):
                     ptt = tr.transform(QgsPointXY(pt.x(), pt.y()))
                     pos[name] = (ptt.x(), ptt.y())
                     world_points.append((ptt.x(), ptt.y()))
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"Skipping node without usable geometry: {e}")
                     continue
 
             # Add all points from cable/pipe geometry

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -1579,8 +1579,8 @@ class FiberQPlugin:
             if prev_slot is not None:
                 try:
                     QgsProject.instance().readProject.disconnect(prev_slot)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Could not disconnect previous schema migration slot: {e}")
             self._schema_migration_slot = (
                 lambda *args: QTimer.singleShot(1000, self._run_schema_migrations)
             )
@@ -1736,9 +1736,9 @@ class FiberQPlugin:
                     except Exception as e:
                         logger.debug(f"Error in FiberQPlugin.activate_fiber_break_tool: {e}")
 
-        except Exception:
+        except Exception as e:
             # if something fails, do not crash tool - just skip style
-            pass
+            logger.debug(f"Could not apply fiber break style: {e}")
 
         self._record_cmd('fiber_break')
 
@@ -1990,8 +1990,8 @@ class FiberQPlugin:
             slot = getattr(self, "_schema_migration_slot", None)
             if slot is not None:
                 QgsProject.instance().readProject.disconnect(slot)
-        except Exception:
-            pass  # May not be connected or already disconnected
+        except Exception as e:
+            logger.debug(f"Could not disconnect schema migration slot: {e}")
 
         # Clear undo stacks (v1.2 — Feature 2)
         try:
@@ -2077,9 +2077,9 @@ class FiberQPlugin:
             node = root.findLayer(self.layer.id())
             if node:
                 node.setCustomLayerName("Poles")
-        except Exception:
+        except Exception as e:
             # If something fails (e.g. layerTreeRoot not ready), just skip
-            pass
+            logger.debug(f"Could not set poles layer alias: {e}")
 
     def _apply_poles_field_aliases(self, layer):
         """Apply English field aliases to the poles layer.
@@ -3424,9 +3424,9 @@ def _open_fiberq_web(iface):
                 "FiberQ – pregledna mapa",
                 f"Greška pri otvaranju pregledne mape:\n{e}"
             )
-        except Exception:
+        except Exception as e:
             # if even QMessageBox fails, just ignore
-            pass
+            logger.debug(f"Could not show preview error dialog: {e}")
 
 
 # =============================================================================

--- a/fiberq/metadata.txt
+++ b/fiberq/metadata.txt
@@ -3,7 +3,7 @@ name=FiberQ
 description=Open-source fiber network design tools for QGIS (FTTH/GPON/FTTx)
 about=FiberQ helps telecom engineers and GIS professionals design, analyze, and document fiber optic networks inside QGIS. FiberQ supports QGIS 4 / Qt6 while keeping support for QGIS 3.22 LTR and later, and clears all findings from the QGIS repository security scan. Some advanced features may require an activation key.
 
-version=1.3.0
+version=1.3.1
 qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 
@@ -23,6 +23,14 @@ license=GPL-3.0-or-later
 class_name=FiberQPlugin
 
 changelog=
+    1.3.1 - Security-scan hardening (no functional change)
+        * Resolved 66 Bandit low-severity findings (B110 try/except/pass and B112
+          try/except/continue): the previously-silent exception handlers now log at
+          debug level instead of swallowing errors. No behaviour change beyond the
+          added debug logging.
+        * The local lint gate (make lint / scan-check) now runs Bandit at ALL
+          severities to match the plugins.qgis.org Security & Quality scanner.
+
     1.3.0 - Project schema versioning, safe migrations, and stable feature IDs
         * New: every FiberQ project now carries a schema-version marker, also
           mirrored into the GeoPackage, so future releases can recognise and

--- a/fiberq/models/element_defs.py
+++ b/fiberq/models/element_defs.py
@@ -353,7 +353,8 @@ def apply_element_aliases(layer) -> None:
             idx = fields.indexFromName(field_name)
             if idx != -1:
                 layer.setFieldAlias(idx, alias)
-        except Exception:
+        except Exception as e:
+            logger.debug(f"could not set alias for field {field_name}: {e}")
             continue
 
 

--- a/fiberq/tools/base.py
+++ b/fiberq/tools/base.py
@@ -180,7 +180,8 @@ def snap_to_point_layers(point, layers, tolerance):
                 if min_dist is None or d < min_dist:
                     min_dist = d
                     snapped_point = QgsPointXY(pt)
-            except Exception:
+            except Exception as e:
+                logger.debug(f"could not compute distance to snap point: {e}")
                 continue
 
     if snapped_point and min_dist is not None and min_dist <= tolerance:

--- a/fiberq/tools/breakpoint_tool.py
+++ b/fiberq/tools/breakpoint_tool.py
@@ -212,8 +212,8 @@ class BreakpointTool(QgsMapToolEmitPoint):
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(feat1)
             set_feature_uuid(feat2)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"could not set uuid on new route segments: {e}")
 
         route_layer.addFeatures([feat1, feat2])
         route_layer.commitChanges()

--- a/fiberq/tools/element_tool.py
+++ b/fiberq/tools/element_tool.py
@@ -124,7 +124,8 @@ class PlaceElementTool(QgsMapToolEmitPoint):
                     continue
                 try:
                     pt = geom.asPoint()
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"skipping node without point geometry: {e}")
                     continue
                 d = QgsPointXY(point).distance(QgsPointXY(pt))
                 if min_dist is None or d < min_dist:

--- a/fiberq/tools/extension_tool.py
+++ b/fiberq/tools/extension_tool.py
@@ -131,9 +131,9 @@ class ExtensionTool(QgsMapToolEmitPoint):
                         for v in geom.vertices():
                             consider(v)
 
-            except Exception:
+            except Exception as e:
                 # if any layer fails, skip it
-                pass
+                logger.debug(f"Skipping layer during snap candidate search: {e}")
 
         if snap_point is not None and min_dist is not None and min_dist < tol:
             return snap_point
@@ -203,8 +203,8 @@ class ExtensionTool(QgsMapToolEmitPoint):
                 try:
                     from ..utils.uuid_utils import ensure_uuid_field
                     ensure_uuid_field(nastavak_layer)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Could not ensure UUID field on joint closure layer: {e}")
                 break
 
         # 2) If doesn't exist – create new
@@ -284,8 +284,8 @@ class ExtensionTool(QgsMapToolEmitPoint):
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(nastavak_feat)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Could not set UUID on joint closure feature: {e}")
 
         nastavak_layer.startEditing()
         nastavak_layer.addFeature(nastavak_feat)

--- a/fiberq/tools/object_tools.py
+++ b/fiberq/tools/object_tools.py
@@ -152,8 +152,8 @@ class _BaseObjMapTool(QgsMapTool):
             try:
                 from ..utils.uuid_utils import set_feature_uuid
                 set_feature_uuid(f)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Could not set feature uuid: {e}")
 
             obj_layer.addFeature(f)
 

--- a/fiberq/tools/point_tool.py
+++ b/fiberq/tools/point_tool.py
@@ -129,8 +129,8 @@ class PointTool(QgsMapToolEmitPoint):
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(feature)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Could not set feature uuid on pole: {e}")
         self.layer.startEditing()
         self.layer.addFeature(feature)
         self.layer.commitChanges()
@@ -141,8 +141,8 @@ class PointTool(QgsMapToolEmitPoint):
         try:
             if hasattr(self, 'plugin') and self.plugin and hasattr(self.plugin, 'undo_manager') and self.plugin.undo_manager:
                 self.plugin.undo_manager.record_add(self.layer, feature)
-        except Exception:
-            pass  # PointTool may not always have plugin reference
+        except Exception as e:
+            logger.debug(f"Could not record undo for added pole (plugin ref may be missing): {e}")
 
 
 __all__ = ['PointTool']

--- a/fiberq/tools/region_tool.py
+++ b/fiberq/tools/region_tool.py
@@ -171,8 +171,8 @@ class DrawRegionPolygonTool(QgsMapTool):
             try:
                 from ..utils.uuid_utils import set_feature_uuid
                 set_feature_uuid(f)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to set uuid on region feature: {e}")
             region.addFeature(f)
             region.commitChanges()
             region.triggerRepaint()

--- a/fiberq/tools/route_tool.py
+++ b/fiberq/tools/route_tool.py
@@ -108,7 +108,8 @@ class ManualRouteTool(QgsMapTool):
                     if min_dist is None or d < min_dist:
                         min_dist = d
                         snap_point = QgsPointXY(pt)
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"could not compute distance to snap point: {e}")
                     continue
 
         # Snap to existing routes (vertices and segment midpoints)
@@ -295,8 +296,8 @@ class ManualRouteTool(QgsMapTool):
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(feat)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"failed to set uuid on route feature: {e}")
         route_layer.addFeature(feat)
         route_layer.commitChanges()
 

--- a/fiberq/tools/select_tool.py
+++ b/fiberq/tools/select_tool.py
@@ -117,7 +117,8 @@ class SmartMultiSelectTool(QgsMapTool):
                 d = geom.distance(gpt)
                 if d <= tol and (best[0] is None or d < best[0]):
                     best = (d, f.id(), geom)
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping feature; could not compute distance: {e}")
                 continue
         return (best[1], best[2]) if best[1] is not None else (None, None)
 
@@ -304,7 +305,8 @@ class SmartMultiSelectTool(QgsMapTool):
                     elif gtype == QgsWkbTypes.PolygonGeometry:
                         if name in valid_poly_names or lname in low_poly:
                             layers.append(lyr)
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"Skipping layer during smart-select classification: {e}")
                     continue
 
             return layers

--- a/fiberq/tools/slack_tool.py
+++ b/fiberq/tools/slack_tool.py
@@ -239,8 +239,8 @@ class SlackPlaceTool(QgsMapTool):
         try:
             from ..utils.uuid_utils import set_feature_uuid
             set_feature_uuid(f)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to set uuid on slack feature: {e}")
 
         vl.startEditing()
         vl.addFeature(f)

--- a/fiberq/ui/objects_ui.py
+++ b/fiberq/ui/objects_ui.py
@@ -128,8 +128,8 @@ class ObjectsUI:
             try:
                 from ..utils.uuid_utils import set_feature_uuid
                 set_feature_uuid(f)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Could not set feature uuid: {e}")
             obj.addFeature(f)
             obj.commitChanges()
             _stylize_objects_layer(obj)

--- a/fiberq/ui/quick_toolbar.py
+++ b/fiberq/ui/quick_toolbar.py
@@ -313,8 +313,8 @@ class QuickToolbar:
                 slack_action = getattr(self.core, 'action_slack_quick', None)
                 if slack_action:
                     slack_action.setShortcut(QKeySequence('R'))
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Could not restore slack 'R' shortcut: {e}")
 
         QgsSettings().setValue(SETTING_ENABLE_SHORTCUTS,
                                'true' if enabled else 'false')
@@ -337,8 +337,8 @@ class QuickToolbar:
             for _, action in self._actions:
                 try:
                     self.iface.removeToolBarIcon(action)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Error removing quick toolbar icon: {e}")
             self._actions.clear()
         except Exception as e:
             logger.debug(f"Error removing quick toolbar actions: {e}")

--- a/fiberq/utils/helpers.py
+++ b/fiberq/utils/helpers.py
@@ -388,7 +388,8 @@ def apply_field_aliases(
             if idx != -1:
                 layer.setFieldAlias(idx, alias)
                 applied_count += 1
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Could not set alias for field {field_name}: {e}")
             continue
 
     return applied_count

--- a/fiberq/utils/legacy_bridge.py
+++ b/fiberq/utils/legacy_bridge.py
@@ -197,9 +197,9 @@ def _apply_fixed_text_label(layer, field_name='naziv', size_mu=8.0, yoff_mu=5.0)
         layer.setLabeling(QgsVectorLayerSimpleLabeling(s))
         layer.setLabelsEnabled(True)
         layer.triggerRepaint()
-    except Exception:
+    except Exception as e:
         # Do not crash the plugin if labeling fails on some older QGIS.
-        pass
+        logger.debug(f"Could not apply fixed text label: {e}")
 
 
 ELEMENT_DEFS = [
@@ -248,8 +248,8 @@ def _img_set(layer, fid, path):
     """Set image path for a feature."""
     try:
         QgsProject.instance().writeEntry("FiberQPlugin", _img_key(layer, fid), path or "")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Could not write image path entry: {e}")
 
 
 def _set_objects_layer_alias(layer):
@@ -299,7 +299,8 @@ def _ensure_region_layer(core):
                     except Exception as e:
                         logger.debug(f"Error ensuring fiberq_uuid on Service Area layer: {e}")
                     return lyr
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Skipping layer while ensuring region layer: {e}")
                 continue
 
         # 2) If doesn't exist – create new layer named 'Service Area'

--- a/fiberq/utils/uuid_utils.py
+++ b/fiberq/utils/uuid_utils.py
@@ -98,11 +98,13 @@ def _log(msg):
     try:
         logger.debug(msg)
     except Exception:
-        pass
+        # best-effort logging; nothing to fall back to
+        pass  # nosec B110
     try:
         QgsMessageLog.logMessage(msg, "FiberQ UUID", Qgis.MessageLevel.Info)
     except Exception:
-        pass
+        # best-effort logging; nothing to fall back to
+        pass  # nosec B110
 
 
 def generate_uuid() -> str:
@@ -155,8 +157,8 @@ def _set_uuid_alias(layer):
         idx = layer.fields().indexOf(FIBERQ_UUID_FIELD)
         if idx >= 0 and layer.attributeAlias(idx) != FIBERQ_UUID_ALIAS:
             layer.setFieldAlias(idx, FIBERQ_UUID_ALIAS)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"could not set fiberq_uuid display alias: {e}")
 
 
 def ensure_uuid_field(layer):
@@ -245,8 +247,8 @@ def ensure_uuid_field(layer):
             try:
                 if layer.isEditable():
                     layer.rollBack()
-            except Exception:
-                pass
+            except Exception as rollback_err:
+                logger.debug(f"rollback after Method 2 failure raised: {rollback_err}")
 
         _log(f"ensure_uuid_field: ALL METHODS FAILED for '{layer.name()}'")
         return False
@@ -322,8 +324,8 @@ def migrate_layer_uuids(layer):
         try:
             if layer.isEditable():
                 layer.rollBack()
-        except Exception:
-            pass
+        except Exception as rollback_err:
+            logger.debug(f"rollback after persist failure raised: {rollback_err}")
         raise UuidMigrationError(f"error persisting UUIDs in '{layer.name()}': {e}")
 
     _log(f"Migrated {count} features with UUID in layer '{layer.name()}'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ show_missing = true
 skip_empty = true
 
 [tool.bandit]
-# Severity threshold is set on the CLI (-ll = medium/high), matching the
-# plugins.qgis.org scan. List B-IDs here only if a finding ever needs skipping.
+# No severity threshold on the CLI — the plugins.qgis.org scanner runs ALL
+# severities (it blocks on LOW findings like B110/B112). List B-IDs here only if
+# a finding ever needs skipping. Prefer an inline `# nosec Bxxx` with a reason.
 exclude_dirs = ["tests", "build", "dist", ".venv"]


### PR DESCRIPTION
plugins.qgis.org **blocked v1.3.0** — its Security & Quality scanner runs Bandit at **all severities** and found **66 LOW-severity** findings: **B110** (try/except/pass ×38) and **B112** (try/except/continue ×28). Secrets ✅ and flake8 ✅ both passed. Our gate used `bandit -ll` (medium/high only), so CI never saw these.

## Fix
- Added `logger.debug(...)` to each previously-silent handler so the `except` body is no longer a bare `pass`/`continue` — clears B110/B112 **and** advances the WP4 goal of not swallowing errors. Control flow preserved exactly (every `continue`/`return`/`break` kept; try bodies untouched). 3 logging-internal handlers keep `pass` with a justified `# nosec`.
- **Hardened the gate**: `make bandit`, `scan-check`, and `pyproject.toml` now run Bandit at **all severities** to match the QGIS scanner.
- Bump **1.3.0 → 1.3.1**.

## Verification
- Bandit (all severities): **0** · flake8: **0** · `py_compile`: OK on all 36 files.
- Not blocking, tracked separately: the Qt6 Check (251 unscoped-enum errors) is informational, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)