### PR TITLE
Support/sponsor links (README + plugin About) — queue for v1.4.0, do not merge standalone

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,8 @@
-github: [vukovicvl]
+# Shown as the "Sponsor" button on the GitHub repo. Personal GitHub Sponsors
+# is the active channel: https://github.com/sponsors/vukovicvl
+# Uncomment the others once those accounts exist — they enable instant,
+# one-off giving without waiting on GitHub Sponsors approval.
+github: vukovicvl
+# ko_fi: <ko-fi-handle>
+# liberapay: <liberapay-handle>
+# custom: ["https://www.fiberq.net/"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Commons Fund**. Sponsorship keeps it maintained and moving beyond that grant —
 independent of any single funder.
 
 - ❤️ **Sponsor development (GitHub Sponsors):** https://github.com/sponsors/vukovicvl
+- 🌐 **Other ways to give (one-off / card):** https://www.fiberq.net/donate/
 
 ## Use of Generative AI
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ For the full feature list and install instructions, see [fiberq/README.md](fiber
 - 🐛 **Bug reports (GitHub Issues):** https://github.com/vukovicvl/fiberq/issues
 - 📊 **Polls (priorities & decisions):** https://github.com/vukovicvl/fiberq/discussions/categories/polls
 
+## Support FiberQ
+
+FiberQ is open source (GPL-3.0) and developed with support from the **NLnet NGI0
+Commons Fund**. Sponsorship keeps it maintained and moving beyond that grant —
+independent of any single funder.
+
+- ❤️ **Sponsor development (GitHub Sponsors):** https://github.com/sponsors/vukovicvl
+
 ## Use of Generative AI
 
 Parts of FiberQ are developed with the help of generative AI tools (Anthropic's

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,8 @@ When to bump which part:
 - [ ] `version=` bumped in `fiberq/metadata.txt`, and `__version__` in
       `fiberq/__init__.py` matches.
 - [ ] `changelog=` block in `fiberq/metadata.txt` updated for this version.
+- [ ] Release notes / `changelog=` include a one-line pointer to sponsorship
+      (e.g. "If FiberQ helps your work, you can now sponsor its development.").
 - [ ] `fiberq/config.ini` contains no credentials or machine-specific paths.
 - [ ] "Use of Generative AI" section present/current in `fiberq/README.md`
       (shipped) and the repo-root `README.md` (public landing page).

--- a/fiberq/config.ini
+++ b/fiberq/config.ini
@@ -38,6 +38,7 @@ rezerve_geom = geom
 
 [web]
 viewer_url = https://www.fiberq.net/
+support_url = https://github.com/sponsors/vukovicvl
 
 [basemaps]
 osm_url = https://tile.openstreetmap.org/{z}/{x}/{y}.png

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -853,7 +853,10 @@ class FiberQPlugin:
             if viewer_url:
                 parts.append(f"<b>Preview map URL:</b> <a href='{viewer_url}'>{viewer_url}</a><br>")
             if support_url:
-                parts.append(f"<b>Support URL:</b> <a href='{support_url}'>{support_url}</a><br>")
+                parts.append(
+                    "<b>&#10084; Support FiberQ:</b> "
+                    f"<a href='{support_url}'>sponsor its ongoing development</a><br>"
+                )
             # NEW: call-to-action text
             parts.append("<hr style='margin:10px 0'>")
             parts.append(


### PR DESCRIPTION
## Summary

Adds a visible "support / sponsor development" path in the two places users and
companies meet FiberQ — the GitHub repo README and the in-QGIS Help/About dialog —
plus a standing release-checklist reminder. Sponsorship channels are already live:
GitHub Sponsors (`github.com/sponsors/vukovicvl`) and a website donate page
(`fiberq.net/donate`).

## Changes

- `.github/FUNDING.yml` — personal GitHub Sponsors active; `ko_fi` / `liberapay` /
  `custom` left as commented placeholders for later one-off options.
- `fiberq/config.ini` `[web]` — `support_url` set to the Sponsors page. The About
  dialog already renders `support_url`, so **no new code path** is introduced.
- `fiberq/main_plugin.py` — the About-dialog support line reworded into a
  "Support FiberQ — sponsor its ongoing development" call to action.
- `README.md` — new "Support FiberQ" section: GitHub Sponsors + `fiberq.net/donate`,
  framed as sustainability alongside the NLnet NGI0 grant.
- `RELEASE.md` — checklist item so every release's notes carry a one-line
  sponsorship pointer.

## Release timing

**Draft — do not merge standalone. Queue for v1.4.0 (WP2).**

- The About-dialog change only reaches users when v1.4.0 is packaged, so it ships
  with the release automatically.
- The README section appears on the repo landing page **as soon as this merges to
  `main`** — so hold the merge until the v1.4.0 release so both land with the
  announcement.

## Notes

- Scan clean: `flake8 --isolated --max-line-length=120 --ignore=E501` + Bandit `-ll`
  = **0/0**. No functional/logic change.
- The About-dialog body is not `tr()`-wrapped today, so the new line ships as
  English (consistent with the rest of that dialog). If translation is wanted for
  v1.4.0, wrap it in `self.tr()` and run `make i18n-update` in the WP2 i18n top-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
