### PR TITLE
WP2 — validation engine core: runner, rule registry, B4/C1/D1

### DIFF
--- a/fiberq/core/validation_manager.py
+++ b/fiberq/core/validation_manager.py
@@ -1,0 +1,269 @@
+"""FiberQ project validation engine (WP2, task 2.1).
+
+A UI-independent, testable validation service. It runs a registry of rules over
+the FiberQ layers in a project and returns a structured :class:`ValidationResult`
+(severity, layer, feature id, message) rather than log lines, so the result can be
+rendered to a panel (WP2 UI) or exported to a QA report (WP2 task 2.2).
+
+Design notes
+------------
+* **No QGIS import at module top.** The data model (``Severity``,
+  ``ValidationIssue``, ``ValidationResult``, ``ValidationRule``) and the rule
+  registry are pure Python, so they can be imported and unit-tested without a
+  running QGIS. Everything that needs QGIS (``QgsProject``, ``QgsSpatialIndex``,
+  ``QgsVectorLayer``) is imported lazily inside the runner / context, which only
+  execute under QGIS.
+* **Canonical-name aware.** Layers are resolved via
+  ``models.schema.canonical_layer_name`` over ``QgsProject.mapLayers()`` — never
+  by ``mapLayersByName``, because some layers are created under a different name
+  than their canonical one (e.g. the slack layer is created as "Optical slacks"
+  but its canonical name is "Optical slack").
+* **One failing rule never stops the run.** Each rule is wrapped; a failure is
+  recorded in ``rule_errors`` (surfaced, not swallowed — WP4 theme) and the
+  remaining rules still run. The runner never raises.
+
+The rule registry and the individual checks live in :mod:`.validation_rules`.
+"""
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+from ..models import schema
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+class Severity(enum.Enum):
+    """Issue severity. The ``value`` is a stable identifier used in CSV/JSON
+    exports and must not be translated."""
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+# Sort/summary order: errors first.
+SEVERITY_ORDER: Dict[Severity, int] = {
+    Severity.ERROR: 0,
+    Severity.WARNING: 1,
+    Severity.INFO: 2,
+}
+
+
+@dataclass
+class ValidationIssue:
+    """One problem found by a rule, tied to a feature where possible."""
+    rule_id: str
+    severity: Severity
+    category: str
+    message: str
+    layer_name: str = ""
+    layer_id: str = ""
+    feature_id: int = -1
+    fiberq_uuid: str = ""
+    where: Optional[Tuple[float, float]] = None  # map coords for zoom/flash
+    details: Dict[str, Any] = field(default_factory=dict)
+    fix_hint: str = ""
+
+
+@dataclass
+class ValidationRule:
+    """A registry entry. ``check`` receives a :class:`ValidationContext` and
+    yields :class:`ValidationIssue`. ``title`` is marked for translation with
+    ``QT_TRANSLATE_NOOP('ValidationRules', ...)`` at its definition site and is
+    translated at display time only. ``applies_to`` is a tuple of canonical layer
+    names, or empty for a project-wide rule."""
+    id: str
+    title: str
+    category: str
+    default_severity: Severity
+    check: Callable[["ValidationContext"], Iterable[ValidationIssue]]
+    applies_to: Tuple[str, ...] = ()
+
+
+@dataclass
+class ValidationConfig:
+    """Runtime configuration. Persisted to a project entry
+    (``FiberQPlugin/validation``) by the UI layer so it travels with the project."""
+    tol: float = 5.0  # snap tolerance in map units (reuses the relations default)
+    disabled_rules: set = field(default_factory=set)
+    severity_overrides: Dict[str, Severity] = field(default_factory=dict)
+
+    def is_enabled(self, rule_id: str) -> bool:
+        return rule_id not in self.disabled_rules
+
+    def severity_for(self, rule: ValidationRule) -> Severity:
+        return self.severity_overrides.get(rule.id, rule.default_severity)
+
+
+@dataclass
+class ValidationResult:
+    """The structured outcome of a validation run."""
+    project_name: str = ""
+    crs: str = ""
+    schema_version: str = ""
+    plugin_version: str = ""
+    timestamp: Optional[str] = None  # passed in — no wall-clock inside pure logic
+    feature_counts: Dict[str, int] = field(default_factory=dict)
+    issues: List[ValidationIssue] = field(default_factory=list)
+    ran_rules: List[str] = field(default_factory=list)
+    skipped_rules: List[str] = field(default_factory=list)
+    rule_errors: List[str] = field(default_factory=list)
+
+    def add(self, issue: ValidationIssue) -> None:
+        self.issues.append(issue)
+
+    def counts_by_severity(self) -> Dict[str, int]:
+        out = {s.value: 0 for s in Severity}
+        for issue in self.issues:
+            out[issue.severity.value] += 1
+        return out
+
+    def counts_by_category(self) -> Dict[str, int]:
+        out: Dict[str, int] = {}
+        for issue in self.issues:
+            out[issue.category] = out.get(issue.category, 0) + 1
+        return out
+
+    def sorted_issues(self) -> List[ValidationIssue]:
+        """Issues ordered most-severe first, then by rule and layer."""
+        return sorted(
+            self.issues,
+            key=lambda i: (SEVERITY_ORDER.get(i.severity, 9), i.rule_id, i.layer_name),
+        )
+
+    def summary(self) -> str:
+        """Plain developer/log one-liner. The user-facing, translated message-bar
+        text (with %n plurals) is built in the UI trigger, which is a QObject."""
+        c = self.counts_by_severity()
+        return (f"Validation: {c['error']} error(s), "
+                f"{c['warning']} warning(s), {c['info']} info")
+
+
+# ---------------------------------------------------------------------------
+# Context
+# ---------------------------------------------------------------------------
+
+class ValidationContext:
+    """Carries the resolved FiberQ layers, tolerances/config, and a lazily-built,
+    shared ``QgsSpatialIndex`` per layer (built once, reused across topology
+    rules). QGIS types are imported lazily so the module stays import-clean
+    without QGIS."""
+
+    def __init__(self, project, config: Optional[ValidationConfig] = None):
+        self.project = project
+        self.config = config or ValidationConfig()
+        self._layers_by_canonical: Optional[Dict[str, list]] = None
+        self._index_cache: Dict[str, Any] = {}
+
+    @property
+    def layers_by_canonical(self) -> Dict[str, list]:
+        """Map canonical layer name -> list of live QgsVectorLayers, resolved via
+        ``canonical_layer_name`` over every project layer (handles legacy/plural
+        names). Cached for the lifetime of the run."""
+        if self._layers_by_canonical is None:
+            from qgis.core import QgsVectorLayer
+            mapping: Dict[str, list] = {}
+            for layer in self.project.mapLayers().values():
+                if not isinstance(layer, QgsVectorLayer):
+                    continue
+                canonical = schema.canonical_layer_name(layer.name())
+                if canonical is None:
+                    continue
+                mapping.setdefault(canonical, []).append(layer)
+            self._layers_by_canonical = mapping
+        return self._layers_by_canonical
+
+    def layers_for(self, *canonical_names: str) -> list:
+        """All live layers whose canonical name is one of ``canonical_names``
+        (all resolved FiberQ layers when called with no argument)."""
+        by = self.layers_by_canonical
+        if not canonical_names:
+            return [lyr for lst in by.values() for lyr in lst]
+        return [lyr for name in canonical_names for lyr in by.get(name, [])]
+
+    def spatial_index(self, layer):
+        """Lazily build and cache a QgsSpatialIndex for ``layer`` (shared across
+        topology rules; used from the wp2-topology branch onward)."""
+        key = layer.id()
+        if key not in self._index_cache:
+            from qgis.core import QgsSpatialIndex
+            self._index_cache[key] = QgsSpatialIndex(layer.getFeatures())
+        return self._index_cache[key]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run_validation(project=None, rules=None, config=None,
+                   timestamp=None, plugin_version="") -> ValidationResult:
+    """Run the validation rules over ``project`` and return a structured result.
+
+    ``project`` defaults to the current ``QgsProject``. ``rules`` defaults to the
+    full registry (:data:`fiberq.core.validation_rules.RULES`). Each rule is run
+    inside a try/except: a failure is recorded in ``result.rule_errors`` and the
+    remaining rules still run. Never raises.
+    """
+    from qgis.core import QgsProject
+
+    if project is None:
+        project = QgsProject.instance()
+    cfg = config or ValidationConfig()
+    ctx = ValidationContext(project, cfg)
+
+    if rules is None:
+        # Lazy import breaks the manager<->rules import cycle (rules imports the
+        # data model above; the manager only needs the registry at call time).
+        from .validation_rules import RULES
+        rules = RULES
+
+    result = ValidationResult(
+        project_name=project.baseName() or project.fileName(),
+        crs=_project_crs(project),
+        schema_version=_project_schema_version(project),
+        plugin_version=plugin_version,
+        timestamp=timestamp,
+        feature_counts=_feature_counts(ctx),
+    )
+
+    for rule in rules:
+        if not cfg.is_enabled(rule.id):
+            result.skipped_rules.append(rule.id)
+            continue
+        override = cfg.severity_overrides.get(rule.id)
+        try:
+            for issue in rule.check(ctx):
+                # A rule sets each issue's severity; a configured per-rule override
+                # (if any) wins, so a site can downgrade e.g. C1 to INFO.
+                if override is not None:
+                    issue.severity = override
+                result.add(issue)
+            result.ran_rules.append(rule.id)
+        except Exception as e:  # one bad rule must not sink the run (WP4 theme)
+            result.rule_errors.append(f"{rule.id}: {e}")
+            logger.warning(f"Validation rule '{rule.id}' failed: {e}")
+
+    logger.info(result.summary())
+    return result
+
+
+def _project_crs(project) -> str:
+    crs = project.crs()
+    return crs.authid() if crs and crs.isValid() else ""
+
+
+def _project_schema_version(project) -> str:
+    from .schema_version import read_project_schema_version
+    return read_project_schema_version(project)
+
+
+def _feature_counts(ctx: ValidationContext) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for canonical, layers in ctx.layers_by_canonical.items():
+        counts[canonical] = sum(lyr.featureCount() for lyr in layers)
+    return counts

--- a/fiberq/core/validation_rules.py
+++ b/fiberq/core/validation_rules.py
@@ -1,0 +1,276 @@
+"""FiberQ validation rule registry (WP2, task 2.1).
+
+The rules that :func:`fiberq.core.validation_manager.run_validation` executes. The
+registry mirrors WP1's ``MIGRATIONS`` list: a list of small dataclass entries,
+each carrying a ``check`` callable. Unlike the migration chain (which stops on the
+first failure), validation rules are independent — the runner ``continue``s past a
+failing rule.
+
+i18n (read before adding a rule)
+--------------------------------
+Rule ``title`` strings are **module-level data**, which is exactly the shape that
+hits the ``tr()`` context trap. They are therefore marked with
+``QT_TRANSLATE_NOOP('ValidationRules', ...)`` at definition (returns the literal
+unchanged, so the table built at import time is not frozen to English) and
+translated at *display* time with ``QCoreApplication.translate('ValidationRules',
+title)``. Rule *messages* are built at run time and use the explicit inline form
+``QCoreApplication.translate('ValidationRules', "literal")`` directly at the call
+site — never a module-level ``tr()`` helper, which pylupdate6 cannot extract.
+
+Not translated: ``rule_id``, ``category``, ``severity`` values, and stored
+layer/field names (passed through ``{field}``/``{layer}`` placeholders as data).
+
+This module has no QGIS import at top level, so the registry can be imported and
+asserted in a pure unit test; QGIS types (``NULL``, feature/geometry access) are
+imported lazily inside the checks, which only run under QGIS.
+"""
+from ..models import schema
+from .validation_manager import Severity, ValidationIssue, ValidationRule
+
+try:
+    from qgis.PyQt.QtCore import QCoreApplication, QT_TRANSLATE_NOOP
+except ImportError:  # pragma: no cover - keep importable without Qt (pure tests)
+    def QT_TRANSLATE_NOOP(context, text):
+        return text
+
+    class _NoQtTranslate:
+        @staticmethod
+        def translate(context, text, *args):
+            return text
+
+    QCoreApplication = _NoQtTranslate
+
+_CTX = "ValidationRules"
+
+# Categories are stable identifiers (grouping keys in the report), not translated.
+_CAT_IDENTITY = "identity"
+_CAT_COMPLETENESS = "completeness"
+_CAT_DOMAIN = "domain"
+
+# Required, domain-meaningful fields per layer type (fiberq_uuid is B4's concern,
+# not repeated here). Element layers share one set; the rest are keyed by
+# canonical layer name.
+_ELEMENT_REQUIRED = ("naziv", "kapacitet")
+_REQUIRED_BY_LAYER = {
+    "Aerial cables": ("tip", "broj_vlakana"),
+    "Underground cables": ("tip", "broj_vlakana"),
+    "Route": ("naziv",),
+    "PE pipes": ("fi",),
+    "Transition pipes": ("fi",),
+}
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (QGIS-aware, called only from checks)
+# ---------------------------------------------------------------------------
+
+def _is_blank(value, null) -> bool:
+    """True for a missing / null / whitespace-only attribute value."""
+    if value is None or value == null:
+        return True
+    return isinstance(value, str) and value.strip() == ""
+
+
+def _feature_xy(feat):
+    """A representative (x, y) for navigation/zoom, or None."""
+    geom = feat.geometry()
+    if geom is None or geom.isNull() or geom.isEmpty():
+        return None
+    centroid = geom.centroid()
+    if centroid.isNull() or centroid.isEmpty():
+        return None
+    point = centroid.asPoint()
+    return (point.x(), point.y())
+
+
+def _uuid_of(feat) -> str:
+    from ..utils.uuid_utils import FIBERQ_UUID_FIELD
+    idx = feat.fields().indexOf(FIBERQ_UUID_FIELD)
+    if idx < 0:
+        return ""
+    value = feat.attribute(idx)
+    return "" if value is None else str(value)
+
+
+def _safe_format(translated, source, **kwargs):
+    """Interpolate into a translated message, falling back to the English source
+    if a volunteer renamed a placeholder (see ``fiberq.i18n.safe_format``)."""
+    from ..i18n import safe_format
+    return safe_format(translated, source, **kwargs)
+
+
+def _allowed_domain(field_def):
+    """The set of valid *stored* values for an enum field. ``value_map`` is
+    ``{display: stored}``, so the stored domain is its values (e.g. cable ``tip``
+    -> ``{opticki, bakarnI}`` — the as-built typo is honoured because the domain
+    is read from the schema, not hardcoded)."""
+    if field_def.value_map:
+        return set(field_def.value_map.values())
+    if field_def.options:
+        return set(field_def.options)
+    return set()
+
+
+def _required_fields_for(canonical: str):
+    if schema.is_element_layer(canonical):
+        return _ELEMENT_REQUIRED
+    return _REQUIRED_BY_LAYER.get(canonical, ())
+
+
+# ---------------------------------------------------------------------------
+# B4 — identity invariant (validates the WP1 fiberq_uuid guarantee at rest)
+# ---------------------------------------------------------------------------
+
+def _check_identity(ctx):
+    from qgis.core import NULL
+    from ..utils.uuid_utils import FIBERQ_UUID_FIELD
+
+    seen = {}  # uuid value -> (layer_name, feature_id) of its first occurrence
+    for layers in ctx.layers_by_canonical.values():
+        for layer in layers:
+            idx = layer.fields().indexOf(FIBERQ_UUID_FIELD)
+            if idx < 0:
+                yield ValidationIssue(
+                    rule_id="B4", severity=Severity.ERROR, category=_CAT_IDENTITY,
+                    message=QCoreApplication.translate(
+                        _CTX, "Layer is missing the fiberq_uuid identity field"),
+                    layer_name=layer.name(), layer_id=layer.id(),
+                    fix_hint=QCoreApplication.translate(
+                        _CTX, "Re-open the project so migration can add fiberq_uuid, "
+                              "or re-create the layer."),
+                )
+                continue
+            for feat in layer.getFeatures():
+                value = feat.attribute(idx)
+                if _is_blank(value, NULL):
+                    yield ValidationIssue(
+                        rule_id="B4", severity=Severity.ERROR, category=_CAT_IDENTITY,
+                        message=QCoreApplication.translate(
+                            _CTX, "Feature has no fiberq_uuid value"),
+                        layer_name=layer.name(), layer_id=layer.id(),
+                        feature_id=feat.id(), where=_feature_xy(feat),
+                    )
+                    continue
+                key = str(value)
+                if key in seen:
+                    prev_layer, prev_fid = seen[key]
+                    src = ("Duplicate fiberq_uuid — the same identity is already "
+                           "used by feature {fid} in layer {layer}")
+                    yield ValidationIssue(
+                        rule_id="B4", severity=Severity.ERROR, category=_CAT_IDENTITY,
+                        message=_safe_format(
+                            QCoreApplication.translate(_CTX, src), src,
+                            fid=prev_fid, layer=prev_layer),
+                        layer_name=layer.name(), layer_id=layer.id(),
+                        feature_id=feat.id(), fiberq_uuid=key, where=_feature_xy(feat),
+                        details={"duplicate_of_layer": prev_layer,
+                                 "duplicate_of_fid": prev_fid},
+                    )
+                else:
+                    seen[key] = (layer.name(), feat.id())
+
+
+# ---------------------------------------------------------------------------
+# C1 — required attributes present
+# ---------------------------------------------------------------------------
+
+def _check_required_fields(ctx):
+    from qgis.core import NULL
+
+    for canonical, layers in ctx.layers_by_canonical.items():
+        required = _required_fields_for(canonical)
+        if not required:
+            continue
+        for layer in layers:
+            names = set(layer.fields().names())
+            for feat in layer.getFeatures():
+                missing = [
+                    f for f in required
+                    if f not in names or _is_blank(feat.attribute(f), NULL)
+                ]
+                if not missing:
+                    continue
+                src = "Required field(s) missing or empty: {fields}"
+                yield ValidationIssue(
+                    rule_id="C1", severity=Severity.WARNING, category=_CAT_COMPLETENESS,
+                    message=_safe_format(
+                        QCoreApplication.translate(_CTX, src), src,
+                        fields=", ".join(missing)),
+                    layer_name=layer.name(), layer_id=layer.id(),
+                    feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                    where=_feature_xy(feat), details={"missing": missing},
+                )
+
+
+# ---------------------------------------------------------------------------
+# D1 — enum conformance (domains read from the schema, never hardcoded)
+# ---------------------------------------------------------------------------
+
+def _check_enum_conformance(ctx):
+    from qgis.core import NULL
+
+    for canonical, layers in ctx.layers_by_canonical.items():
+        layer_schema = schema.get_layer_schema(canonical)
+        if layer_schema is None:
+            continue
+        enum_fields = [
+            (f.key, _allowed_domain(f)) for f in layer_schema.fields
+            if f.value_map or f.options
+        ]
+        enum_fields = [(key, dom) for key, dom in enum_fields if dom]
+        if not enum_fields:
+            continue
+        for layer in layers:
+            names = set(layer.fields().names())
+            active = [(key, dom) for key, dom in enum_fields if key in names]
+            for feat in layer.getFeatures():
+                for key, allowed in active:
+                    value = feat.attribute(key)
+                    if _is_blank(value, NULL):
+                        continue  # emptiness is C1's concern, not D1's
+                    if str(value) in allowed:
+                        continue
+                    src = ("Field {field}: value {value} is not one of the "
+                           "allowed values ({allowed})")
+                    yield ValidationIssue(
+                        rule_id="D1", severity=Severity.WARNING, category=_CAT_DOMAIN,
+                        message=_safe_format(
+                            QCoreApplication.translate(_CTX, src), src,
+                            field=key, value=value,
+                            allowed=", ".join(sorted(allowed))),
+                        layer_name=layer.name(), layer_id=layer.id(),
+                        feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                        where=_feature_xy(feat),
+                        details={"field": key, "value": str(value),
+                                 "allowed": sorted(allowed)},
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Registry — [core] rules shipping in v1.4.0. Append as the engine grows;
+# keep each rule independent (the runner continues past a failing one).
+# ---------------------------------------------------------------------------
+
+RULES = [
+    ValidationRule(
+        id="B4",
+        title=QT_TRANSLATE_NOOP(_CTX, "Feature identity present and unique"),
+        category=_CAT_IDENTITY,
+        default_severity=Severity.ERROR,
+        check=_check_identity,
+    ),
+    ValidationRule(
+        id="C1",
+        title=QT_TRANSLATE_NOOP(_CTX, "Required attributes present"),
+        category=_CAT_COMPLETENESS,
+        default_severity=Severity.WARNING,
+        check=_check_required_fields,
+    ),
+    ValidationRule(
+        id="D1",
+        title=QT_TRANSLATE_NOOP(_CTX, "Attribute values within allowed domain"),
+        category=_CAT_DOMAIN,
+        default_severity=Severity.WARNING,
+        check=_check_enum_conformance,
+    ),
+]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,189 @@
+"""Tests for the WP2 validation engine (core: runner + registry + B4/C1/D1).
+
+These need a QgsApplication (provided by pytest-qgis): the rules read features
+from in-memory QgsVectorLayers. Each test builds a tiny project with a known
+defect and asserts exactly the expected issue(s). No translator is installed, so
+``QCoreApplication.translate`` returns the English source — issue text is English.
+"""
+from qgis.core import (
+    QgsFeature,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProject,
+    QgsVectorLayer,
+)
+
+from fiberq.core import validation_manager as vm
+from fiberq.core import validation_rules as vr
+
+
+def _mk_layer(name, fields, rows, geom_type="Point", crs="EPSG:3857"):
+    """Build a valid in-memory layer. ``fields`` are "key:type" strings; ``rows``
+    are (attrs_dict, QgsPointXY|None) tuples."""
+    uri = geom_type + "?crs=" + crs
+    for field_spec in fields:
+        uri += "&field=" + field_spec
+    layer = QgsVectorLayer(uri, name, "memory")
+    assert layer.isValid(), f"failed to build memory layer {name!r}"
+    feats = []
+    for attrs, point in rows:
+        feat = QgsFeature(layer.fields())
+        for key, value in attrs.items():
+            feat.setAttribute(key, value)
+        if point is not None:
+            feat.setGeometry(QgsGeometry.fromPointXY(point))
+        feats.append(feat)
+    layer.dataProvider().addFeatures(feats)
+    layer.updateExtents()
+    return layer
+
+
+def _issues(result, rule_id):
+    return [i for i in result.issues if i.rule_id == rule_id]
+
+
+# ---------------------------------------------------------------------------
+# Registry integrity (pure metadata)
+# ---------------------------------------------------------------------------
+
+def test_registry_ids_unique_and_wellformed():
+    ids = [r.id for r in vr.RULES]
+    assert ids == ["B4", "C1", "D1"]
+    assert len(ids) == len(set(ids))
+    for rule in vr.RULES:
+        assert rule.id and rule.title and rule.category
+        assert callable(rule.check)
+        assert isinstance(rule.default_severity, vm.Severity)
+
+
+# ---------------------------------------------------------------------------
+# Layer resolution — the "Optical slacks" plural / canonical divergence
+# ---------------------------------------------------------------------------
+
+def test_plural_slack_layer_resolves_to_canonical():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer("Optical slacks", ["fiberq_uuid:string"], []))
+    ctx = vm.ValidationContext(project)
+    # Created as the plural "Optical slacks"; canonical name is "Optical slack".
+    assert "Optical slack" in ctx.layers_by_canonical
+
+
+# ---------------------------------------------------------------------------
+# B4 — identity invariant
+# ---------------------------------------------------------------------------
+
+def test_b4_flags_missing_and_duplicate_uuid():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer(
+        "ODF", ["fiberq_uuid:string", "naziv:string", "kapacitet:integer"],
+        [({"fiberq_uuid": "a", "naziv": "x", "kapacitet": 1}, QgsPointXY(0, 0)),
+         ({"fiberq_uuid": "", "naziv": "y", "kapacitet": 1}, QgsPointXY(1, 1)),
+         ({"fiberq_uuid": "a", "naziv": "z", "kapacitet": 1}, QgsPointXY(2, 2))],
+    ))
+    b4 = _issues(vm.run_validation(project), "B4")
+    assert len(b4) == 2
+    assert {i.severity for i in b4} == {vm.Severity.ERROR}
+    kinds = sorted(
+        "dup" if i.details.get("duplicate_of_fid") is not None else "blank"
+        for i in b4
+    )
+    assert kinds == ["blank", "dup"]
+
+
+def test_b4_flags_layer_missing_uuid_field():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer(
+        "ODF", ["naziv:string", "kapacitet:integer"],
+        [({"naziv": "x", "kapacitet": 1}, QgsPointXY(0, 0))],
+    ))
+    b4 = _issues(vm.run_validation(project), "B4")
+    assert len(b4) == 1
+    assert b4[0].feature_id == -1  # a layer-level issue, not a feature one
+
+
+# ---------------------------------------------------------------------------
+# C1 — required attributes present
+# ---------------------------------------------------------------------------
+
+def test_c1_flags_missing_required_on_cable():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer(
+        "Underground cables",
+        ["fiberq_uuid:string", "tip:string", "broj_vlakana:integer"],
+        [({"fiberq_uuid": "u1", "tip": "opticki", "broj_vlakana": 12}, QgsPointXY(0, 0)),
+         ({"fiberq_uuid": "u2", "tip": "", "broj_vlakana": 24}, QgsPointXY(1, 1))],
+    ))
+    c1 = _issues(vm.run_validation(project), "C1")
+    assert len(c1) == 1
+    assert c1[0].details["missing"] == ["tip"]
+    assert c1[0].severity == vm.Severity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# D1 — enum conformance (domains read from the schema, as-built typo honoured)
+# ---------------------------------------------------------------------------
+
+def test_d1_accepts_asbuilt_typo_and_flags_bad_value():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer(
+        "Underground cables",
+        ["fiberq_uuid:string", "tip:string", "broj_vlakana:integer"],
+        [({"fiberq_uuid": "u1", "tip": "opticki", "broj_vlakana": 12}, QgsPointXY(0, 0)),
+         ({"fiberq_uuid": "u2", "tip": "bakarnI", "broj_vlakana": 12}, QgsPointXY(1, 1)),
+         ({"fiberq_uuid": "u3", "tip": "banana", "broj_vlakana": 12}, QgsPointXY(2, 2))],
+    ))
+    d1 = _issues(vm.run_validation(project), "D1")
+    assert len(d1) == 1  # opticki + the bakarnI typo are both valid stored values
+    assert d1[0].details["field"] == "tip"
+    assert d1[0].details["value"] == "banana"
+    assert "bakarnI" in d1[0].details["allowed"]
+    assert "opticki" in d1[0].details["allowed"]
+
+
+# ---------------------------------------------------------------------------
+# Runner behaviour
+# ---------------------------------------------------------------------------
+
+def test_clean_project_has_no_issues():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer(
+        "Underground cables",
+        ["fiberq_uuid:string", "tip:string", "broj_vlakana:integer"],
+        [({"fiberq_uuid": "u1", "tip": "opticki", "broj_vlakana": 12}, QgsPointXY(0, 0))],
+    ))
+    result = vm.run_validation(project)
+    assert result.issues == []
+    assert result.feature_counts.get("Underground cables") == 1
+
+
+def test_empty_project_runs_clean():
+    result = vm.run_validation(QgsProject())
+    assert result.issues == []
+    assert result.ran_rules  # every rule still ran (over zero layers)
+    assert not result.rule_errors
+
+
+def test_failing_rule_is_recorded_not_raised():
+    def boom(ctx):
+        raise RuntimeError("kaboom")
+        yield  # noqa: unreachable — makes boom a generator like a real check
+
+    bad = vm.ValidationRule(
+        id="X1", title="x", category="c",
+        default_severity=vm.Severity.INFO, check=boom,
+    )
+    result = vm.run_validation(QgsProject(), rules=[bad, vr.RULES[0]])
+    assert any("X1" in e for e in result.rule_errors)
+    assert "B4" in result.ran_rules  # the good rule still ran after the bad one
+
+
+def test_severity_override_downgrades_rule():
+    project = QgsProject()
+    project.addMapLayer(_mk_layer(
+        "Underground cables",
+        ["fiberq_uuid:string", "tip:string", "broj_vlakana:integer"],
+        [({"fiberq_uuid": "u1", "tip": "", "broj_vlakana": 12}, QgsPointXY(0, 0))],
+    ))
+    cfg = vm.ValidationConfig(severity_overrides={"C1": vm.Severity.INFO})
+    c1 = _issues(vm.run_validation(project, config=cfg), "C1")
+    assert c1 and all(i.severity == vm.Severity.INFO for i in c1)


### PR DESCRIPTION
## WP2 task 2.1 — validation engine core

First branch of the WP2 validation work (targets **v1.4.0**). Adds the engine, the rule
registry and the first three rules, with tests. UI, topology rules and the audit report
follow in their own branches.

### What this adds

| File | Contents |
|---|---|
| `fiberq/core/validation_manager.py` | `Severity`, `ValidationIssue`, `ValidationRule`, `ValidationConfig`, `ValidationResult`, `ValidationContext`, `run_validation()` |
| `fiberq/core/validation_rules.py` | Rule registry + **B4** (identity), **C1** (required attributes), **D1** (enum conformance) |
| `tests/test_validation.py` | 10 tests |

### Design notes

- **UI-independent and testable.** No QGIS import at module top — QGIS types are imported
  lazily inside the runner/context, so the data model and registry can be unit-tested
  without a running QGIS.
- **One failing rule never sinks the run.** Unlike WP1's `MIGRATIONS` chain (which `break`s
  on first failure — correct for an ordered dependent chain), validation rules are
  independent, so the runner records the failure in `rule_errors` and `continue`s. It never
  raises. Covered by a test.
- **Canonical layer resolution** goes through `schema.canonical_layer_name()` over
  `mapLayers()`, never `mapLayersByName()`. The slack layer is created as *"Optical slacks"*
  (plural) while its canonical name is *"Optical slack"* — a name lookup silently returns
  nothing. Covered by a test.
- **D1 reads its domains from the schema**, not from hardcoded lists:
  `set(FieldDefinition.value_map.values())`. `value_map` is `{display: stored}`, so the valid
  stored domain for cable `tip` is `{opticki, bakarnI}` — including the deliberately
  preserved as-built typo (`bakarnI`, capital I). A hardcoded list would either miss it or
  "fix" it and corrupt data. There's a test asserting `bakarnI` passes and `banana` fails.
- **i18n from the start.** Rule titles are marked with `QT_TRANSLATE_NOOP('ValidationRules', …)`
  and translated at display time; messages use the inline `QCoreApplication.translate(...)`
  form. No module-level `tr()` helper — that hits the context trap documented in
  `docs/i18n.md` and fails silently. The module keeps an identity fallback so it stays
  importable without Qt.
- `ValidationContext` exposes a lazily-built, shared `QgsSpatialIndex` per layer, ready for
  the topology rules in the next branch.

### Testing

- flake8 `--isolated` + Bandit `-ll`: **0/0**
- **63 tests green** on QGIS 3.44 (Qt5) and QGIS 4.0 (Qt6) via `make test` in the CI images
