### PR TITLE
fix(tools): stop Place Joint Closure / Split route creating an empty Poles layer

### DIFF
--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -1785,9 +1785,12 @@ class FiberQPlugin:
                 logger.debug(f"Error in FiberQPlugin.open_color_catalog_manager: {e}")
 
     def activate_breakpoint_tool(self):
-        """Aktivira alat za dodavanje tačke na lom trase (BreakpointTool)."""
-        if self.layer is None or sip.isdeleted(self.layer) or not self.layer.isValid():
-            self.init_layer()
+        """Aktivira alat za dodavanje tačke na lom trase (BreakpointTool).
+
+        No init_layer() here: BreakpointTool.__init__(canvas, iface, plugin) never
+        receives or reads the Poles layer, so creating one only added an empty
+        "Poles" entry to the Layers panel on Split route.
+        """
         self.breakpoint_tool = BreakpointTool(self.iface.mapCanvas(), self.iface, self)
         self.iface.mapCanvas().setMapTool(self.breakpoint_tool)
         self._record_cmd('split_route')
@@ -1798,9 +1801,14 @@ class FiberQPlugin:
         self._record_cmd('manual_route')
 
     def activate_extension_tool(self):
-        if self.layer is None or sip.isdeleted(self.layer) or not self.layer.isValid():
-            self.init_layer()
-        self.extension_tool = ExtensionTool(self.iface.mapCanvas(), self.layer)
+        """Activate the Joint Closure placement tool.
+
+        No init_layer() here: ExtensionTool writes only to the Joint Closures
+        layer, which it resolves or creates itself on each click. Creating the
+        Poles layer only added an empty "Poles" entry to the Layers panel before
+        the user had clicked anything.
+        """
+        self.extension_tool = ExtensionTool(self.iface.mapCanvas())
         self.extension_tool.plugin = self  # v1.2: for undo_manager access
         self.iface.mapCanvas().setMapTool(self.extension_tool)
         self._record_cmd('place_joint_closure')

--- a/fiberq/tools/extension_tool.py
+++ b/fiberq/tools/extension_tool.py
@@ -6,8 +6,6 @@ Phase 2.1: Extracted from extracted_classes.py
 Phase 5.2: Added logging infrastructure
 """
 
-from qgis.PyQt import sip
-
 from qgis.PyQt.QtCore import Qt, QVariant
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import QMessageBox, QInputDialog
@@ -35,10 +33,17 @@ logger = get_logger(__name__)
 class ExtensionTool(QgsMapToolEmitPoint):
     """Tool for placing joint closures on the network."""
 
-    def __init__(self, canvas, layer):
+    def __init__(self, canvas, layer=None):
+        """``layer`` is accepted and ignored.
+
+        The tool writes only to the Joint Closures layer, which it resolves (or
+        creates) from the project on each click. It never read or wrote the layer
+        passed here -- that argument is leftover coupling from when joint closures
+        were placed onto poles. The parameter is kept so any out-of-tree caller
+        keeps working; new code should omit it.
+        """
         super().__init__(canvas)
         self.canvas = canvas
-        self.layer = layer
         self.snap_marker = QgsVertexMarker(self.canvas)
         self.snap_marker.setColor(QColor(255, 0, 0))
         self.snap_marker.setIconType(QgsVertexMarker.IconType.ICON_CIRCLE)
@@ -165,10 +170,6 @@ class ExtensionTool(QgsMapToolEmitPoint):
     def canvasReleaseEvent(self, event):
         # Only left click places joint closure
         if event.button() != Qt.MouseButton.LeftButton:
-            return
-
-        if self.layer is None or sip.isdeleted(self.layer) or not self.layer.isValid():
-            QMessageBox.warning(None, "FiberQ", "Layer not found or invalid!")
             return
 
         click_point = self.toMapCoordinates(event.pos())

--- a/tests/test_stray_poles_layer.py
+++ b/tests/test_stray_poles_layer.py
@@ -1,0 +1,132 @@
+"""Regression: Place Joint Closure / Split route created an empty "Poles" layer.
+
+Both activators called init_layer() -> ensure_poles_layer() -> project.addMapLayer(),
+so an empty "Poles" entry appeared in the Layers panel as soon as the user clicked
+the toolbar button, before placing anything and regardless of whether anything was
+ever placed.
+
+Neither tool needs it. BreakpointTool.__init__(canvas, iface, plugin) never receives
+a layer at all; ExtensionTool was passed one but only ever used it for a validity
+guard -- it writes exclusively to the Joint Closures layer, which it resolves or
+creates from the project on each click.
+
+FiberQPlugin is not instantiable in the test harness (it needs a live iface and the
+full initGui chain), so the activator behaviour is guarded at source level, matching
+the precedent in test_objects_ui.py.
+"""
+import ast
+import inspect
+import textwrap
+
+from qgis.core import QgsProject
+from qgis.gui import QgsMapCanvas
+
+
+def _called_names(func):
+    """Names of everything actually *called* in ``func``.
+
+    Parsed from the AST rather than grepped from the source text, so prose in a
+    docstring explaining what the function no longer calls cannot trip the
+    assertions below.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            target = node.func
+            if isinstance(target, ast.Attribute):
+                names.add(target.attr)
+            elif isinstance(target, ast.Name):
+                names.add(target.id)
+    return names
+
+
+def test_extension_tool_constructs_without_a_layer(qgis_app):
+    """The tool must be usable with no layer argument at all."""
+    from fiberq.tools.extension_tool import ExtensionTool
+
+    canvas = QgsMapCanvas()
+    tool = ExtensionTool(canvas)
+    assert tool is not None
+    # The layer is no longer stored as an instance attribute. (Do not use
+    # hasattr: the QgsMapTool C++ base exposes an unrelated layer() method, so
+    # hasattr is True regardless.)
+    assert "layer" not in vars(tool)
+
+
+def test_extension_tool_still_accepts_a_layer_argument(qgis_app):
+    """The parameter is kept (and ignored) so out-of-tree callers keep working."""
+    from fiberq.tools.extension_tool import ExtensionTool
+
+    canvas = QgsMapCanvas()
+    tool = ExtensionTool(canvas, None)
+    assert tool is not None
+
+    sig = inspect.signature(ExtensionTool.__init__)
+    assert sig.parameters["layer"].default is None, "layer must be optional"
+
+
+def test_constructing_the_tool_creates_no_layers(qgis_app):
+    """The heart of the bug: activating the tool must not add anything to the project."""
+    from fiberq.tools.extension_tool import ExtensionTool
+
+    project = QgsProject.instance()
+    project.removeAllMapLayers()
+    before = len(project.mapLayers())
+
+    ExtensionTool(QgsMapCanvas())
+
+    assert len(project.mapLayers()) == before
+    assert project.mapLayersByName("Poles") == []
+    assert project.mapLayersByName("Stubovi") == []
+
+
+def test_activators_do_not_create_the_poles_layer(qgis_app):
+    """Guards the actual fix in main_plugin.py.
+
+    Both activators must not call init_layer(); ExtensionTool must be constructed
+    without self.layer. A source check is used because FiberQPlugin cannot be
+    instantiated here (see module docstring).
+    """
+    import fiberq.main_plugin as mp
+
+    for name in ("activate_extension_tool", "activate_breakpoint_tool"):
+        called = _called_names(getattr(mp.FiberQPlugin, name))
+        assert "init_layer" not in called, (
+            f"{name} must not call init_layer() -- that is what created the stray "
+            f"empty Poles layer"
+        )
+
+    ext_src = inspect.getsource(mp.FiberQPlugin.activate_extension_tool)
+    assert "ExtensionTool(self.iface.mapCanvas())" in ext_src, (
+        "ExtensionTool must be constructed without the Poles layer"
+    )
+    # Behaviour that must survive the change.
+    assert "self.extension_tool.plugin = self" in ext_src, "undo wiring must be kept"
+    assert "_record_cmd('place_joint_closure')" in ext_src, "repeat-command must be kept"
+
+    bp_src = inspect.getsource(mp.FiberQPlugin.activate_breakpoint_tool)
+    assert "_record_cmd('split_route')" in bp_src, "repeat-command must be kept"
+
+
+def test_place_pole_still_creates_the_poles_layer(qgis_app):
+    """The Poles layer must still be created where it is genuinely wanted."""
+    import fiberq.main_plugin as mp
+
+    assert "init_layer" in _called_names(mp.FiberQPlugin.activate_point_tool), (
+        "Place Pole legitimately creates the Poles layer -- do not strip this one"
+    )
+
+
+def test_extension_tool_has_no_dead_layer_references(qgis_app):
+    """The guard and its now-orphaned sip import must both be gone.
+
+    Deleting the guard without the import leaves flake8 F401, which fails the
+    plugins.qgis.org scan gate (make lint must stay 0/0).
+    """
+    import fiberq.tools.extension_tool as et
+
+    src = inspect.getsource(et)
+    assert "self.layer" not in src
+    assert "from qgis.PyQt import sip" not in src
+    assert "Layer not found or invalid!" not in src


### PR DESCRIPTION
## Fix: Place Joint Closure / Split route created an empty "Poles" layer

Clicking **Place Joint Closure** or **Split route** added an empty `Poles` layer to the
Layers panel immediately — before the user had clicked the map, and whether or not anything
was ever placed.

> Not part of WP2. This is an unfunded bugfix riding in the v1.4.0 release.

### Root cause

Both activators called `init_layer()` → `ensure_poles_layer()` → `project.addMapLayer()`.
Neither tool needs it:

- `BreakpointTool.__init__(canvas, iface, plugin)` never receives a layer at all.
- `ExtensionTool` was passed one, but only used it for a validity guard — it writes
  exclusively to the **Joint Closures** layer, which it resolves or creates from the project
  on each click.

Leftover coupling from when joint closures were placed onto poles.

### Changes

- **`main_plugin.py`** — drop the `init_layer()` call from `activate_extension_tool` and
  `activate_breakpoint_tool`; construct `ExtensionTool` without the layer. The undo wiring
  (`.plugin = self`) and `_record_cmd()` are preserved, so **undo and repeat-last-command are
  unaffected**. `activate_point_tool` (Place Pole) is untouched — it legitimately creates the
  layer, and there's a test pinning that.
- **`extension_tool.py`** — `layer` parameter is now optional and ignored (kept so any
  out-of-tree caller keeps working); `self.layer` and the guard that consumed it are gone.

### Two things worth reviewer attention

1. **The guard was not dead code.** It ran on every left-click and aborted with *"Layer not
   found or invalid!"*. Removing `init_layer()` without deleting the guard in the same change
   would break joint-closure placement outright on any project without a Poles layer.
2. **Removing the guard orphaned `from qgis.PyQt import sip`**, which was its only consumer in
   that file. It's dropped here too — left in place it's an `F401`, which fails the
   plugins.qgis.org scan gate (`make lint` must stay 0/0).

### Accepted behaviour changes (deliberate)

- A user whose only action is Place Joint Closure no longer gets a Poles layer, so the project
  health check now reports Poles as *missing* rather than *OK*. Previously it said OK purely
  because of the phantom layer.
- The Poles uuid/alias backfill loses two of its four trigger points (still covered by Place
  Pole). Worth addressing separately — the identity invariant shouldn't depend on which map
  tool the user happens to click.

### Testing

- flake8 `--isolated` + Bandit `-ll`: **0/0**
- **59 tests green** on QGIS 3.44 (Qt5) and QGIS 4.0 (Qt6) via `make test` in the CI images
- New `tests/test_stray_poles_layer.py` (6 tests) covers: the tool constructs with no layer,
  constructing it adds nothing to the project, neither activator calls `init_layer()` (checked
  via AST so docstring prose can't fool it), Place Pole still does, and the undo/repeat wiring
  survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
