### PR TITLE
fix(qt6): scope 251 QGIS enum accesses (v1.3.0)

### DIFF
--- a/fiberq/__init__.py
+++ b/fiberq/__init__.py
@@ -124,7 +124,7 @@ class _FiberQStub:
 # PACKAGE INFO
 # =============================================================================
 
-__version__ = "1.3.1"
+__version__ = "1.3.0"
 __author__ = "Vladimir Vukovic"
 __email__ = "vukovicvl@fiberq.net"
 __license__ = "GPL-3.0-or-later"

--- a/fiberq/addons/fiber_break.py
+++ b/fiberq/addons/fiber_break.py
@@ -40,7 +40,7 @@ class FiberBreakTool(QgsMapTool):
         self.iface = iface
         self.canvas = iface.mapCanvas()
         self.snap_marker = QgsVertexMarker(self.canvas)
-        self.snap_marker.setIconType(QgsVertexMarker.ICON_CROSS)
+        self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
         self.snap_marker.setPenWidth(2)
         self.snap_marker.setIconSize(12)
         self.snap_marker.hide()
@@ -107,13 +107,13 @@ class FiberBreakTool(QgsMapTool):
 
         try:
             marker = QgsSimpleMarkerSymbolLayer()
-            marker.setShape(QgsSimpleMarkerSymbolLayer.Circle)
+            marker.setShape(QgsSimpleMarkerSymbolLayer.Shape.Circle)
             marker.setSize(2.4)
-            marker.setSizeUnit(QgsUnitTypes.RenderMillimeters)
+            marker.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
             marker.setColor(QColor(0, 0, 0))
             marker.setOutlineColor(QColor(0, 0, 0))
             marker.setOutlineWidth(0.2)
-            marker.setOutlineWidthUnit(QgsUnitTypes.RenderMillimeters)
+            marker.setOutlineWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
 
             sym = QgsMarkerSymbol()
             sym.changeSymbolLayer(0, marker)
@@ -144,7 +144,7 @@ class FiberBreakTool(QgsMapTool):
             try:
                 is_break_layer = (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry  # noqa: W503
                     and lyr.name() in ("Prekid vlakna", "Fiber break")  # noqa: W503
                 )
                 if not is_break_layer:
@@ -197,7 +197,7 @@ class FiberBreakTool(QgsMapTool):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     and lyr.isValid()  # noqa: W503
                 ):
                     yield lyr

--- a/fiberq/addons/fiberq_preview.py
+++ b/fiberq/addons/fiberq_preview.py
@@ -53,7 +53,7 @@ def _http_get_json(url, user_agent, timeout_ms=15000):
         logger.debug(f"Could not set network request timeout: {e}")
 
     err = blocking.get(request, forceRefresh=True)
-    if err != QgsBlockingNetworkRequest.NoError:
+    if err != QgsBlockingNetworkRequest.ErrorCode.NoError:
         raise RuntimeError(blocking.errorMessage() or "Network request failed")
 
     reply = blocking.reply()
@@ -141,7 +141,7 @@ class RectSelectTool(QgsMapTool):
     def canvasPressEvent(self, event):
         self.start_point = self.toMapCoordinates(event.pos())
         if self.rubber is None:
-            self.rubber = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+            self.rubber = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.PolygonGeometry)
             self.rubber.setFillColor(QtCore.Qt.GlobalColor.transparent)
             self.rubber.setStrokeColor(QtCore.Qt.GlobalColor.red)
             self.rubber.setWidth(1)
@@ -190,7 +190,7 @@ class RectSelectTool(QgsMapTool):
             QgsPointXY(x_max, y_min),
             QgsPointXY(x_min, y_min),
         ]
-        self.rubber.reset(QgsWkbTypes.PolygonGeometry)
+        self.rubber.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
         for pt in points:
             self.rubber.addPoint(pt, False)
         self.rubber.addPoint(points[0], True)
@@ -824,12 +824,12 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
                 if hasattr(QgsPalLayerSettings, 'LinePlacement') and hasattr(QgsPalLayerSettings.LinePlacement, 'AboveLine'):
                     s.placement = QgsPalLayerSettings.LinePlacement.AboveLine
                 elif hasattr(QgsPalLayerSettings, 'Line'):
-                    s.placement = QgsPalLayerSettings.Line
+                    s.placement = QgsPalLayerSettings.Placement.Line
             except Exception as e:
                 logger.debug(f"Error in FiberQPreviewDialog._apply_preview_cable_labels: {e}")
             tf = QgsTextFormat()
             tf.setSize(8.0)
-            tf.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+            tf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
 
             tf.setColor(QColor(200, 0, 0))
 
@@ -872,18 +872,18 @@ class FiberQPreviewDialog(QtWidgets.QDialog):
             try:
                 s.xOffset = 0.0
                 s.yOffset = 5.0
-                s.offsetUnits = QgsUnitTypes.RenderMapUnits
+                s.offsetUnits = QgsUnitTypes.RenderUnit.RenderMapUnits
             except Exception as e:
                 logger.debug(f"Error in FiberQPreviewDialog._apply_preview_manhole_labels: {e}")
             tf = QgsTextFormat()
             tf.setSize(7.0)
-            tf.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+            tf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             tf.setColor(QColor(0, 0, 0))
 
             buf = QgsTextBufferSettings()
             buf.setEnabled(True)
             try:
-                buf.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                buf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             except Exception as e:
                 logger.debug(f"Error in FiberQPreviewDialog._apply_preview_manhole_labels: {e}")
             buf.setSize(0.8)

--- a/fiberq/addons/infrastructure_cut.py
+++ b/fiberq/addons/infrastructure_cut.py
@@ -42,7 +42,7 @@ class InfrastructureCutTool(QgsMapTool):
         # Marker for live snap preview
         self._marker = QgsVertexMarker(self.canvas)
         self._marker.setColor(QColor(255, 0, 0))
-        self._marker.setIconType(QgsVertexMarker.ICON_CROSS)
+        self._marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
         self._marker.setPenWidth(2)
         self._marker.setIconSize(12)
         self._marker.hide()
@@ -64,12 +64,12 @@ class InfrastructureCutTool(QgsMapTool):
         """Yield eligible line layers, preferring active layer first if valid."""
         layers = []
         al = self.iface.activeLayer()
-        if isinstance(al, QgsVectorLayer) and al.geometryType() == QgsWkbTypes.LineGeometry:
+        if isinstance(al, QgsVectorLayer) and al.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
             layers.append(al)
         for lyr in QgsProject.instance().mapLayers().values():
             if not isinstance(lyr, QgsVectorLayer):
                 continue
-            if lyr.geometryType() != QgsWkbTypes.LineGeometry:
+            if lyr.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
                 continue
             if lyr is al:
                 continue
@@ -79,7 +79,7 @@ class InfrastructureCutTool(QgsMapTool):
         # Fallback: include all other line layers if nothing matched hints
         if not layers:
             for lyr in QgsProject.instance().mapLayers().values():
-                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.LineGeometry:
+                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
                     layers.append(lyr)
         return layers
 
@@ -118,7 +118,7 @@ class InfrastructureCutTool(QgsMapTool):
             if not lyr.isValid():
                 continue
             rect = QgsRectangle(map_pt.x() - tol, map_pt.y() - tol, map_pt.x() + tol, map_pt.y() + tol)
-            req = QgsFeatureRequest().setFilterRect(rect).setFlags(QgsFeatureRequest.ExactIntersect)
+            req = QgsFeatureRequest().setFilterRect(rect).setFlags(QgsFeatureRequest.Flag.ExactIntersect)
             for f in lyr.getFeatures(req):
                 g = f.geometry()
                 if not g or g.isEmpty():
@@ -208,7 +208,7 @@ class InfrastructureCutTool(QgsMapTool):
         else:
             layer, feat, cp = self._last_preview_layer, self._last_preview_feat, self._last_preview_point
 
-        if not isinstance(layer, QgsVectorLayer) or layer.geometryType() != QgsWkbTypes.LineGeometry:
+        if not isinstance(layer, QgsVectorLayer) or layer.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
             self._flash("Active layer is not a line layer.")
             return
 
@@ -355,7 +355,7 @@ class InfrastructureCutTool(QgsMapTool):
             logger.debug(f"Error in InfrastructureCutTool._norm: {e}")
         L = da.measureLength(feat.geometry())
         try:
-            L = da.convertLengthMeasurement(L, QgsUnitTypes.DistanceMeters)
+            L = da.convertLengthMeasurement(L, QgsUnitTypes.DistanceUnit.DistanceMeters)
         except Exception as e:
             logger.debug(f"Error in InfrastructureCutTool._norm: {e}")
         val_m = round(float(L or 0.0), 3)

--- a/fiberq/addons/reserve_hook.py
+++ b/fiberq/addons/reserve_hook.py
@@ -28,7 +28,7 @@ class ReserveHook(QObject):
             return
         for l in QgsProject.instance().mapLayers().values():  # noqa: E741
             try:
-                if isinstance(l, QgsVectorLayer) and l.geometryType() == QgsWkbTypes.PointGeometry and l.name().lower().startswith('opticke_rezerve'):
+                if isinstance(l, QgsVectorLayer) and l.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and l.name().lower().startswith('opticke_rezerve'):
                     self._connect_layer(l)
                     self._connected = True
             except Exception as e:
@@ -37,7 +37,7 @@ class ReserveHook(QObject):
     def _layers_added(self, layers):
         try:
             for l in layers:  # noqa: E741
-                if isinstance(l, QgsVectorLayer) and l.geometryType() == QgsWkbTypes.PointGeometry and l.name().lower().startswith('opticke_rezerve'):
+                if isinstance(l, QgsVectorLayer) and l.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and l.name().lower().startswith('opticke_rezerve'):
                     self._connect_layer(l)
         except Exception as e:
             logger.debug(f"Error in ReserveHook._layers_added: {e}")
@@ -79,7 +79,7 @@ class ReserveHook(QObject):
         return os.path.abspath(base)
 
     def _apply_style(self, rez: QgsVectorLayer):
-        if not isinstance(rez, QgsVectorLayer) or rez.geometryType() != QgsWkbTypes.PointGeometry:
+        if not isinstance(rez, QgsVectorLayer) or rez.geometryType() != QgsWkbTypes.GeometryType.PointGeometry:
             return
         field = 'tip' if rez.fields().indexFromName('tip') != -1 else None
         if not field:
@@ -92,12 +92,12 @@ class ReserveHook(QObject):
                 path = os.path.join(self._icons_dir(), svg_name)
                 if os.path.exists(path):
                     sl = QgsSvgMarkerSymbolLayer(path, 12, 0)
-                    sl.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                    sl.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
                     s.changeSymbolLayer(0, sl)
                 else:
-                    s.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                    s.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             except Exception:
-                s.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                s.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             return s
         cats = [
             QgsRendererCategory('zavrsna', _svg_symbol('map_rezerva_c.svg'), 'Završna'),

--- a/fiberq/core/cable_manager.py
+++ b/fiberq/core/cable_manager.py
@@ -214,13 +214,13 @@ class CableManager:
 
         # Fallback: inline implementation
         base_width = 0.8
-        base_unit = QgsUnitTypes.RenderMetersInMapUnits
+        base_unit = QgsUnitTypes.RenderUnit.RenderMetersInMapUnits
         try:
             route_layer = next(
                 (
                     lyr for lyr in QgsProject.instance().mapLayers().values()
                     if lyr.name().lower().strip() in ("trasa", "route")
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                 ),
                 None
             )
@@ -285,7 +285,7 @@ class CableManager:
                 if hasattr(QgsPalLayerSettings, 'LinePlacement') and hasattr(QgsPalLayerSettings.LinePlacement, 'AboveLine'):
                     s.placement = QgsPalLayerSettings.LinePlacement.AboveLine
                 elif hasattr(QgsPalLayerSettings, 'Line'):
-                    s.placement = QgsPalLayerSettings.Line
+                    s.placement = QgsPalLayerSettings.Placement.Line
             except Exception as e:
                 logger.debug(f"Error in CableManager.stylize_cable_layer: {e}")
 
@@ -338,7 +338,7 @@ class CableManager:
         Returns:
             Tuple of (groups_count, updated_count)
         """
-        if layer is None or layer.geometryType() != QgsWkbTypes.LineGeometry:
+        if layer is None or layer.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
             return 0, 0
 
         tol_units = float(tol_m)
@@ -424,7 +424,7 @@ class CableManager:
         # Fallback: inline implementation
         if layer is None or layer.renderer() is None:
             return
-        if layer.geometryType() != QgsWkbTypes.LineGeometry:
+        if layer.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
             return
 
         renderer = layer.renderer()
@@ -437,7 +437,7 @@ class CableManager:
                 for sl in sym.symbolLayers():
                     try:
                         if hasattr(sl, "setOffsetUnit"):
-                            sl.setOffsetUnit(QgsUnitTypes.RenderMillimeters)
+                            sl.setOffsetUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
                         if hasattr(sl, "setOffset"):
                             sl.setOffset(0.0)
                     except Exception as e:
@@ -489,7 +489,7 @@ class CableManager:
             layer = None
 
         if not (layer and isinstance(layer, QgsVectorLayer)
-                and layer.geometryType() == QgsWkbTypes.LineGeometry):  # noqa: W503
+                and layer.geometryType() == QgsWkbTypes.GeometryType.LineGeometry):  # noqa: W503
             try:
                 self.iface.messageBar().pushWarning(
                     "Branch cables",
@@ -543,7 +543,7 @@ class CableManager:
             try:
                 if (
                     not isinstance(lyr, QgsVectorLayer)
-                    or lyr.geometryType() != QgsWkbTypes.LineGeometry  # noqa: W503
+                    or lyr.geometryType() != QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     or lyr.name() not in candidate_names  # noqa: W503
                 ):
                     continue
@@ -621,7 +621,7 @@ class CableManager:
         relevant_names = [NASTAVAK_DEF['name']] + [d['name'] for d in ELEMENT_DEFS] + ['Poles', 'Stubovi', 'OKNA', 'Manholes']
         selected = []
         for lyr in QgsProject.instance().mapLayers().values():
-            if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry and lyr.name() in relevant_names:
+            if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and lyr.name() in relevant_names:
                 feats = lyr.selectedFeatures()
                 for f in feats:
                     selected.append((lyr, f))
@@ -633,7 +633,7 @@ class CableManager:
         # Find route layer
         route_layer = None
         for lyr in QgsProject.instance().mapLayers().values():
-            if lyr.name() in ('Route', 'Trasa') and lyr.geometryType() == QgsWkbTypes.LineGeometry:
+            if lyr.name() in ('Route', 'Trasa') and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
                 route_layer = lyr
                 break
         if route_layer is None or route_layer.featureCount() == 0:
@@ -717,7 +717,7 @@ class CableManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     and lyr.name() in candidate_names  # noqa: W503
                 ):
                     cables_layer = lyr
@@ -846,7 +846,7 @@ class CableManager:
         cable_geom = None
         for feat in route_layer.getFeatures():
             geom = feat.geometry()
-            if geom.type() != QgsWkbTypes.LineGeometry:
+            if geom.type() != QgsWkbTypes.GeometryType.LineGeometry:
                 continue
             line = geom.asPolyline()
             if not line:

--- a/fiberq/core/data_manager.py
+++ b/fiberq/core/data_manager.py
@@ -410,7 +410,7 @@ class DataManager:
             try:
                 if (
                     not isinstance(lyr, QgsVectorLayer)
-                    or lyr.geometryType() != QgsWkbTypes.LineGeometry  # noqa: W503
+                    or lyr.geometryType() != QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     or lyr.name() not in candidate_names  # noqa: W503
                 ):
                     continue
@@ -482,7 +482,7 @@ class DataManager:
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                         and lyr.name() in pipe_names):  # noqa: W503
                     layers.append(lyr)
             except Exception as e:
@@ -563,7 +563,7 @@ class DataManager:
         cands = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if lyr.geometryType() != QgsWkbTypes.PointGeometry:
+                if lyr.geometryType() != QgsWkbTypes.GeometryType.PointGeometry:
                     continue
 
                 # Issue #5: Only include layers from "Placing elements"

--- a/fiberq/core/export_manager.py
+++ b/fiberq/core/export_manager.py
@@ -217,7 +217,7 @@ class ExportManager:
             res = result
             err_message = ""
 
-        if res != QgsVectorFileWriter.NoError:
+        if res != QgsVectorFileWriter.WriterError.NoError:
             QMessageBox.critical(
                 self.iface.mainWindow(),
                 "Export",
@@ -302,9 +302,9 @@ class ExportManager:
                 opts.driverName = "GPKG"
                 opts.layerName = name
                 opts.actionOnExistingFile = (
-                    QgsVectorFileWriter.CreateOrOverwriteLayer
+                    QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteLayer
                     if os.path.exists(gpkg_path)
-                    else QgsVectorFileWriter.CreateOrOverwriteFile
+                    else QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteFile
                 )
 
                 result = QgsVectorFileWriter.writeAsVectorFormatV3(
@@ -318,7 +318,7 @@ class ExportManager:
                     err_code = result
                     err_msg = ""
 
-                if err_code != QgsVectorFileWriter.NoError:
+                if err_code != QgsVectorFileWriter.WriterError.NoError:
                     errors.append(f"{lyr.name()}: {err_msg}")
                     continue
 
@@ -392,9 +392,9 @@ class ExportManager:
         opts.driverName = "GPKG"
         opts.layerName = name
         opts.actionOnExistingFile = (
-            QgsVectorFileWriter.CreateOrOverwriteLayer
+            QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteLayer
             if os.path.exists(gpkg_path)
-            else QgsVectorFileWriter.CreateOrOverwriteFile
+            else QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteFile
         )
 
         try:
@@ -414,7 +414,7 @@ class ExportManager:
             err_code = result
             err_msg = ""
 
-        if err_code != QgsVectorFileWriter.NoError:
+        if err_code != QgsVectorFileWriter.WriterError.NoError:
             try:
                 self.iface.messageBar().pushWarning(
                     "GPKG export",

--- a/fiberq/core/layer_manager.py
+++ b/fiberq/core/layer_manager.py
@@ -109,14 +109,14 @@ def _apply_fixed_text_label(layer, field_name='naziv', size_mu=8.0, yoff_mu=5.0)
         try:
             s.xOffset = 0.0
             s.yOffset = float(yoff_mu)
-            s.offsetUnits = QgsUnitTypes.RenderMapUnits
+            s.offsetUnits = QgsUnitTypes.RenderUnit.RenderMapUnits
         except Exception as e:
             logger.debug(f"Could not set label offset: {e}")
 
         tf = QgsTextFormat()
         try:
             tf.setSize(float(size_mu))
-            tf.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+            tf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
         except Exception as e:
             logger.debug(f"Could not set text format size: {e}")
 
@@ -171,7 +171,7 @@ def _ensure_element_layer_with_style(plugin, layer_name: str):
     elem_layer = None
     for lyr in QgsProject.instance().mapLayers().values():
         try:
-            if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry and lyr.name() == layer_name:
+            if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and lyr.name() == layer_name:
                 elem_layer = lyr
                 break
         except Exception as e:
@@ -222,9 +222,9 @@ def _ensure_element_layer_with_style(plugin, layer_name: str):
                 except Exception as e:
                     logger.debug(f"Error in element layer creation: {e}")
                 try:
-                    svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                    svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
                 except Exception:
-                    svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                    svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
                 symbol.changeSymbolLayer(0, svg_layer)
             except Exception as e:
                 logger.debug(f"Error in element layer creation: {e}")
@@ -353,7 +353,7 @@ def _ensure_region_layer(core):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PolygonGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.PolygonGeometry  # noqa: W503
                     and lyr.name() in ('Rejon', 'Service Area')  # noqa: W503
                 ):
                     # Rename old 'Rejon' to 'Service Area'
@@ -458,7 +458,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
         try:
             g = QgsGeometry(g)  # copy
             gtype = lyr.geometryType()
-            if gtype in (QgsWkbTypes.PointGeometry, QgsWkbTypes.LineGeometry):
+            if gtype in (QgsWkbTypes.GeometryType.PointGeometry, QgsWkbTypes.GeometryType.LineGeometry):
                 if buf_m > 0:
                     polys.append(g.buffer(buf_m, 8))
                 else:
@@ -501,7 +501,7 @@ def _create_region_from_selection(core, name: str, buf_m: float):
         return False
 
     # Ensure polygon geometry
-    if u.type() != QgsWkbTypes.PolygonGeometry:
+    if u.type() != QgsWkbTypes.GeometryType.PolygonGeometry:
         try:
             u = u.buffer(0.01, 8)
         except Exception as e:
@@ -626,10 +626,10 @@ def _ensure_objects_layer(core):
                 if (
                     isinstance(lyr, QgsVectorLayer)
                     and lyr.wkbType() in (  # noqa: W503
-                        QgsWkbTypes.Polygon,
-                        QgsWkbTypes.MultiPolygon,
-                        QgsWkbTypes.PolygonZM,
-                        QgsWkbTypes.MultiPolygonZM,
+                        QgsWkbTypes.Type.Polygon,
+                        QgsWkbTypes.Type.MultiPolygon,
+                        QgsWkbTypes.Type.PolygonZM,
+                        QgsWkbTypes.Type.MultiPolygonZM,
                     )
                     and lyr.name() in ("Objekti", "Objects")  # noqa: W503
                 ):
@@ -683,7 +683,7 @@ def _stylize_objects_layer(layer):
         simple.setFillColor(QColor(0, 0, 0, 0))
         simple.setStrokeColor(QColor(0, 0, 0))
         simple.setStrokeWidth(0.8)
-        simple.setStrokeWidthUnit(QgsUnitTypes.RenderMillimeters)
+        simple.setStrokeWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
 
         hatch = QgsLinePatternFillSymbolLayer()
         try:
@@ -697,7 +697,7 @@ def _stylize_objects_layer(layer):
         except Exception as e:
             logger.debug(f"Error in _stylize_objects_layer: {e}")
         hatch.setDistance(2.2)
-        hatch.setDistanceUnit(QgsUnitTypes.RenderMillimeters)
+        hatch.setDistanceUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
         try:
             sub = hatch.subSymbol()
             if sub and sub.symbolLayerCount() > 0:
@@ -708,7 +708,7 @@ def _stylize_objects_layer(layer):
                     logger.debug(f"Error in _stylize_objects_layer: {e}")
                 try:
                     sl.setWidth(0.3)
-                    sl.setWidthUnit(QgsUnitTypes.RenderMillimeters)
+                    sl.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
                 except Exception as e:
                     logger.debug(f"Error in _stylize_objects_layer: {e}")
         except Exception as e:
@@ -798,9 +798,9 @@ def _telecom_save_all_layers_to_gpkg(iface):
             opts.driverName = "GPKG"
             opts.layerName = name
             opts.actionOnExistingFile = (
-                QgsVectorFileWriter.CreateOrOverwriteLayer
+                QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteLayer
                 if os.path.exists(gpkg_path)
-                else QgsVectorFileWriter.CreateOrOverwriteFile
+                else QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteFile
             )
 
             result = QgsVectorFileWriter.writeAsVectorFormatV3(
@@ -813,7 +813,7 @@ def _telecom_save_all_layers_to_gpkg(iface):
                 err_code = result
                 err_msg = ""
 
-            if err_code != QgsVectorFileWriter.NoError:
+            if err_code != QgsVectorFileWriter.WriterError.NoError:
                 errors.append(f"{lyr.name()}: {err_msg}")
                 continue
 
@@ -877,9 +877,9 @@ def _telecom_export_one_layer_to_gpkg(lyr, gpkg_path, iface):
     opts.driverName = "GPKG"
     opts.layerName = name
     opts.actionOnExistingFile = (
-        QgsVectorFileWriter.CreateOrOverwriteLayer
+        QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteLayer
         if os.path.exists(gpkg_path)
-        else QgsVectorFileWriter.CreateOrOverwriteFile
+        else QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteFile
     )
 
     try:
@@ -898,7 +898,7 @@ def _telecom_export_one_layer_to_gpkg(lyr, gpkg_path, iface):
         err_code = result
         err_msg = ""
 
-    if err_code != QgsVectorFileWriter.NoError:
+    if err_code != QgsVectorFileWriter.WriterError.NoError:
         try:
             iface.messageBar().pushWarning("GPKG export", f"{lyr.name()}: {err_msg}")
         except Exception as e:
@@ -980,7 +980,7 @@ class LayerManager:
         for lyr in project.mapLayers().values():
             if (
                 isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                 lyr.name() in ("Poles", "Stubovi")
             ):
                 self._apply_poles_aliases(lyr)
@@ -1008,7 +1008,7 @@ class LayerManager:
             symbol = QgsSymbol.defaultSymbol(layer.geometryType())
             symbol_layer = symbol.symbolLayer(0)
             symbol_layer.setSize(10)
-            symbol_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            symbol_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
             layer.renderer().setSymbol(symbol)
             layer.triggerRepaint()
         except Exception as e:
@@ -1043,7 +1043,7 @@ class LayerManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry  # noqa: W503
                     and lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")  # noqa: W503
                 ):
                     self._apply_slack_aliases(lyr)
@@ -1094,7 +1094,7 @@ class LayerManager:
             except Exception as e:
                 logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
             try:
-                sym.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                sym.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             except Exception as e:
                 logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
 
@@ -1121,7 +1121,7 @@ class LayerManager:
         for lyr in project.mapLayers().values():
             try:
                 name = lyr.name().strip()
-                if name in ("OKNA", "Manholes") and lyr.geometryType() == QgsWkbTypes.PointGeometry:
+                if name in ("OKNA", "Manholes") and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry:
                     self._apply_manholes_aliases(lyr)
                     ensure_uuid_field(lyr)
                     self.move_layer_to_top(lyr)
@@ -1236,7 +1236,7 @@ class LayerManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     and lyr.name() in target_names  # noqa: W503
                 ):
                     self._apply_pipe_aliases(lyr)
@@ -1355,7 +1355,7 @@ class LayerManager:
                 try:
                     if (
                         isinstance(lyr, QgsVectorLayer)
-                        and lyr.geometryType() == QgsWkbTypes.PolygonGeometry  # noqa: W503
+                        and lyr.geometryType() == QgsWkbTypes.GeometryType.PolygonGeometry  # noqa: W503
                         and lyr.name() in ('Rejon', 'Service Area')  # noqa: W503
                     ):
                         if lyr.name() == 'Rejon':
@@ -1416,10 +1416,10 @@ class LayerManager:
                     if (
                         isinstance(lyr, QgsVectorLayer)
                         and lyr.wkbType() in (  # noqa: W503
-                            QgsWkbTypes.Polygon,
-                            QgsWkbTypes.MultiPolygon,
-                            QgsWkbTypes.PolygonZM,
-                            QgsWkbTypes.MultiPolygonZM,
+                            QgsWkbTypes.Type.Polygon,
+                            QgsWkbTypes.Type.MultiPolygon,
+                            QgsWkbTypes.Type.PolygonZM,
+                            QgsWkbTypes.Type.MultiPolygonZM,
                         )
                         and lyr.name() in ("Objekti", "Objects")  # noqa: W503
                     ):
@@ -1482,7 +1482,7 @@ class LayerManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry  # noqa: W503
                     and lyr.name() == layer_name  # noqa: W503
                 ):
                     self._apply_element_aliases(lyr)
@@ -1565,9 +1565,9 @@ class LayerManager:
                     except Exception as e:
                         logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
                     try:
-                        svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                        svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
                     except Exception:
-                        svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                        svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
                     symbol.changeSymbolLayer(0, svg_layer)
                 except Exception as e:
                     logger.debug(f"Error in _telecom_export_one_layer_to_gpkg: {e}")
@@ -1609,7 +1609,7 @@ class LayerManager:
             if (
                 isinstance(lyr, QgsVectorLayer)
                 and lyr.name() in ('Route', 'Trasa')  # noqa: W503
-                and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
             ):
                 ensure_uuid_field(lyr)
                 return lyr

--- a/fiberq/core/pipe_manager.py
+++ b/fiberq/core/pipe_manager.py
@@ -229,7 +229,7 @@ class PipeManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     and lyr.name() in target_names  # noqa: W503
                 ):
                     try:
@@ -323,7 +323,7 @@ class PipeManager:
             sl = QgsSimpleLineSymbolLayer()
             sl.setColor(QColor(color_hex))
             sl.setWidth(float(width_mm))
-            sl.setWidthUnit(QgsUnitTypes.RenderMillimeters)
+            sl.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
             try:
                 sl.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
                 sl.setCapStyle(Qt.PenCapStyle.RoundCap)
@@ -360,7 +360,7 @@ class PipeManager:
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                         and lyr.name() in self.PIPE_LAYER_NAMES):  # noqa: W503
                     layers.append(lyr)
             except Exception as e:

--- a/fiberq/core/relations_manager.py
+++ b/fiberq/core/relations_manager.py
@@ -371,7 +371,7 @@ class RelationsManager:
         cands = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if lyr.geometryType() != QgsWkbTypes.PointGeometry:
+                if lyr.geometryType() != QgsWkbTypes.GeometryType.PointGeometry:
                     continue
 
                 fields = lyr.fields()

--- a/fiberq/core/route_manager.py
+++ b/fiberq/core/route_manager.py
@@ -106,7 +106,7 @@ class RouteManager:
             symbol = QgsSymbol.defaultSymbol(route_layer.geometryType())
             symbol_layer = symbol.symbolLayer(0)
             symbol_layer.setWidth(0.8)
-            symbol_layer.setWidthUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            symbol_layer.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
             symbol_layer.setPenStyle(Qt.PenStyle.DashLine)
             route_layer.renderer().setSymbol(symbol)
             route_layer.triggerRepaint()
@@ -151,7 +151,7 @@ class RouteManager:
     def _find_route_layer(self) -> Optional[QgsVectorLayer]:
         """Find existing Route layer."""
         for lyr in QgsProject.instance().mapLayers().values():
-            if lyr.name() in ('Route', 'Trasa') and lyr.geometryType() == QgsWkbTypes.LineGeometry:
+            if lyr.name() in ('Route', 'Trasa') and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
                 return lyr
         return None
 
@@ -225,7 +225,7 @@ class RouteManager:
         selected_features = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if (lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                if (lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                         lyr.name() in ('Poles', 'Stubovi', 'OKNA', 'Manholes')):
                     if lyr.selectedFeatureCount() > 0:
                         selected_features.extend(lyr.selectedFeatures())

--- a/fiberq/core/slack_manager.py
+++ b/fiberq/core/slack_manager.py
@@ -98,7 +98,7 @@ class SlackManager:
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry  # noqa: W503
                     and lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")  # noqa: W503
                 ):
                     self.apply_slack_field_aliases(lyr)
@@ -157,7 +157,7 @@ class SlackManager:
             except Exception as e:
                 logger.debug(f"Error in SlackManager.stylize_slack_layer: {e}")
             try:
-                sym.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                sym.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             except Exception as e:
                 logger.debug(f"Error in SlackManager.stylize_slack_layer: {e}")
 
@@ -273,7 +273,7 @@ class SlackManager:
         kabl_layers = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if lyr.geometryType() == QgsWkbTypes.LineGeometry and lyr.name() in (
+                if lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry and lyr.name() in (
                     "Kablovi_podzemni", "Kablovi_vazdusni",
                     "Underground cables", "Aerial cables"
                 ):

--- a/fiberq/core/style_manager.py
+++ b/fiberq/core/style_manager.py
@@ -68,7 +68,7 @@ class StyleManager:
             symbol = QgsSymbol.defaultSymbol(layer.geometryType())
             symbol_layer = symbol.symbolLayer(0)
             symbol_layer.setWidth(0.8)
-            symbol_layer.setWidthUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            symbol_layer.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
             symbol_layer.setPenStyle(Qt.PenStyle.DashLine)
             layer.renderer().setSymbol(symbol)
             layer.triggerRepaint()
@@ -96,13 +96,13 @@ class StyleManager:
         try:
             # Get base width from route layer if available
             base_width = 0.8
-            base_unit = QgsUnitTypes.RenderMetersInMapUnits
+            base_unit = QgsUnitTypes.RenderUnit.RenderMetersInMapUnits
             try:
                 route_layer = next(
                     (
                         lyr for lyr in QgsProject.instance().mapLayers().values()
                         if lyr.name().lower().strip() in ("trasa", "route")
-                        and lyr.geometryType() == QgsWkbTypes.LineGeometry  # noqa: W503
+                        and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry  # noqa: W503
                     ),
                     None
                 )
@@ -188,7 +188,7 @@ class StyleManager:
                 if hasattr(QgsPalLayerSettings, 'LinePlacement') and hasattr(QgsPalLayerSettings.LinePlacement, 'AboveLine'):
                     s.placement = QgsPalLayerSettings.LinePlacement.AboveLine
                 elif hasattr(QgsPalLayerSettings, 'Line'):
-                    s.placement = QgsPalLayerSettings.Line
+                    s.placement = QgsPalLayerSettings.Placement.Line
             except Exception as e:
                 logger.debug(f"Error in StyleManager._apply_cable_labels: {e}")
 
@@ -231,7 +231,7 @@ class StyleManager:
             except Exception as e:
                 logger.debug(f"Error in StyleManager.stylize_slack_layer: {e}")
             try:
-                sym.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                sym.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             except Exception as e:
                 logger.debug(f"Error in StyleManager.stylize_slack_layer: {e}")
 
@@ -271,16 +271,16 @@ class StyleManager:
 
             # Size in meters on map
             try:
-                sl.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                sl.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
             except Exception:
-                sl.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                sl.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
 
             # Outline in mm (constant width)
             try:
-                sl.setOutlineWidthUnit(QgsUnitTypes.RenderMillimeters)
+                sl.setOutlineWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
             except Exception:
                 try:
-                    sl.setStrokeWidthUnit(QgsUnitTypes.RenderMillimeters)
+                    sl.setStrokeWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
                 except Exception as e:
                     logger.debug(f"Error in StyleManager.stylize_manhole_layer: {e}")
 
@@ -288,7 +288,7 @@ class StyleManager:
             try:
                 ddp = sl.dataDefinedProperties()
                 if ddp:
-                    ddp.setProperty(QgsSymbolLayer.PropertySize, QgsProperty())
+                    ddp.setProperty(QgsSymbolLayer.Property.PropertySize, QgsProperty())
                     sl.setDataDefinedProperties(ddp)
             except Exception as e:
                 logger.debug(f"Error in StyleManager.stylize_manhole_layer: {e}")
@@ -355,12 +355,12 @@ class StyleManager:
             # Fixed offset above marker
             s.xOffset = 0.0
             s.yOffset = 5.0
-            s.offsetUnits = QgsUnitTypes.RenderMapUnits
+            s.offsetUnits = QgsUnitTypes.RenderUnit.RenderMapUnits
 
             tf = QgsTextFormat()
             tf.setSize(8.0)
             try:
-                tf.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                tf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
             except Exception as e:
                 logger.debug(f"Error in StyleManager._apply_manhole_labels: {e}")
             f = QFont()
@@ -400,7 +400,7 @@ class StyleManager:
             sl = QgsSimpleLineSymbolLayer()
             sl.setColor(QColor(color_hex))
             sl.setWidth(float(width_mm))
-            sl.setWidthUnit(QgsUnitTypes.RenderMillimeters)
+            sl.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
             # Rounded corners for better appearance
             try:
                 sl.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
@@ -432,16 +432,16 @@ class StyleManager:
             simple = QgsSimpleMarkerSymbolLayer()
 
             try:
-                simple.setShape(QgsSimpleMarkerSymbolLayer.Circle)
+                simple.setShape(QgsSimpleMarkerSymbolLayer.Shape.Circle)
             except Exception as e:
                 logger.debug(f"Error in StyleManager.stylize_fiber_break_layer: {e}")
 
             simple.setSize(2.4)
-            simple.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            simple.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
             simple.setColor(QColor(0, 0, 0))
             simple.setOutlineColor(QColor(0, 0, 0))
             simple.setOutlineWidth(0.2)
-            simple.setOutlineWidthUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            simple.setOutlineWidthUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
 
             sym = QgsMarkerSymbol()
             sym.changeSymbolLayer(0, simple)
@@ -472,7 +472,7 @@ class StyleManager:
             simple.setFillColor(QColor(0, 0, 0, 0))
             simple.setStrokeColor(QColor(0, 0, 0))
             simple.setStrokeWidth(0.8)
-            simple.setStrokeWidthUnit(QgsUnitTypes.RenderMillimeters)
+            simple.setStrokeWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
 
             # Diagonal hatch lines
             hatch = QgsLinePatternFillSymbolLayer()
@@ -487,7 +487,7 @@ class StyleManager:
             except Exception as e:
                 logger.debug(f"Error in StyleManager.stylize_objects_layer: {e}")
             hatch.setDistance(2.2)
-            hatch.setDistanceUnit(QgsUnitTypes.RenderMillimeters)
+            hatch.setDistanceUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
 
             # Tune hatch sub symbol
             try:
@@ -500,7 +500,7 @@ class StyleManager:
                         logger.debug(f"Error in StyleManager.stylize_objects_layer: {e}")
                     try:
                         sl.setWidth(0.3)
-                        sl.setWidthUnit(QgsUnitTypes.RenderMillimeters)
+                        sl.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
                     except Exception as e:
                         logger.debug(f"Error in StyleManager.stylize_objects_layer: {e}")
             except Exception as e:
@@ -536,7 +536,7 @@ class StyleManager:
         """
         if layer is None or layer.renderer() is None:
             return
-        if layer.geometryType() != QgsWkbTypes.LineGeometry:
+        if layer.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
             return
 
         try:
@@ -552,7 +552,7 @@ class StyleManager:
                         # Base offset 0, units = mm
                         try:
                             if hasattr(sl, "setOffsetUnit"):
-                                sl.setOffsetUnit(QgsUnitTypes.RenderMillimeters)
+                                sl.setOffsetUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
                             if hasattr(sl, "setOffset"):
                                 sl.setOffset(0.0)
                         except Exception as e:
@@ -630,9 +630,9 @@ class StyleManager:
                     except Exception as e:
                         logger.debug(f"Error in StyleManager.stylize_element_layer: {e}")
                     try:
-                        svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                        svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
                     except Exception:
-                        svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                        svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
                     symbol.changeSymbolLayer(0, svg_layer)
                 except Exception as e:
                     logger.debug(f"Error in StyleManager.stylize_element_layer: {e}")
@@ -673,7 +673,7 @@ class StyleManager:
             tf = QgsTextFormat()
             tf.setSize(font_size)
             try:
-                tf.setSizeUnit(QgsUnitTypes.RenderPoints)
+                tf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderPoints)
             except Exception as e:
                 logger.debug(f"Error in StyleManager.apply_fixed_text_label: {e}")
 

--- a/fiberq/dialogs/bom_dialog.py
+++ b/fiberq/dialogs/bom_dialog.py
@@ -163,7 +163,7 @@ class _BOMDialog(QDialog):
 
             for f in lyr.getFeatures():
                 feat_count += 1
-                if gtype == QgsWkbTypes.LineGeometry:
+                if gtype == QgsWkbTypes.GeometryType.LineGeometry:
                     # prefer attribute duzina if it exists and >0, else compute geometry
                     val_len = None
                     if attr_duz is not None:
@@ -185,17 +185,17 @@ class _BOMDialog(QDialog):
                             slack_m += float(f[attr_slack] or 0.0)
                         except Exception as e:
                             logger.debug(f"Error in _BOMDialog._build: {e}")
-                elif gtype == QgsWkbTypes.PointGeometry:
+                elif gtype == QgsWkbTypes.GeometryType.PointGeometry:
                     # nothing to compute; just counting
                     pass
 
-            if gtype == QgsWkbTypes.LineGeometry:
+            if gtype == QgsWkbTypes.GeometryType.LineGeometry:
                 total_m = length_m + slack_m
                 rows.append([lyr.name(), "Line", feat_count, length_m, slack_m, total_m])
                 totals["line_len"] += length_m
                 totals["line_slack"] += slack_m
                 totals["line_total"] += total_m
-            elif gtype == QgsWkbTypes.PointGeometry:
+            elif gtype == QgsWkbTypes.GeometryType.PointGeometry:
                 rows.append([lyr.name(), "Point", feat_count, "", "", ""])
                 totals["points"] += feat_count
             else:

--- a/fiberq/dialogs/locator_dialog.py
+++ b/fiberq/dialogs/locator_dialog.py
@@ -64,7 +64,7 @@ def _http_get_json(url, user_agent, timeout_ms=15000):
         logger.debug(f"could not set network timeout: {e}")
 
     err = blocking.get(request, forceRefresh=True)
-    if err != QgsBlockingNetworkRequest.NoError:
+    if err != QgsBlockingNetworkRequest.ErrorCode.NoError:
         raise RuntimeError(blocking.errorMessage() or "Network request failed")
 
     reply = blocking.reply()

--- a/fiberq/dialogs/schematic_dialog.py
+++ b/fiberq/dialogs/schematic_dialog.py
@@ -293,7 +293,7 @@ class OpticalSchematicDialog(QDialog):
         nodes = {}
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry:
+                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry:
                     lname = lyr.name()
                     fields = lyr.fields()
                     has_naziv = fields.indexFromName('naziv') != -1
@@ -529,9 +529,9 @@ class OpticalSchematicDialog(QDialog):
                     pt = None
                     if g.isEmpty():
                         continue
-                    if g.type() == QgsWkbTypes.PointGeometry:
+                    if g.type() == QgsWkbTypes.GeometryType.PointGeometry:
                         pt = g.asPoint()
-                    elif g.type() == QgsWkbTypes.LineGeometry:
+                    elif g.type() == QgsWkbTypes.GeometryType.LineGeometry:
                         try:
                             d = g.length()
                             pt = g.interpolate(d / 2.0).asPoint()

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -290,7 +290,7 @@ class FiberQPlugin:
 
             m = QgsVertexMarker(canvas)
             m.setCenter(pt)
-            m.setIconType(QgsVertexMarker.ICON_CROSS)
+            m.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
             m.setIconSize(18)
             m.setPenWidth(3)
             try:
@@ -491,13 +491,13 @@ class FiberQPlugin:
             manholes_layer = layers.get("Manholes") or layers.get("OKNA")
 
             # Route – line
-            if route_layer and route_layer.geometryType() == QgsWkbTypes.LineGeometry:
+            if route_layer and route_layer.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
                 msgs.append("Routes: OK")
             else:
                 msgs.append("Routes: MISSING or wrong type")
 
             # Poles – point
-            if poles_layer and poles_layer.geometryType() == QgsWkbTypes.PointGeometry:
+            if poles_layer and poles_layer.geometryType() == QgsWkbTypes.GeometryType.PointGeometry:
                 msgs.append("Poles: OK")
             else:
                 msgs.append("Poles: MISSING or wrong type")
@@ -1700,7 +1700,7 @@ class FiberQPlugin:
             for lyr in QgsProject.instance().mapLayers().values():
                 if not isinstance(lyr, QgsVectorLayer):
                     continue
-                if lyr.geometryType() != QgsWkbTypes.PointGeometry:
+                if lyr.geometryType() != QgsWkbTypes.GeometryType.PointGeometry:
                     continue
 
                 name = (lyr.name() or "").lower()
@@ -2171,7 +2171,7 @@ class FiberQPlugin:
             fset = {f.name() for f in layer.fields()}
 
             # 1) CABLES (Line)
-            if gtype == QgsWkbTypes.LineGeometry and lname in cable_names:
+            if gtype == QgsWkbTypes.GeometryType.LineGeometry and lname in cable_names:
                 self._stylize_cable_layer(layer)      # EN legend labels
                 self._apply_cable_field_aliases(layer)   # EN user view
                 self._set_cable_layer_alias(layer)       # EN layer name
@@ -2179,7 +2179,7 @@ class FiberQPlugin:
                 continue
 
             # 2) FIBER BREAK (Point)
-            if gtype == QgsWkbTypes.PointGeometry and {
+            if gtype == QgsWkbTypes.GeometryType.PointGeometry and {
                 "cable_layer_id", "cable_fid", "distance_m", "segments_hit", "vreme"
             }.issubset(fset):
                 alias_map = {
@@ -2203,7 +2203,7 @@ class FiberQPlugin:
             # Dozvoli:
             # - by layer name (Joint Closures) even with suffixes
             # - or if layer actually has only id,fid,naziv fields
-            if gtype == QgsWkbTypes.PointGeometry and (
+            if gtype == QgsWkbTypes.GeometryType.PointGeometry and (
                 lname_l.startswith("joint closures")
                 or lname_l.startswith("nastav")  # noqa: W503
                 or fset.issubset({"id", "fid", "naziv"})  # noqa: W503
@@ -2223,7 +2223,7 @@ class FiberQPlugin:
                 continue
 
             # 3.5) ROUTE (Line) – EN field aliases + EN layer name (posle export/import iz Preview Map)
-            if gtype == QgsWkbTypes.LineGeometry and (
+            if gtype == QgsWkbTypes.GeometryType.LineGeometry and (
                 lname_l.startswith("route")
                 or lname_l.startswith("trasa")  # noqa: W503
                 or {"naziv", "duzina", "tip_trase"}.issubset(fset)  # noqa: W503
@@ -2237,7 +2237,7 @@ class FiberQPlugin:
                 continue
 
             # 3.6) POLES (Point) – EN field aliases + EN layer name
-            if gtype == QgsWkbTypes.PointGeometry and (
+            if gtype == QgsWkbTypes.GeometryType.PointGeometry and (
                 lname_l.startswith("poles")
                 or lname_l.startswith("stubov")  # noqa: W503
                 or {"tip", "podtip", "visina", "materijal"}.issubset(fset)  # noqa: W503
@@ -2251,7 +2251,7 @@ class FiberQPlugin:
                 continue
 
             # 3.7) MANHOLES / OKNA (Point) – EN field aliases + EN layer name
-            if gtype == QgsWkbTypes.PointGeometry and (
+            if gtype == QgsWkbTypes.GeometryType.PointGeometry and (
                 lname_l.startswith("manholes")
                 or lname_l.startswith("okna")  # noqa: W503
                 or {"broj_okna", "tip_okna"}.issubset(fset)  # noqa: W503
@@ -2266,7 +2266,7 @@ class FiberQPlugin:
 
             # 4) GENERIC “Placing elements” (ODF/TB/OTB/TO/Patch panel/Optical slacks…)
             if (
-                gtype in (QgsWkbTypes.PointGeometry, QgsWkbTypes.PolygonGeometry)
+                gtype in (QgsWkbTypes.GeometryType.PointGeometry, QgsWkbTypes.GeometryType.PolygonGeometry)
                 and (  # noqa: W503
                     "proizvodjac" in fset
                     or "kapacitet" in fset  # noqa: W503
@@ -2333,7 +2333,7 @@ class FiberQPlugin:
             # THIS IS A CHECK THAT USES capabilities()
             if isinstance(lyr, QgsVectorLayer) and (
                 lyr.isEditable()
-                or lyr.dataProvider().capabilities() & QgsVectorDataProvider.DeleteFeatures  # noqa: W503
+                or lyr.dataProvider().capabilities() & QgsVectorDataProvider.Capability.DeleteFeatures  # noqa: W503
             ):
                 selected_feats = list(lyr.selectedFeatures())
 
@@ -2516,7 +2516,7 @@ class FiberQPlugin:
             QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "Unable to load or invalid file!")
             return
 
-        if imported_layer.geometryType() != QgsWkbTypes.PointGeometry:
+        if imported_layer.geometryType() != QgsWkbTypes.GeometryType.PointGeometry:
             QMessageBox.warning(self.iface.mainWindow(), "FiberQ", "The selected file does not contain points!")
             return
         # Find all existing point layers relevant to plugin:
@@ -2542,7 +2542,7 @@ class FiberQPlugin:
         existing_layers = [
             lyr for lyr in QgsProject.instance().mapLayers().values()
             if isinstance(lyr, QgsVectorLayer)
-            and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+            and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry  # noqa: W503
             and lyr.name() in node_layer_names  # noqa: W503
         ]
         layer_names = [lyr.name() for lyr in existing_layers]
@@ -2611,7 +2611,7 @@ class FiberQPlugin:
                 symbol_layer = symbol.symbolLayer(0)
                 if symbol_layer is not None:
                     symbol_layer.setSize(10)
-                    symbol_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                    symbol_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
                 layer.renderer().setSymbol(symbol)
                 layer.triggerRepaint()
 
@@ -2650,7 +2650,7 @@ class FiberQPlugin:
                 geom.transform(transform)
 
             # Add each individual Point (even from MultiPoint)
-            if geom.type() == QgsWkbTypes.PointGeometry:
+            if geom.type() == QgsWkbTypes.GeometryType.PointGeometry:
                 if geom.isMultipart():
                     for pt in geom.asMultiPoint():
                         if pt:
@@ -2853,7 +2853,7 @@ class FiberQPlugin:
             res = result
             err_message = ""
 
-        if res != QgsVectorFileWriter.NoError:
+        if res != QgsVectorFileWriter.WriterError.NoError:
             QMessageBox.critical(
                 self.iface.mainWindow(),
                 "Export",
@@ -2946,7 +2946,7 @@ class FiberQPlugin:
 
     def fix_route_to_pole(self, route_feature, must_start=True):
         poles_layer = next((lyr for lyr in QgsProject.instance().mapLayers().values()
-                            if lyr.geometryType() == QgsWkbTypes.PointGeometry
+                            if lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry
                             and lyr.name() in ('Poles', 'Poles')), None)  # noqa: W503
 
         if not poles_layer:
@@ -2985,7 +2985,7 @@ class FiberQPlugin:
                 (lyr for lyr in QgsProject.instance().mapLayers().values()
                  if isinstance(lyr, QgsVectorLayer)
                  and lyr.name() in ('Route', 'Route')  # noqa: W503
-                 and lyr.geometryType() == QgsWkbTypes.LineGeometry),  # noqa: W503
+                 and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry),  # noqa: W503
                 None
             )
             if not route_layer:

--- a/fiberq/metadata.txt
+++ b/fiberq/metadata.txt
@@ -3,7 +3,7 @@ name=FiberQ
 description=Open-source fiber network design tools for QGIS (FTTH/GPON/FTTx)
 about=FiberQ helps telecom engineers and GIS professionals design, analyze, and document fiber optic networks inside QGIS. FiberQ supports QGIS 4 / Qt6 while keeping support for QGIS 3.22 LTR and later, and clears all findings from the QGIS repository security scan. Some advanced features may require an activation key.
 
-version=1.3.1
+version=1.3.0
 qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 
@@ -23,14 +23,6 @@ license=GPL-3.0-or-later
 class_name=FiberQPlugin
 
 changelog=
-    1.3.1 - Security-scan hardening (no functional change)
-        * Resolved 66 Bandit low-severity findings (B110 try/except/pass and B112
-          try/except/continue): the previously-silent exception handlers now log at
-          debug level instead of swallowing errors. No behaviour change beyond the
-          added debug logging.
-        * The local lint gate (make lint / scan-check) now runs Bandit at ALL
-          severities to match the plugins.qgis.org Security & Quality scanner.
-
     1.3.0 - Project schema versioning, safe migrations, and stable feature IDs
         * New: every FiberQ project now carries a schema-version marker, also
           mirrored into the GeoPackage, so future releases can recognise and
@@ -52,6 +44,12 @@ changelog=
         * Fix: the Optical Schematic View now draws pipes in the legend orange for
           English-named layers (previously grey), matching the "Pipes" legend.
         * Fix: renamed the mislabeled "FiberQ web browser" action to "Preview Map".
+        * Compat: scoped all QGIS enum accesses (e.g. QgsWkbTypes.PointGeometry ->
+          QgsWkbTypes.GeometryType.PointGeometry) for PyQt6 / QGIS 4; unchanged
+          behaviour on QGIS 3 / Qt5.
+        * Hardening: previously-silent exception handlers now log at debug level
+          instead of swallowing errors, and the local lint gate runs Bandit at all
+          severities to match the plugins.qgis.org scanner.
         * Quality: the maintainer manually reviewed the entire plugin source -
           every Python module - prior to this release. Lint (flake8 + Bandit)
           remains at zero findings on the plugins.qgis.org scan, and the pytest

--- a/fiberq/tools/base.py
+++ b/fiberq/tools/base.py
@@ -65,7 +65,7 @@ def find_route_layer():
     for lyr in QgsProject.instance().mapLayers().values():
         try:
             if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry and  # noqa: W504
                     lyr.name() in ('Route', 'Trasa')):
                 return lyr
         except Exception as e:
@@ -83,7 +83,7 @@ def find_cable_layers():
     for lyr in QgsProject.instance().mapLayers().values():
         try:
             if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry and  # noqa: W504
                     lyr.name() in cable_names):
                 layers.append(lyr)
         except Exception as e:
@@ -98,7 +98,7 @@ def find_node_layers():
     for lyr in QgsProject.instance().mapLayers().values():
         try:
             if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                     lyr.name() in node_names):
                 layers.append(lyr)
         except Exception as e:
@@ -126,7 +126,7 @@ def find_element_layers():
     for lyr in QgsProject.instance().mapLayers().values():
         try:
             if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                     lyr.name() in element_names):
                 layers.append(lyr)
         except Exception as e:
@@ -167,7 +167,7 @@ def snap_to_point_layers(point, layers, tolerance):
     snapped_point = None
 
     for layer in layers:
-        if layer.geometryType() != QgsWkbTypes.PointGeometry:
+        if layer.geometryType() != QgsWkbTypes.GeometryType.PointGeometry:
             continue
 
         for feature in layer.getFeatures():
@@ -201,7 +201,7 @@ def snap_to_line_layer(point, layer, tolerance):
     Returns:
         Tuple of (snapped_point, feature, segment_index, distance) or (None, None, None, None)
     """
-    if layer.geometryType() != QgsWkbTypes.LineGeometry:
+    if layer.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
         return None, None, None, None
 
     min_dist = None
@@ -238,7 +238,7 @@ def snap_to_line_vertices(point, layer, tolerance):
     Returns:
         Tuple of (snapped_point, min_distance) or (None, None)
     """
-    if layer.geometryType() != QgsWkbTypes.LineGeometry:
+    if layer.geometryType() != QgsWkbTypes.GeometryType.LineGeometry:
         return None, None
 
     min_dist = None

--- a/fiberq/tools/branch_tool.py
+++ b/fiberq/tools/branch_tool.py
@@ -58,7 +58,7 @@ class BranchInfoTool(QgsMapToolIdentify):
         for h in hits or []:
             lyr = h.mLayer
             try:
-                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.LineGeometry:
+                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
                     name = (lyr.name() or "").lower().strip()
                     # Accept both old and new cable layer names
                     if name in (

--- a/fiberq/tools/breakpoint_tool.py
+++ b/fiberq/tools/breakpoint_tool.py
@@ -32,7 +32,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         self.plugin = plugin
 
         # Visual feedback rubber band
-        self.rubber = QgsRubberBand(self.canvas, QgsWkbTypes.PointGeometry)
+        self.rubber = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.PointGeometry)
         self.rubber.setColor(QColor(0, 255, 0))
         self.rubber.setWidth(10)
 
@@ -44,7 +44,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         for lyr in QgsProject.instance().mapLayers().values():
             if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
                 lyr.name() in ('Route', 'Trasa') and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry):
                 return lyr
         return None
 
@@ -54,7 +54,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
 
         route_layer = self._find_route_layer()
         if route_layer is None or route_layer.featureCount() == 0:
-            self.rubber.reset(QgsWkbTypes.PointGeometry)
+            self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             self.snap_info = None
             return
 
@@ -77,7 +77,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
 
         tolerance = self.canvas.mapUnitsPerPixel() * 10
         if snapped_point and min_dist < tolerance:
-            self.rubber.reset(QgsWkbTypes.PointGeometry)
+            self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             self.rubber.addPoint(snapped_point)
             self.snap_info = {
                 'feat': min_feat,
@@ -87,7 +87,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
                 'dist': min_dist
             }
         else:
-            self.rubber.reset(QgsWkbTypes.PointGeometry)
+            self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             self.snap_info = None
 
     def canvasReleaseEvent(self, event):
@@ -95,7 +95,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         # Right click = cancel tool
         if event.button() == Qt.MouseButton.RightButton:
             self.snap_info = None
-            self.rubber.reset(QgsWkbTypes.PointGeometry)
+            self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             self.iface.mapCanvas().unsetMapTool(self)
             return
 
@@ -109,7 +109,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
                 "Split route",
                 "Click closer to a route!"
             )
-            self.rubber.reset(QgsWkbTypes.PointGeometry)
+            self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             return
 
         min_feat = self.snap_info['feat']
@@ -130,7 +130,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
                     "and cannot be split with this tool!\n"
                     "Merge the lines so that there is ONE line (not a MultiLineString)."
                 )
-                self.rubber.reset(QgsWkbTypes.PointGeometry)
+                self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
                 return
 
         # Convert all vertices to QgsPointXY
@@ -149,7 +149,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
                     "Split route",
                     "Click closer to the middle of the segment."
                 )
-                self.rubber.reset(QgsWkbTypes.PointGeometry)
+                self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
                 return
 
             geom1 = QgsGeometry.fromPolylineXY([p0, snapped_point])
@@ -164,7 +164,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
                     "Split route",
                     "Cannot split the route at this location."
                 )
-                self.rubber.reset(QgsWkbTypes.PointGeometry)
+                self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
                 return
 
             geom1 = min_geom
@@ -182,7 +182,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
                 "Split route",
                 "Route layer 'Route' not found!"
             )
-            self.rubber.reset(QgsWkbTypes.PointGeometry)
+            self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             return
 
         # Perform the split
@@ -222,7 +222,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         if self.plugin:
             self.plugin.stylize_route_layer(route_layer)
 
-        self.rubber.reset(QgsWkbTypes.PointGeometry)
+        self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
         QMessageBox.information(
             self.iface.mainWindow(),
             "Split route",
@@ -232,7 +232,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
 
     def deactivate(self):
         """Clean up when tool is deactivated."""
-        self.rubber.reset(QgsWkbTypes.PointGeometry)
+        self.rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
         self.snap_info = None
         super().deactivate()
 

--- a/fiberq/tools/element_tool.py
+++ b/fiberq/tools/element_tool.py
@@ -49,7 +49,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
         self.symbol_spec = symbol_spec or {'name': 'diamond', 'color': 'red', 'size': '5', 'size_unit': 'MapUnit'}
         self.snap_marker = QgsVertexMarker(self.canvas)
         self.snap_marker.setColor(QColor(255, 0, 0))
-        self.snap_marker.setIconType(QgsVertexMarker.ICON_CIRCLE)
+        self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CIRCLE)
         self.snap_marker.setIconSize(14)
         self.snap_marker.setPenWidth(3)
         self.snap_marker.hide()
@@ -66,13 +66,13 @@ class PlaceElementTool(QgsMapToolEmitPoint):
 
         try:
             simple = QgsSimpleMarkerSymbolLayer()
-            simple.setShape(QgsSimpleMarkerSymbolLayer.Circle)
+            simple.setShape(QgsSimpleMarkerSymbolLayer.Shape.Circle)
             simple.setSize(2.4)  # mm
-            simple.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            simple.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
             simple.setColor(QColor(0, 0, 0))  # black fill
             simple.setOutlineColor(QColor(0, 0, 0))  # black outline
             simple.setOutlineWidth(0.2)
-            simple.setOutlineWidthUnit(QgsUnitTypes.RenderMetersInMapUnits)
+            simple.setOutlineWidthUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
 
             sym = QgsMarkerSymbol()
             sym.changeSymbolLayer(0, simple)
@@ -89,12 +89,12 @@ class PlaceElementTool(QgsMapToolEmitPoint):
         node_layers = []
         for lyr in QgsProject.instance().mapLayers().values():
             try:
-                if lyr.geometryType() == QgsWkbTypes.LineGeometry and lyr.name() in (
+                if lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry and lyr.name() in (
                     "Kablovi_podzemni", "Kablovi_vazdusni", "Underground cables",
                     "Aerial cables", "Route", "Route"
                 ):
                     line_layers.append(lyr)
-                if lyr.geometryType() == QgsWkbTypes.PointGeometry and lyr.name() in (
+                if lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and lyr.name() in (
                     "Poles", "Poles", "OKNA", "Manholes"
                 ):
                     node_layers.append(lyr)
@@ -165,7 +165,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
         existing_layer = None
         try:
             for lyr in QgsProject.instance().mapLayers().values():
-                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry and lyr.name() == self.target_layer_name:
+                if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and lyr.name() == self.target_layer_name:
                     existing_layer = lyr
                     break
         except Exception:
@@ -192,7 +192,7 @@ class PlaceElementTool(QgsMapToolEmitPoint):
         # Find or create layer
         elem_layer = None
         for lyr in QgsProject.instance().mapLayers().values():
-            if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry and lyr.name() == self.target_layer_name:
+            if isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and lyr.name() == self.target_layer_name:
                 elem_layer = lyr
                 break
 
@@ -237,9 +237,9 @@ class PlaceElementTool(QgsMapToolEmitPoint):
                     except Exception as e:
                         logger.debug(f"Error in PlaceElementTool.canvasPressEvent: {e}")
                     try:
-                        svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                        svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
                     except Exception:
-                        svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                        svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
                     symbol.changeSymbolLayer(0, svg_layer)
                 except Exception as e:
                     logger.debug(f"Error in PlaceElementTool.canvasPressEvent: {e}")
@@ -355,7 +355,7 @@ class ChangeElementTypeTool(QgsMapToolIdentify):
         self.canvas = iface.mapCanvas()
         try:
             self.snap_marker = QgsVertexMarker(self.canvas)
-            self.snap_marker.setIconType(QgsVertexMarker.ICON_CROSS)
+            self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
             self.snap_marker.setPenWidth(3)
             self.snap_marker.setIconSize(14)
             self.snap_marker.setColor(QColor(0, 200, 0))
@@ -404,7 +404,7 @@ class ChangeElementTypeTool(QgsMapToolIdentify):
 
     def _is_element_layer(self, lyr):
         try:
-            if not (isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.PointGeometry):
+            if not (isinstance(lyr, QgsVectorLayer) and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry):
                 return False
 
             name = (lyr.name() or "").strip()

--- a/fiberq/tools/extension_tool.py
+++ b/fiberq/tools/extension_tool.py
@@ -41,7 +41,7 @@ class ExtensionTool(QgsMapToolEmitPoint):
         self.layer = layer
         self.snap_marker = QgsVertexMarker(self.canvas)
         self.snap_marker.setColor(QColor(255, 0, 0))
-        self.snap_marker.setIconType(QgsVertexMarker.ICON_CIRCLE)
+        self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CIRCLE)
         self.snap_marker.setIconSize(14)
         self.snap_marker.setPenWidth(3)
         self.snap_marker.hide()
@@ -104,7 +104,7 @@ class ExtensionTool(QgsMapToolEmitPoint):
                     or lname.strip() in ("cuts", "cut")  # noqa: W503
                 )
 
-                if gtype == QgsWkbTypes.PointGeometry and is_node_layer:
+                if gtype == QgsWkbTypes.GeometryType.PointGeometry and is_node_layer:
                     req = QgsFeatureRequest().setFilterRect(rect)
                     for feat in lyr.getFeatures(req):
                         geom = feat.geometry()
@@ -122,7 +122,7 @@ class ExtensionTool(QgsMapToolEmitPoint):
                     or lyr.name() in ("Route", "Route")  # noqa: W503
                 )
 
-                if gtype == QgsWkbTypes.LineGeometry and is_cable_layer:
+                if gtype == QgsWkbTypes.GeometryType.LineGeometry and is_cable_layer:
                     req = QgsFeatureRequest().setFilterRect(rect)
                     for feat in lyr.getFeatures(req):
                         geom = feat.geometry()
@@ -194,7 +194,7 @@ class ExtensionTool(QgsMapToolEmitPoint):
         for lyr in QgsProject.instance().mapLayers().values():
             if (
                 isinstance(lyr, QgsVectorLayer)
-                and lyr.geometryType() == QgsWkbTypes.PointGeometry  # noqa: W503
+                and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry  # noqa: W503
                 and lyr.name() in target_names  # noqa: W503
             ):
                 nastavak_layer = lyr
@@ -232,9 +232,9 @@ class ExtensionTool(QgsMapToolEmitPoint):
                 )
                 svg_layer.setSize(10)
                 try:
-                    svg_layer.setSizeUnit(QgsUnitTypes.RenderMetersInMapUnits)
+                    svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMetersInMapUnits)
                 except Exception:
-                    svg_layer.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+                    svg_layer.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
                 symbol.changeSymbolLayer(0, svg_layer)
             except Exception as e:
                 logger.debug(f"Error in ExtensionTool.canvasReleaseEvent: {e}")

--- a/fiberq/tools/manhole_tool.py
+++ b/fiberq/tools/manhole_tool.py
@@ -186,7 +186,7 @@ class ManholePlaceTool(QgsMapToolEmitPoint):
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
                     lyr.name() in ('Manholes', 'OKNA') and  # noqa: W504
-                        lyr.geometryType() == QgsWkbTypes.PointGeometry):
+                        lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry):
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in ManholePlaceTool._find_manhole_layer: {e}")
@@ -198,7 +198,7 @@ class ManholePlaceTool(QgsMapToolEmitPoint):
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
                     lyr.name() in ('Route', 'Trasa') and  # noqa: W504
-                        lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                        lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry):
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in ManholePlaceTool._find_route_layer: {e}")

--- a/fiberq/tools/move_tool.py
+++ b/fiberq/tools/move_tool.py
@@ -39,7 +39,7 @@ class MoveFeatureTool(QgsMapTool):
     def _clear(self):
         try:
             if self.rb:
-                self.rb.reset(QgsWkbTypes.PolygonGeometry)
+                self.rb.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
                 self.canvas.scene().removeItem(self.rb)
         except Exception as e:
             logger.debug(f"Error in MoveFeatureTool._clear: {e}")

--- a/fiberq/tools/object_tools.py
+++ b/fiberq/tools/object_tools.py
@@ -84,7 +84,7 @@ class _BaseObjMapTool(QgsMapTool):
         self.core = core
         self.canvas = iface.mapCanvas()
         self.points = []
-        self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+        self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.PolygonGeometry)
         try:
             self.rb.setWidth(2)
             # semi-transparent fill
@@ -111,7 +111,7 @@ class _BaseObjMapTool(QgsMapTool):
             self._update_rb([])
         except Exception:
             try:
-                self.rb.reset(QgsWkbTypes.PolygonGeometry)
+                self.rb.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
             except Exception as e:
                 logger.debug(f"Error in _BaseObjMapTool._reset: {e}")
 

--- a/fiberq/tools/pipe_tool.py
+++ b/fiberq/tools/pipe_tool.py
@@ -44,7 +44,7 @@ class PipePlaceTool(QgsMapTool):
         self.points = []
 
         # Temporary line rubber band
-        self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.LineGeometry)
+        self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.LineGeometry)
         self.rb.setLineStyle(Qt.PenStyle.SolidLine)
         self.rb.show()
         self.rb.setWidth(1.5)
@@ -52,7 +52,7 @@ class PipePlaceTool(QgsMapTool):
 
         # Snap indicator
         self.snap_marker = QgsVertexMarker(self.canvas)
-        self.snap_marker.setIconType(QgsVertexMarker.ICON_CROSS)
+        self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
         self.snap_marker.setPenWidth(3)
         self.snap_marker.setIconSize(14)
         self.snap_marker.setColor(QColor(0, 200, 0))
@@ -97,7 +97,7 @@ class PipePlaceTool(QgsMapTool):
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                         lyr.name() in node_names):
                     for f in lyr.getFeatures():
                         p = f.geometry().asPoint()
@@ -113,7 +113,7 @@ class PipePlaceTool(QgsMapTool):
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
                     lyr.name() in ('Route', 'Trasa') and  # noqa: W504
-                        lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                        lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry):
 
                     for g in lyr.getFeatures():
                         geom = g.geometry()
@@ -214,7 +214,7 @@ class PipePlaceTool(QgsMapTool):
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
                     lyr.name() in ('Route', 'Trasa') and  # noqa: W504
-                        lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                        lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry):
                     return lyr
             except Exception as e:
                 logger.debug(f"Error in PipePlaceTool._find_route_layer: {e}")
@@ -338,7 +338,7 @@ class PipePlaceTool(QgsMapTool):
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                         lyr.name() in node_names):
                     node_layers.append(lyr)
             except Exception as e:
@@ -404,7 +404,7 @@ class PipePlaceTool(QgsMapTool):
 
             if getattr(self, "rb", None) is not None:
                 try:
-                    self.rb.reset(QgsWkbTypes.LineGeometry)
+                    self.rb.reset(QgsWkbTypes.GeometryType.LineGeometry)
                     self.rb.hide()
                 except Exception as e:
                     logger.debug(f"Error in PipePlaceTool._cleanup: {e}")

--- a/fiberq/tools/point_tool.py
+++ b/fiberq/tools/point_tool.py
@@ -30,7 +30,7 @@ class PointTool(QgsMapToolEmitPoint):
         self.layer = layer
         self.snap_marker = QgsVertexMarker(self.canvas)
         self.snap_marker.setColor(QColor(0, 255, 0))
-        self.snap_marker.setIconType(QgsVertexMarker.ICON_CROSS)
+        self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
         self.snap_marker.setIconSize(14)
         self.snap_marker.setPenWidth(3)
         self.snap_marker.hide()
@@ -39,7 +39,7 @@ class PointTool(QgsMapToolEmitPoint):
         """Find snap candidate on route layer vertices and midpoints."""
         route_layer = None
         for lyr in QgsProject.instance().mapLayers().values():
-            if lyr.name() in ('Route', 'Route') and lyr.geometryType() == QgsWkbTypes.LineGeometry:
+            if lyr.name() in ('Route', 'Route') and lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry:
                 route_layer = lyr
                 break
 

--- a/fiberq/tools/region_tool.py
+++ b/fiberq/tools/region_tool.py
@@ -39,7 +39,7 @@ class DrawRegionPolygonTool(QgsMapTool):
 
     def _setup_rb(self):
         try:
-            self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+            self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.PolygonGeometry)
             # Style similar to other toolbar icons: soft slate stroke, semi-transparent fill
             self.rb.setWidth(2)
             self.rb.setStrokeColor(QColor('#334155'))  # slate-700
@@ -55,7 +55,7 @@ class DrawRegionPolygonTool(QgsMapTool):
                 self._setup_rb()
             self.points = []
             if self.rb:
-                self.rb.reset(QgsWkbTypes.PolygonGeometry)
+                self.rb.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
             self.iface.messageBar().pushInfo(
                 'Draw Service Area (manual)',
                 'Left click adds vertices, Backspace removes, right click finishes.'
@@ -67,7 +67,7 @@ class DrawRegionPolygonTool(QgsMapTool):
     def deactivate(self):
         try:
             if self.rb:
-                self.rb.reset(QgsWkbTypes.PolygonGeometry)
+                self.rb.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
         except Exception as e:
             logger.debug(f"Error in DrawRegionPolygonTool.deactivate: {e}")
         super().deactivate()
@@ -115,7 +115,7 @@ class DrawRegionPolygonTool(QgsMapTool):
         try:
             if not self.rb:
                 return
-            self.rb.reset(QgsWkbTypes.PolygonGeometry)
+            self.rb.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
             pts = list(self.points)
             if temp_point is not None:
                 pts.append(temp_point)

--- a/fiberq/tools/route_tool.py
+++ b/fiberq/tools/route_tool.py
@@ -34,7 +34,7 @@ class ManualRouteTool(QgsMapTool):
         self.canvas = iface.mapCanvas()
 
         # Route line rubber band
-        self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.LineGeometry)
+        self.rb = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.LineGeometry)
         self.rb.setColor(QColor(0, 0, 255, 150))
         self.rb.setWidth(2)
 
@@ -42,7 +42,7 @@ class ManualRouteTool(QgsMapTool):
         self.points = []
 
         # Snap indicator
-        self.snap_rubber = QgsRubberBand(self.canvas, QgsWkbTypes.PointGeometry)
+        self.snap_rubber = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.PointGeometry)
         self.snap_rubber.setColor(QColor(255, 0, 0, 180))
         self.snap_rubber.setWidth(12)
 
@@ -90,7 +90,7 @@ class ManualRouteTool(QgsMapTool):
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                         lyr.name() in node_layer_names):
                     node_layers.append(lyr)
             except Exception as e:
@@ -117,7 +117,7 @@ class ManualRouteTool(QgsMapTool):
             for lyr in QgsProject.instance().mapLayers().values():
                 try:
                     if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                        lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                        lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry and  # noqa: W504
                             lyr.name() in ('Route', 'Trasa')):
 
                         for feat in lyr.getFeatures():
@@ -172,10 +172,10 @@ class ManualRouteTool(QgsMapTool):
 
         if min_dist is not None and min_dist < snap_tolerance and snap_point is not None:
             point = snap_point
-            self.snap_rubber.reset(QgsWkbTypes.PointGeometry)
+            self.snap_rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             self.snap_rubber.addPoint(snap_point)
         else:
-            self.snap_rubber.reset(QgsWkbTypes.PointGeometry)
+            self.snap_rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
 
         self.points.append(point)
         self.rb.addPoint(point)
@@ -189,11 +189,11 @@ class ManualRouteTool(QgsMapTool):
         snap_tolerance = self.canvas.mapUnitsPerPixel() * 15
 
         if snap_point is not None and min_dist is not None and min_dist < snap_tolerance:
-            self.snap_rubber.reset(QgsWkbTypes.PointGeometry)
+            self.snap_rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             self.snap_rubber.addPoint(snap_point)
             disp_point = snap_point
         else:
-            self.snap_rubber.reset(QgsWkbTypes.PointGeometry)
+            self.snap_rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
             disp_point = point
 
         # Update rubber band
@@ -207,11 +207,11 @@ class ManualRouteTool(QgsMapTool):
     def _finish_route(self):
         """Complete the route and add it to the layer."""
         # Clear snap marker
-        self.snap_rubber.reset(QgsWkbTypes.PointGeometry)
+        self.snap_rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
 
         # Need at least 2 points
         if len(self.points) < 2:
-            self.rb.reset(QgsWkbTypes.LineGeometry)
+            self.rb.reset(QgsWkbTypes.GeometryType.LineGeometry)
             self.points = []
             self.canvas.unsetMapTool(self)
             return
@@ -221,7 +221,7 @@ class ManualRouteTool(QgsMapTool):
         for lyr in QgsProject.instance().mapLayers().values():
             if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
                 lyr.name() in ('Route', 'Trasa') and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry):
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry):
                 route_layer = lyr
                 break
 
@@ -324,13 +324,13 @@ class ManualRouteTool(QgsMapTool):
 
         # Reset tool
         self.points = []
-        self.rb.reset(QgsWkbTypes.LineGeometry)
+        self.rb.reset(QgsWkbTypes.GeometryType.LineGeometry)
         self.canvas.unsetMapTool(self)
 
     def deactivate(self):
         """Clean up when tool is deactivated."""
-        self.rb.reset(QgsWkbTypes.LineGeometry)
-        self.snap_rubber.reset(QgsWkbTypes.PointGeometry)
+        self.rb.reset(QgsWkbTypes.GeometryType.LineGeometry)
+        self.snap_rubber.reset(QgsWkbTypes.GeometryType.PointGeometry)
         self.points = []
         super().deactivate()
 

--- a/fiberq/tools/select_tool.py
+++ b/fiberq/tools/select_tool.py
@@ -40,7 +40,7 @@ class SmartMultiSelectTool(QgsMapTool):
         # Marker for visual feedback
         try:
             self._marker = QgsVertexMarker(self.canvas)
-            self._marker.setIconType(QgsVertexMarker.ICON_CROSS)
+            self._marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
             self._marker.setColor(QColor(0, 170, 255))
             self._marker.setIconSize(12)
             self._marker.setPenWidth(3)
@@ -88,11 +88,11 @@ class SmartMultiSelectTool(QgsMapTool):
             return 10
 
         # 3) lines: route, cables, pipes
-        if gtype == QgsWkbTypes.LineGeometry:
+        if gtype == QgsWkbTypes.GeometryType.LineGeometry:
             return 50
 
         # 4) polygons: objects, regions
-        if gtype == QgsWkbTypes.PolygonGeometry:
+        if gtype == QgsWkbTypes.GeometryType.PolygonGeometry:
             return 80
 
         # other
@@ -296,13 +296,13 @@ class SmartMultiSelectTool(QgsMapTool):
                     lname = name.lower()
                     gtype = lyr.geometryType()
 
-                    if gtype == QgsWkbTypes.PointGeometry:
+                    if gtype == QgsWkbTypes.GeometryType.PointGeometry:
                         if name in valid_point_names or lname in low_point:
                             layers.append(lyr)
-                    elif gtype == QgsWkbTypes.LineGeometry:
+                    elif gtype == QgsWkbTypes.GeometryType.LineGeometry:
                         if name in valid_line_names or lname in low_line:
                             layers.append(lyr)
-                    elif gtype == QgsWkbTypes.PolygonGeometry:
+                    elif gtype == QgsWkbTypes.GeometryType.PolygonGeometry:
                         if name in valid_poly_names or lname in low_poly:
                             layers.append(lyr)
                 except Exception as e:
@@ -318,7 +318,7 @@ class SmartMultiSelectTool(QgsMapTool):
             layers = []
             for lyr in QgsProject.instance().mapLayers().values():
                 try:
-                    if isinstance(lyr, QgsVectorLayer) and lyr.isValid() and lyr.geometryType() == QgsWkbTypes.PointGeometry:
+                    if isinstance(lyr, QgsVectorLayer) and lyr.isValid() and lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry:
                         if _re.search(r"(nastav|stub|okno|zok|patch|ormar|panel|izvod|or)", (lyr.name() or "").lower()):
                             layers.append(lyr)
                 except Exception as e2:

--- a/fiberq/tools/slack_tool.py
+++ b/fiberq/tools/slack_tool.py
@@ -33,7 +33,7 @@ class SlackPlaceTool(QgsMapTool):
 
         # Snap marker
         self.snap_marker = QgsVertexMarker(self.canvas)
-        self.snap_marker.setIconType(QgsVertexMarker.ICON_CROSS)
+        self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
         self.snap_marker.setPenWidth(3)
         self.snap_marker.setIconSize(14)
         self.snap_marker.setColor(QColor(0, 200, 0))
@@ -63,7 +63,7 @@ class SlackPlaceTool(QgsMapTool):
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.LineGeometry and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.LineGeometry and  # noqa: W504
                         lyr.name() in cable_names):
                     yield lyr
             except Exception as e:
@@ -75,7 +75,7 @@ class SlackPlaceTool(QgsMapTool):
         for lyr in QgsProject.instance().mapLayers().values():
             try:
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                         lyr.name() in node_names):
                     yield lyr
             except Exception as e:
@@ -212,7 +212,7 @@ class SlackPlaceTool(QgsMapTool):
             # Fallback: find existing slack layer
             for lyr in QgsProject.instance().mapLayers().values():
                 if (isinstance(lyr, QgsVectorLayer) and  # noqa: W504
-                    lyr.geometryType() == QgsWkbTypes.PointGeometry and  # noqa: W504
+                    lyr.geometryType() == QgsWkbTypes.GeometryType.PointGeometry and  # noqa: W504
                         lyr.name() in ("Opticke_rezerve", "Optical slacks", "Optical slack")):
                     vl = lyr
                     break

--- a/fiberq/ui/objects_ui.py
+++ b/fiberq/ui/objects_ui.py
@@ -98,7 +98,7 @@ class ObjectsUI:
                 return
 
             g = sel[0].geometry()
-            if not g or g.type() != QgsWkbTypes.PolygonGeometry:
+            if not g or g.type() != QgsWkbTypes.GeometryType.PolygonGeometry:
                 QMessageBox.information(
                     core.iface.mainWindow(),
                     "Objects",

--- a/fiberq/utils/compat.py
+++ b/fiberq/utils/compat.py
@@ -260,11 +260,11 @@ def get_geometry_type(type_name: str):
 # Convenience constants
 try:
     from qgis.core import QgsWkbTypes
-    PointGeometry = QgsWkbTypes.PointGeometry
-    LineGeometry = QgsWkbTypes.LineGeometry
-    PolygonGeometry = QgsWkbTypes.PolygonGeometry
-    UnknownGeometry = QgsWkbTypes.UnknownGeometry
-    NullGeometry = QgsWkbTypes.NullGeometry
+    PointGeometry = QgsWkbTypes.GeometryType.PointGeometry
+    LineGeometry = QgsWkbTypes.GeometryType.LineGeometry
+    PolygonGeometry = QgsWkbTypes.GeometryType.PolygonGeometry
+    UnknownGeometry = QgsWkbTypes.GeometryType.UnknownGeometry
+    NullGeometry = QgsWkbTypes.GeometryType.NullGeometry
 except (ImportError, AttributeError):
     PointGeometry = 0
     LineGeometry = 1

--- a/fiberq/utils/helpers.py
+++ b/fiberq/utils/helpers.py
@@ -316,7 +316,7 @@ def apply_fixed_text_label(
         try:
             settings.xOffset = 0.0
             settings.yOffset = float(y_offset_mu)
-            settings.offsetUnits = QgsUnitTypes.RenderMapUnits
+            settings.offsetUnits = QgsUnitTypes.RenderUnit.RenderMapUnits
         except Exception as e:
             logger.debug(f"Error in apply_fixed_text_label: {e}")
 
@@ -324,7 +324,7 @@ def apply_fixed_text_label(
         text_format = QgsTextFormat()
         try:
             text_format.setSize(float(size_mu))
-            text_format.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+            text_format.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
         except Exception as e:
             logger.debug(f"Error in apply_fixed_text_label: {e}")
 
@@ -704,7 +704,7 @@ def is_route_layer(layer: QgsVectorLayer) -> bool:
         from qgis.core import QgsWkbTypes
 
         name = (layer.name() or "").lower()
-        is_line = layer.geometryType() == QgsWkbTypes.LineGeometry
+        is_line = layer.geometryType() == QgsWkbTypes.GeometryType.LineGeometry
 
         return is_line and name in ('trasa', 'route', 'routes')
     except Exception:
@@ -728,7 +728,7 @@ def is_cable_layer(layer: QgsVectorLayer) -> bool:
         from qgis.core import QgsWkbTypes
 
         name = (layer.name() or "").lower()
-        is_line = layer.geometryType() == QgsWkbTypes.LineGeometry
+        is_line = layer.geometryType() == QgsWkbTypes.GeometryType.LineGeometry
 
         cable_keywords = ['kabl', 'cable', 'kablo']
         return is_line and any(kw in name for kw in cable_keywords)
@@ -753,7 +753,7 @@ def is_pole_layer(layer: QgsVectorLayer) -> bool:
         from qgis.core import QgsWkbTypes
 
         name = (layer.name() or "").lower()
-        is_point = layer.geometryType() == QgsWkbTypes.PointGeometry
+        is_point = layer.geometryType() == QgsWkbTypes.GeometryType.PointGeometry
 
         return is_point and name in ('stubovi', 'poles', 'pole')
     except Exception:

--- a/fiberq/utils/legacy_bridge.py
+++ b/fiberq/utils/legacy_bridge.py
@@ -169,14 +169,14 @@ def _apply_fixed_text_label(layer, field_name='naziv', size_mu=8.0, yoff_mu=5.0)
         try:
             s.xOffset = 0.0
             s.yOffset = float(yoff_mu)
-            s.offsetUnits = QgsUnitTypes.RenderMapUnits
+            s.offsetUnits = QgsUnitTypes.RenderUnit.RenderMapUnits
         except Exception as e:
             logger.debug(f"Error in _apply_fixed_text_label: {e}")
 
         tf = QgsTextFormat()
         try:
             tf.setSize(float(size_mu))
-            tf.setSizeUnit(QgsUnitTypes.RenderMapUnits)
+            tf.setSizeUnit(QgsUnitTypes.RenderUnit.RenderMapUnits)
         except Exception as e:
             logger.debug(f"Error in _apply_fixed_text_label: {e}")
 
@@ -284,7 +284,7 @@ def _ensure_region_layer(core):
             try:
                 if (
                     isinstance(lyr, QgsVectorLayer)
-                    and lyr.geometryType() == QgsWkbTypes.PolygonGeometry  # noqa: W503
+                    and lyr.geometryType() == QgsWkbTypes.GeometryType.PolygonGeometry  # noqa: W503
                     and lyr.name() in ('Rejon', 'Service Area')  # noqa: W503
                 ):
                     # If old name 'Rejon', rename so user sees 'Service Area'
@@ -353,10 +353,10 @@ def _ensure_objects_layer(core):
                 if (
                     isinstance(lyr, QgsVectorLayer)
                     and lyr.wkbType() in (  # noqa: W503
-                        QgsWkbTypes.Polygon,
-                        QgsWkbTypes.MultiPolygon,
-                        QgsWkbTypes.PolygonZM,
-                        QgsWkbTypes.MultiPolygonZM,
+                        QgsWkbTypes.Type.Polygon,
+                        QgsWkbTypes.Type.MultiPolygon,
+                        QgsWkbTypes.Type.PolygonZM,
+                        QgsWkbTypes.Type.MultiPolygonZM,
                     )
                     and lyr.name() in ("Objekti", "Objects")  # noqa: W503
                 ):
@@ -422,7 +422,7 @@ def _stylize_objects_layer(layer):
         simple.setFillColor(QColor(0, 0, 0, 0))
         simple.setStrokeColor(QColor(0, 0, 0))
         simple.setStrokeWidth(0.8)
-        simple.setStrokeWidthUnit(QgsUnitTypes.RenderMillimeters)
+        simple.setStrokeWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
 
         hatch = QgsLinePatternFillSymbolLayer()
         try:
@@ -436,7 +436,7 @@ def _stylize_objects_layer(layer):
         except Exception as e:
             logger.debug(f"Error in _stylize_objects_layer: {e}")
         hatch.setDistance(2.2)
-        hatch.setDistanceUnit(QgsUnitTypes.RenderMillimeters)
+        hatch.setDistanceUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
         try:
             sub = hatch.subSymbol()
             if sub and sub.symbolLayerCount() > 0:
@@ -447,7 +447,7 @@ def _stylize_objects_layer(layer):
                     logger.debug(f"Could not set hatch color: {e}")
                 try:
                     sl.setWidth(0.3)
-                    sl.setWidthUnit(QgsUnitTypes.RenderMillimeters)
+                    sl.setWidthUnit(QgsUnitTypes.RenderUnit.RenderMillimeters)
                 except Exception as e:
                     logger.debug(f"Error in _stylize_objects_layer: {e}")
         except Exception as e:


### PR DESCRIPTION
The plugins.qgis.org **Qt6 Check** flagged **251 unscoped enum accesses** that break on PyQt6 / QGIS 4. This scopes all of them via their enum class.

## Fix
- e.g. `QgsWkbTypes.PointGeometry` → `QgsWkbTypes.GeometryType.PointGeometry`; covers **GeometryType, WKB Type, RenderUnit, DistanceUnit, WriterError, ActionOnExistingFile, ErrorCode, IconType, Shape, Capability, Property, Flag, Placement**.
- Deterministic, **word-boundary-safe** replacement (distinctive `Qgs<Class>.` prefixes) — verified `QgsWkbTypes.Polygon`→`Type.Polygon` did **not** disturb `PolygonGeometry`→`GeometryType.PolygonGeometry`.
- **Behaviour unchanged on QGIS 3 / Qt5** — scoped enums work on both.
- Kept at **version 1.3.0** (folding in the earlier Bandit scan-hardening); changelog consolidated to one 1.3.0 entry.

## Verification
- **0** unscoped enum forms remaining · **0** double-scoping · `py_compile` OK on all 37 files.
- flake8 **0** · Bandit all-severity **0**.
- CI runs the suite on QGIS 3 (Qt5) + QGIS 4 (Qt6) — the runtime proof for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)