### PR TITLE
WP2 — topology (A1–A3) and referential integrity (B1–B3)

### DIFF
--- a/fiberq/core/validation_manager.py
+++ b/fiberq/core/validation_manager.py
@@ -159,6 +159,10 @@ class ValidationContext:
         self.config = config or ValidationConfig()
         self._layers_by_canonical: Optional[Dict[str, list]] = None
         self._index_cache: Dict[str, Any] = {}
+        # Scratch space shared between rules for structures that are expensive to
+        # build and useful to more than one rule (e.g. the cable-endpoint scan
+        # that A1 and A2 both read). Lives for one validation run.
+        self.cache: Dict[str, Any] = {}
 
     @property
     def layers_by_canonical(self) -> Dict[str, list]:

--- a/fiberq/core/validation_rules.py
+++ b/fiberq/core/validation_rules.py
@@ -46,6 +46,19 @@ _CTX = "ValidationRules"
 _CAT_IDENTITY = "identity"
 _CAT_COMPLETENESS = "completeness"
 _CAT_DOMAIN = "domain"
+_CAT_TOPOLOGY = "topology"
+_CAT_REFERENTIAL = "referential"
+
+# Layer groupings used by the topology rules, by canonical name.
+_CABLE_LAYERS = ("Aerial cables", "Underground cables")
+# Everything a cable endpoint may legitimately terminate on.
+_NODE_LAYERS = tuple(schema.ELEMENT_LAYER_NAMES) + (
+    "Joint Closures", "Poles", "Manholes",
+)
+# Linear features an element is expected to sit on/near.
+_LINEAR_LAYERS = _CABLE_LAYERS + ("Route",)
+# Layers carrying a cable_layer_id + cable_fid foreign key.
+_FK_LAYERS = ("Optical slack", "Fiber break")
 
 # Required, domain-meaningful fields per layer type (fiberq_uuid is B4's concern,
 # not repeated here). Element layers share one set; the rest are keyed by
@@ -92,6 +105,16 @@ def _uuid_of(feat) -> str:
     return "" if value is None else str(value)
 
 
+def _fmt(value) -> str:
+    """Compact number for a message: trims trailing zeros so a tolerance of 5.0
+    reads as "5" and a distance of 7.25 keeps its precision."""
+    try:
+        text = f"{float(value):.2f}".rstrip("0").rstrip(".")
+        return text or "0"
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def _safe_format(translated, source, **kwargs):
     """Interpolate into a translated message, falling back to the English source
     if a volunteer renamed a placeholder (see ``fiberq.i18n.safe_format``)."""
@@ -115,6 +138,385 @@ def _required_fields_for(canonical: str):
     if schema.is_element_layer(canonical):
         return _ELEMENT_REQUIRED
     return _REQUIRED_BY_LAYER.get(canonical, ())
+
+
+# ---------------------------------------------------------------------------
+# Geometry / spatial helpers (QGIS-aware, called only from checks)
+# ---------------------------------------------------------------------------
+
+def _first_point(geom):
+    """First vertex of a point/multipoint geometry, or None. Avoids asPoint(),
+    which raises on multipoint."""
+    if geom is None or geom.isNull() or geom.isEmpty():
+        return None
+    from qgis.core import QgsPointXY
+    for vertex in geom.vertices():
+        return QgsPointXY(vertex)
+    return None
+
+
+def _line_parts(geom):
+    """Vertex lists of every line part with at least two vertices."""
+    if geom is None or geom.isNull() or geom.isEmpty():
+        return []
+    if geom.isMultipart():
+        return [part for part in geom.asMultiPolyline() if len(part) >= 2]
+    points = geom.asPolyline()
+    return [points] if len(points) >= 2 else []
+
+
+def _line_endpoints(geom):
+    """``[(label, QgsPointXY)]`` for both ends of every part.
+
+    ``label`` ("start"/"end", suffixed with the part number when multipart) is a
+    stable identifier carried in ``details`` -- it is never translated and never
+    interpolated into a message.
+    """
+    out = []
+    parts = _line_parts(geom)
+    multipart = len(parts) > 1
+    for i, part in enumerate(parts):
+        suffix = f" part {i + 1}" if multipart else ""
+        out.append((f"start{suffix}", part[0]))
+        out.append((f"end{suffix}", part[-1]))
+    return out
+
+
+def _rect_around(point, radius):
+    from qgis.core import QgsRectangle
+    return QgsRectangle(point.x() - radius, point.y() - radius,
+                        point.x() + radius, point.y() + radius)
+
+
+def _node_index(ctx):
+    """``(QgsSpatialIndex, {id: (layer_name, fid, QgsPointXY)})`` over every point
+    a cable endpoint may legally connect to.
+
+    One combined index rather than one per layer, so an endpoint costs a single
+    query instead of ~15. Built once per run and shared by A1/A2/A3.
+    """
+    cached = ctx.cache.get("node_index")
+    if cached is not None:
+        return cached
+
+    from qgis.core import QgsFeature, QgsGeometry, QgsSpatialIndex
+
+    index = QgsSpatialIndex()
+    records = {}
+    next_id = 0
+    for layer in ctx.layers_for(*_NODE_LAYERS):
+        for feat in layer.getFeatures():
+            point = _first_point(feat.geometry())
+            if point is None:
+                continue
+            holder = QgsFeature(next_id)
+            holder.setGeometry(QgsGeometry.fromPointXY(point))
+            index.addFeature(holder)
+            records[next_id] = (layer.name(), feat.id(), point)
+            next_id += 1
+
+    cached = (index, records)
+    ctx.cache["node_index"] = cached
+    return cached
+
+
+def _cable_endpoint_index(ctx):
+    """``(QgsSpatialIndex, {id: (layer_name, layer_id, fid, label, QgsPointXY)})``
+    over every cable endpoint, so endpoint-to-endpoint joins can be detected.
+
+    A plain index over cable features would index their bounding boxes, which says
+    nothing about where the ends are -- hence a synthetic point index.
+    """
+    cached = ctx.cache.get("cable_endpoint_index")
+    if cached is not None:
+        return cached
+
+    from qgis.core import QgsFeature, QgsGeometry, QgsSpatialIndex
+
+    index = QgsSpatialIndex()
+    records = {}
+    next_id = 0
+    for layer in ctx.layers_for(*_CABLE_LAYERS):
+        for feat in layer.getFeatures():
+            for label, point in _line_endpoints(feat.geometry()):
+                holder = QgsFeature(next_id)
+                holder.setGeometry(QgsGeometry.fromPointXY(point))
+                index.addFeature(holder)
+                records[next_id] = (layer.name(), layer.id(), feat.id(), label, point)
+                next_id += 1
+
+    cached = (index, records)
+    ctx.cache["cable_endpoint_index"] = cached
+    return cached
+
+
+def _endpoint_scan(ctx):
+    """Classify every cable endpoint by its distance to the nearest legal partner.
+
+    Returns ``[{layer_name, layer_id, feature_id, label, point, distance, target}]``
+    where ``distance`` is ``None`` when nothing at all lies within 2*tol.
+    Shared by A1 and A2 so the scan runs once.
+    """
+    cached = ctx.cache.get("endpoint_scan")
+    if cached is not None:
+        return cached
+
+    tol = ctx.config.tol
+    reach = tol * 2.0
+    node_index, node_records = _node_index(ctx)
+    ep_index, ep_records = _cable_endpoint_index(ctx)
+
+    findings = []
+    for holder_id, (layer_name, layer_id, fid, label, point) in ep_records.items():
+        rect = _rect_around(point, reach)
+        best_distance = None
+        best_target = None
+
+        for candidate in node_index.intersects(rect):
+            target_layer, target_fid, target_point = node_records[candidate]
+            distance = point.distance(target_point)
+            if best_distance is None or distance < best_distance:
+                best_distance = distance
+                best_target = (target_layer, target_fid)
+
+        for candidate in ep_index.intersects(rect):
+            if candidate == holder_id:
+                continue
+            other_layer, other_layer_id, other_fid, _lbl, other_point = ep_records[candidate]
+            # An endpoint must join a *different* feature; its own other end does
+            # not count as a connection.
+            if other_layer_id == layer_id and other_fid == fid:
+                continue
+            distance = point.distance(other_point)
+            if best_distance is None or distance < best_distance:
+                best_distance = distance
+                best_target = (other_layer, other_fid)
+
+        findings.append({
+            "layer_name": layer_name,
+            "layer_id": layer_id,
+            "feature_id": fid,
+            "label": label,
+            "point": point,
+            "distance": best_distance,
+            "target": best_target,
+        })
+
+    ctx.cache["endpoint_scan"] = findings
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# A1 -- cable dangles
+# ---------------------------------------------------------------------------
+
+def _check_cable_dangles(ctx):
+    """Every cable endpoint should terminate on a node or another cable's end.
+
+    Fires for *every* unconnected endpoint, including the near-misses that A2 also
+    reports -- so the A1 count is a clean "number of unconnected endpoints". A2
+    refines those, it does not partition them.
+    """
+    tol = ctx.config.tol
+    for finding in _endpoint_scan(ctx):
+        distance = finding["distance"]
+        if distance is not None and distance <= tol:
+            continue
+        src = "Cable endpoint is not connected to any element or cable (tolerance {tol})"
+        yield ValidationIssue(
+            rule_id="A1", severity=Severity.WARNING, category=_CAT_TOPOLOGY,
+            message=_safe_format(
+                QCoreApplication.translate(_CTX, src), src, tol=_fmt(tol)),
+            layer_name=finding["layer_name"], layer_id=finding["layer_id"],
+            feature_id=finding["feature_id"],
+            where=(finding["point"].x(), finding["point"].y()),
+            details={
+                "endpoint": finding["label"],
+                "nearest_distance": distance,
+                "nearest": finding["target"],
+                "tolerance": tol,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# A2 -- near miss / overshoot
+# ---------------------------------------------------------------------------
+
+def _check_near_miss(ctx):
+    """An unconnected endpoint with something just outside tolerance: almost
+    certainly meant to be snapped to it."""
+    tol = ctx.config.tol
+    for finding in _endpoint_scan(ctx):
+        distance = finding["distance"]
+        if distance is None or distance <= tol or distance > tol * 2.0:
+            continue
+        target = finding["target"]
+        src = ("Cable endpoint is {distance} from {target} -- just outside the "
+               "{tol} snapping tolerance; it probably should connect")
+        yield ValidationIssue(
+            rule_id="A2", severity=Severity.INFO, category=_CAT_TOPOLOGY,
+            message=_safe_format(
+                QCoreApplication.translate(_CTX, src), src,
+                distance=_fmt(distance),
+                target=target[0] if target else "",
+                tol=_fmt(tol)),
+            layer_name=finding["layer_name"], layer_id=finding["layer_id"],
+            feature_id=finding["feature_id"],
+            where=(finding["point"].x(), finding["point"].y()),
+            details={
+                "endpoint": finding["label"],
+                "nearest_distance": distance,
+                "nearest": target,
+                "tolerance": tol,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# A3 -- orphan elements
+# ---------------------------------------------------------------------------
+
+def _check_orphan_elements(ctx):
+    """A node that sits near no cable and no route is probably stranded."""
+    from qgis.core import QgsGeometry
+
+    tol = ctx.config.tol
+    linears = ctx.layers_for(*_LINEAR_LAYERS)
+    if not linears:
+        return  # nothing to be connected to; not a finding
+
+    for layer in ctx.layers_for(*_NODE_LAYERS):
+        for feat in layer.getFeatures():
+            point = _first_point(feat.geometry())
+            if point is None:
+                continue  # geometry health is E2's concern
+            rect = _rect_around(point, tol)
+            probe = QgsGeometry.fromPointXY(point)
+            attached = False
+            for linear in linears:
+                index = ctx.spatial_index(linear)
+                for candidate in index.intersects(rect):
+                    other = linear.getFeature(candidate)
+                    geom = other.geometry()
+                    # Index hits are bbox-level; confirm with a real distance.
+                    if geom is not None and not geom.isNull() and probe.distance(geom) <= tol:
+                        attached = True
+                        break
+                if attached:
+                    break
+            if attached:
+                continue
+            src = "Element is not on or near any cable or route (tolerance {tol})"
+            yield ValidationIssue(
+                rule_id="A3", severity=Severity.WARNING, category=_CAT_TOPOLOGY,
+                message=_safe_format(
+                    QCoreApplication.translate(_CTX, src), src, tol=_fmt(tol)),
+                layer_name=layer.name(), layer_id=layer.id(),
+                feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                where=(point.x(), point.y()),
+                details={"tolerance": tol},
+            )
+
+
+# ---------------------------------------------------------------------------
+# B1 / B2 -- cable foreign keys, and B3 -- their spatial coherence
+# ---------------------------------------------------------------------------
+
+def _fk_rows(ctx, canonical):
+    """Yield ``(layer, feat, cable_layer_id, cable_fid)`` for features carrying a
+    populated cable reference. Rows with no reference at all are skipped -- an
+    unlinked slack is incomplete (C1's concern), not a broken link."""
+    from qgis.core import NULL
+
+    for layer in ctx.layers_for(canonical):
+        names = set(layer.fields().names())
+        if not {"cable_layer_id", "cable_fid"} <= names:
+            continue
+        for feat in layer.getFeatures():
+            raw_layer_id = feat.attribute("cable_layer_id")
+            raw_fid = feat.attribute("cable_fid")
+            if _is_blank(raw_layer_id, NULL) and _is_blank(raw_fid, NULL):
+                continue
+            yield layer, feat, raw_layer_id, raw_fid
+
+
+def _resolve_cable(ctx, raw_layer_id, raw_fid):
+    """``(layer, feature)`` for a cable reference, or ``(layer_or_None, None)``."""
+    from qgis.core import NULL, QgsVectorLayer
+
+    if _is_blank(raw_layer_id, NULL):
+        return None, None
+    layer = ctx.project.mapLayer(str(raw_layer_id))
+    if layer is None or not isinstance(layer, QgsVectorLayer):
+        return None, None
+    if _is_blank(raw_fid, NULL):
+        return layer, None
+    try:
+        feat = layer.getFeature(int(raw_fid))
+    except (TypeError, ValueError):
+        return layer, None
+    return layer, (feat if feat.isValid() else None)
+
+
+def _fk_checker(canonical, rule_id):
+    """Build the B1/B2 check for one layer -- both carry the identical FK shape."""
+    def check(ctx):
+        for layer, feat, raw_layer_id, raw_fid in _fk_rows(ctx, canonical):
+            cable_layer, cable_feat = _resolve_cable(ctx, raw_layer_id, raw_fid)
+            if cable_feat is not None:
+                continue
+            if cable_layer is None:
+                src = "Referenced cable layer {layer_id} is not in the project"
+                message = _safe_format(
+                    QCoreApplication.translate(_CTX, src), src, layer_id=raw_layer_id)
+            else:
+                src = "Referenced cable feature {fid} does not exist in layer {layer}"
+                message = _safe_format(
+                    QCoreApplication.translate(_CTX, src), src,
+                    fid=raw_fid, layer=cable_layer.name())
+            yield ValidationIssue(
+                rule_id=rule_id, severity=Severity.ERROR, category=_CAT_REFERENTIAL,
+                message=message,
+                layer_name=layer.name(), layer_id=layer.id(),
+                feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                where=_feature_xy(feat),
+                details={"cable_layer_id": str(raw_layer_id), "cable_fid": raw_fid},
+            )
+    return check
+
+
+def _check_fk_spatial(ctx):
+    """A resolvable cable reference whose point sits far from that cable usually
+    means the cable was re-routed after the slack/break was placed."""
+    from qgis.core import QgsGeometry
+
+    tol = ctx.config.tol
+    for canonical in _FK_LAYERS:
+        for layer, feat, raw_layer_id, raw_fid in _fk_rows(ctx, canonical):
+            _cable_layer, cable_feat = _resolve_cable(ctx, raw_layer_id, raw_fid)
+            if cable_feat is None:
+                continue  # broken links are B1/B2's finding, not this one
+            point = _first_point(feat.geometry())
+            cable_geom = cable_feat.geometry()
+            if point is None or cable_geom is None or cable_geom.isNull():
+                continue
+            distance = QgsGeometry.fromPointXY(point).distance(cable_geom)
+            if distance <= tol:
+                continue
+            src = ("Feature is {distance} from the cable it references "
+                   "(tolerance {tol}) -- the cable may have been re-routed")
+            yield ValidationIssue(
+                rule_id="B3", severity=Severity.WARNING, category=_CAT_REFERENTIAL,
+                message=_safe_format(
+                    QCoreApplication.translate(_CTX, src), src,
+                    distance=_fmt(distance), tol=_fmt(tol)),
+                layer_name=layer.name(), layer_id=layer.id(),
+                feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                where=(point.x(), point.y()),
+                details={"distance": distance, "tolerance": tol,
+                         "cable_fid": raw_fid},
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +654,54 @@ def _check_enum_conformance(ctx):
 # ---------------------------------------------------------------------------
 
 RULES = [
+    ValidationRule(
+        id="A1",
+        title=QT_TRANSLATE_NOOP(_CTX, "Cable endpoints are connected"),
+        category=_CAT_TOPOLOGY,
+        default_severity=Severity.WARNING,
+        check=_check_cable_dangles,
+        applies_to=_CABLE_LAYERS,
+    ),
+    ValidationRule(
+        id="A2",
+        title=QT_TRANSLATE_NOOP(_CTX, "Cable endpoints are not near-misses"),
+        category=_CAT_TOPOLOGY,
+        default_severity=Severity.INFO,
+        check=_check_near_miss,
+        applies_to=_CABLE_LAYERS,
+    ),
+    ValidationRule(
+        id="A3",
+        title=QT_TRANSLATE_NOOP(_CTX, "Elements are attached to the network"),
+        category=_CAT_TOPOLOGY,
+        default_severity=Severity.WARNING,
+        check=_check_orphan_elements,
+        applies_to=_NODE_LAYERS,
+    ),
+    ValidationRule(
+        id="B1",
+        title=QT_TRANSLATE_NOOP(_CTX, "Optical slack references an existing cable"),
+        category=_CAT_REFERENTIAL,
+        default_severity=Severity.ERROR,
+        check=_fk_checker("Optical slack", "B1"),
+        applies_to=("Optical slack",),
+    ),
+    ValidationRule(
+        id="B2",
+        title=QT_TRANSLATE_NOOP(_CTX, "Fiber break references an existing cable"),
+        category=_CAT_REFERENTIAL,
+        default_severity=Severity.ERROR,
+        check=_fk_checker("Fiber break", "B2"),
+        applies_to=("Fiber break",),
+    ),
+    ValidationRule(
+        id="B3",
+        title=QT_TRANSLATE_NOOP(_CTX, "Cable references are spatially coherent"),
+        category=_CAT_REFERENTIAL,
+        default_severity=Severity.WARNING,
+        check=_check_fk_spatial,
+        applies_to=_FK_LAYERS,
+    ),
     ValidationRule(
         id="B4",
         title=QT_TRANSLATE_NOOP(_CTX, "Feature identity present and unique"),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -47,8 +47,13 @@ def _issues(result, rule_id):
 # ---------------------------------------------------------------------------
 
 def test_registry_ids_unique_and_wellformed():
+    """The rules this module covers are registered, and every entry is sane.
+
+    The exact full rule list is pinned in test_validation_topology.py -- asserting
+    it here too would mean two tests to update every time a rule lands.
+    """
     ids = [r.id for r in vr.RULES]
-    assert ids == ["B4", "C1", "D1"]
+    assert {"B4", "C1", "D1"} <= set(ids)
     assert len(ids) == len(set(ids))
     for rule in vr.RULES:
         assert rule.id and rule.title and rule.category
@@ -172,7 +177,8 @@ def test_failing_rule_is_recorded_not_raised():
         id="X1", title="x", category="c",
         default_severity=vm.Severity.INFO, check=boom,
     )
-    result = vm.run_validation(QgsProject(), rules=[bad, vr.RULES[0]])
+    good = next(r for r in vr.RULES if r.id == "B4")
+    result = vm.run_validation(QgsProject(), rules=[bad, good])
     assert any("X1" in e for e in result.rule_errors)
     assert "B4" in result.ran_rules  # the good rule still ran after the bad one
 

--- a/tests/test_validation_topology.py
+++ b/tests/test_validation_topology.py
@@ -1,0 +1,368 @@
+"""Tests for the WP2 topology (A1-A3) and referential-integrity (B1-B3) rules.
+
+Each test builds a tiny project with one known defect and asserts exactly that
+issue. Geometry is in EPSG:3857 (metres) so the default 5.0 map-unit tolerance
+means 5 metres and the distances below are easy to reason about.
+"""
+from qgis.core import (
+    QgsFeature,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProject,
+    QgsVectorLayer,
+)
+
+from fiberq.core import validation_manager as vm
+from fiberq.core import validation_rules as vr
+
+CRS = "EPSG:3857"
+
+
+def _point_layer(name, rows, fields=("fiberq_uuid:string",)):
+    """rows: [(attrs, QgsPointXY|None)]"""
+    uri = f"Point?crs={CRS}"
+    for spec in fields:
+        uri += "&field=" + spec
+    layer = QgsVectorLayer(uri, name, "memory")
+    assert layer.isValid(), name
+    feats = []
+    for attrs, point in rows:
+        feat = QgsFeature(layer.fields())
+        for key, value in attrs.items():
+            feat.setAttribute(key, value)
+        if point is not None:
+            feat.setGeometry(QgsGeometry.fromPointXY(point))
+        feats.append(feat)
+    layer.dataProvider().addFeatures(feats)
+    layer.updateExtents()
+    return layer
+
+
+def _line_layer(name, lines, fields=("fiberq_uuid:string",)):
+    """lines: [(attrs, [QgsPointXY, ...])]"""
+    uri = f"LineString?crs={CRS}"
+    for spec in fields:
+        uri += "&field=" + spec
+    layer = QgsVectorLayer(uri, name, "memory")
+    assert layer.isValid(), name
+    feats = []
+    for attrs, pts in lines:
+        feat = QgsFeature(layer.fields())
+        for key, value in attrs.items():
+            feat.setAttribute(key, value)
+        feat.setGeometry(QgsGeometry.fromPolylineXY(pts))
+        feats.append(feat)
+    layer.dataProvider().addFeatures(feats)
+    layer.updateExtents()
+    return layer
+
+
+def _run(project, rule_ids):
+    """Run only the named rules and return their issues."""
+    rules = [r for r in vr.RULES if r.id in rule_ids]
+    assert len(rules) == len(rule_ids)
+    result = vm.run_validation(project, rules=rules)
+    assert not result.rule_errors, result.rule_errors
+    return result
+
+
+def _ids(result, rule_id):
+    return [i for i in result.issues if i.rule_id == rule_id]
+
+
+# ---------------------------------------------------------------------------
+# A1 -- cable dangles
+# ---------------------------------------------------------------------------
+
+def test_a1_connected_cable_is_clean(qgis_app):
+    """Both ends land exactly on an ODF -> no issue."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),
+        ({"fiberq_uuid": "n2"}, QgsPointXY(100, 0)),
+    ]))
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ]))
+    assert _ids(_run(project, {"A1"}), "A1") == []
+
+
+def test_a1_flags_a_dangling_end(qgis_app):
+    """One end on a node, the far end alone in space."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),
+    ]))
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(500, 0)]),
+    ]))
+    issues = _ids(_run(project, {"A1"}), "A1")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.WARNING
+    assert issues[0].details["endpoint"] == "end"
+    assert issues[0].where == (500.0, 0.0)
+
+
+def test_a1_accepts_cable_to_cable_joins(qgis_app):
+    """Two cables meeting end-to-end are connected, with no node present."""
+    project = QgsProject()
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+        ({"fiberq_uuid": "c2"}, [QgsPointXY(100, 0), QgsPointXY(200, 0)]),
+    ]))
+    # The outer ends (0,0) and (200,0) still dangle; the shared join does not.
+    issues = _ids(_run(project, {"A1"}), "A1")
+    assert len(issues) == 2
+    assert {i.where for i in issues} == {(0.0, 0.0), (200.0, 0.0)}
+
+
+def test_a1_does_not_let_a_cable_connect_to_itself(qgis_app):
+    """A cable's own other end must not count as a connection."""
+    project = QgsProject()
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(300, 0)]),
+    ]))
+    assert len(_ids(_run(project, {"A1"}), "A1")) == 2
+
+
+def test_a1_respects_a_configured_tolerance(qgis_app):
+    """A 12 m gap dangles at the default 5 m tolerance and is fine at 20 m."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),
+        ({"fiberq_uuid": "n2"}, QgsPointXY(112, 0)),
+    ]))
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ]))
+    rules = [r for r in vr.RULES if r.id == "A1"]
+    assert len(vm.run_validation(project, rules=rules).issues) == 1
+
+    loose = vm.ValidationConfig(tol=20.0)
+    assert vm.run_validation(project, rules=rules, config=loose).issues == []
+
+
+# ---------------------------------------------------------------------------
+# A2 -- near miss
+# ---------------------------------------------------------------------------
+
+def test_a2_flags_an_endpoint_just_outside_tolerance(qgis_app):
+    """7 m from a node: outside the 5 m tolerance, inside the 10 m near band."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),
+        ({"fiberq_uuid": "n2"}, QgsPointXY(107, 0)),
+    ]))
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ]))
+    result = _run(project, {"A1", "A2"})
+    near = _ids(result, "A2")
+    assert len(near) == 1
+    assert near[0].severity == vm.Severity.INFO
+    assert round(near[0].details["nearest_distance"], 3) == 7.0
+    # A2 refines A1 rather than replacing it: the endpoint is still unconnected.
+    assert len(_ids(result, "A1")) == 1
+
+
+def test_a2_ignores_a_far_dangle(qgis_app):
+    """Nothing within 2*tol -> A1 only, no near-miss hint."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),
+    ]))
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(500, 0)]),
+    ]))
+    result = _run(project, {"A1", "A2"})
+    assert _ids(result, "A2") == []
+    assert len(_ids(result, "A1")) == 1
+
+
+# ---------------------------------------------------------------------------
+# A3 -- orphan elements
+# ---------------------------------------------------------------------------
+
+def test_a3_flags_an_element_off_the_network(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),      # on the cable
+        ({"fiberq_uuid": "n2"}, QgsPointXY(50, 400)),   # stranded
+    ]))
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ]))
+    issues = _ids(_run(project, {"A3"}), "A3")
+    assert len(issues) == 1
+    assert issues[0].where == (50.0, 400.0)
+    assert issues[0].fiberq_uuid == "n2"
+
+
+def test_a3_counts_a_route_as_attachment(qgis_app):
+    """An element on a Route but no cable is still attached."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("Manholes", [
+        ({"fiberq_uuid": "m1"}, QgsPointXY(50, 0)),
+    ]))
+    project.addMapLayer(_line_layer("Route", [
+        ({"fiberq_uuid": "r1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ]))
+    assert _ids(_run(project, {"A3"}), "A3") == []
+
+
+def test_a3_is_silent_when_there_is_no_network_at_all(qgis_app):
+    """Elements with no cables/routes anywhere are not each an orphan finding."""
+    project = QgsProject()
+    project.addMapLayer(_point_layer("ODF", [
+        ({"fiberq_uuid": "n1"}, QgsPointXY(0, 0)),
+        ({"fiberq_uuid": "n2"}, QgsPointXY(10, 10)),
+    ]))
+    assert _ids(_run(project, {"A3"}), "A3") == []
+
+
+# ---------------------------------------------------------------------------
+# B1 / B2 -- cable foreign keys
+# ---------------------------------------------------------------------------
+
+_FK_FIELDS = ("fiberq_uuid:string", "cable_layer_id:string", "cable_fid:integer")
+
+
+def _project_with_cable():
+    project = QgsProject()
+    cables = _line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ])
+    project.addMapLayer(cables)
+    cable_fid = next(cables.getFeatures()).id()
+    return project, cables, cable_fid
+
+
+def test_b1_resolvable_reference_is_clean(qgis_app):
+    project, cables, fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": cables.id(), "cable_fid": fid},
+         QgsPointXY(50, 0)),
+    ], fields=_FK_FIELDS))
+    assert _ids(_run(project, {"B1"}), "B1") == []
+
+
+def test_b1_flags_a_missing_cable_feature(qgis_app):
+    project, cables, _fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": cables.id(), "cable_fid": 9999},
+         QgsPointXY(50, 0)),
+    ], fields=_FK_FIELDS))
+    issues = _ids(_run(project, {"B1"}), "B1")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.ERROR
+    assert issues[0].details["cable_fid"] == 9999
+
+
+def test_b1_flags_a_missing_cable_layer(qgis_app):
+    project, _cables, fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": "no_such_layer_id", "cable_fid": fid},
+         QgsPointXY(50, 0)),
+    ], fields=_FK_FIELDS))
+    issues = _ids(_run(project, {"B1"}), "B1")
+    assert len(issues) == 1
+    assert "no_such_layer_id" in issues[0].message
+
+
+def test_b1_ignores_an_unlinked_slack(qgis_app):
+    """No reference at all is incompleteness (C1), not a broken link."""
+    project, _cables, _fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1"}, QgsPointXY(50, 0)),
+    ], fields=_FK_FIELDS))
+    assert _ids(_run(project, {"B1"}), "B1") == []
+
+
+def test_b2_checks_fiber_break_the_same_way(qgis_app):
+    project, cables, _fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Fiber break", [
+        ({"fiberq_uuid": "b1", "cable_layer_id": cables.id(), "cable_fid": 4242},
+         QgsPointXY(50, 0)),
+    ], fields=_FK_FIELDS))
+    issues = _ids(_run(project, {"B2"}), "B2")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.ERROR
+    assert issues[0].layer_name == "Fiber break"
+
+
+# ---------------------------------------------------------------------------
+# B3 -- spatial coherence of a resolvable reference
+# ---------------------------------------------------------------------------
+
+def test_b3_flags_a_slack_far_from_its_cable(qgis_app):
+    project, cables, fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": cables.id(), "cable_fid": fid},
+         QgsPointXY(50, 250)),
+    ], fields=_FK_FIELDS))
+    issues = _ids(_run(project, {"B3"}), "B3")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.WARNING
+    assert round(issues[0].details["distance"]) == 250
+
+
+def test_b3_is_clean_when_the_slack_sits_on_the_cable(qgis_app):
+    project, cables, fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": cables.id(), "cable_fid": fid},
+         QgsPointXY(50, 2)),
+    ], fields=_FK_FIELDS))
+    assert _ids(_run(project, {"B3"}), "B3") == []
+
+
+def test_b3_stays_quiet_when_the_link_is_broken(qgis_app):
+    """A broken link is B1/B2's finding; B3 must not double-report it."""
+    project, cables, _fid = _project_with_cable()
+    project.addMapLayer(_point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": cables.id(), "cable_fid": 9999},
+         QgsPointXY(50, 250)),
+    ], fields=_FK_FIELDS))
+    assert _ids(_run(project, {"B3"}), "B3") == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting
+# ---------------------------------------------------------------------------
+
+def test_plural_slack_layer_is_actually_checked(qgis_app):
+    """Regression guard for the canonical-name divergence.
+
+    The layer is created as "Optical slacks" (plural) but its canonical name is
+    "Optical slack". A mapLayersByName() lookup would silently skip it and B1
+    would report nothing at all.
+    """
+    project, cables, _fid = _project_with_cable()
+    slacks = _point_layer("Optical slacks", [
+        ({"fiberq_uuid": "s1", "cable_layer_id": cables.id(), "cable_fid": 9999},
+         QgsPointXY(50, 0)),
+    ], fields=_FK_FIELDS)
+    project.addMapLayer(slacks)
+
+    ctx = vm.ValidationContext(project)
+    assert "Optical slack" in ctx.layers_by_canonical
+    assert len(_ids(_run(project, {"B1"}), "B1")) == 1
+
+
+def test_registry_is_wellformed_after_the_topology_batch(qgis_app):
+    ids = [r.id for r in vr.RULES]
+    assert ids == ["A1", "A2", "A3", "B1", "B2", "B3", "B4", "C1", "D1"]
+    assert len(ids) == len(set(ids))
+    for rule in vr.RULES:
+        assert rule.title and rule.category and callable(rule.check)
+
+
+def test_endpoint_scan_is_built_once_per_run(qgis_app):
+    """A1 and A2 share the scan through the context cache."""
+    project = QgsProject()
+    project.addMapLayer(_line_layer("Underground cables", [
+        ({"fiberq_uuid": "c1"}, [QgsPointXY(0, 0), QgsPointXY(100, 0)]),
+    ]))
+    ctx = vm.ValidationContext(project)
+    first = vr._endpoint_scan(ctx)
+    assert vr._endpoint_scan(ctx) is first
+    assert "endpoint_scan" in ctx.cache


### PR DESCRIPTION
## WP2 — topology (A1–A3) and referential integrity (B1–B3)

Second WP2 branch, building on the runner and registry from #34. This is the spatial
half of task 2.1. Brings the engine to **9 of the ~14 core rules** planned for v1.4.0.

### Rules added

| Rule | Severity | Fires when |
|---|---|---|
| **A1** | WARNING | a cable endpoint is not within tolerance of a node or another cable's end |
| **A2** | INFO | an unconnected endpoint has a candidate in `(tol, 2·tol]` — a near miss that probably should be snapped |
| **A3** | WARNING | a node sits near no cable and no route |
| **B1** | ERROR | Optical slack's `cable_layer_id` + `cable_fid` does not resolve |
| **B2** | ERROR | same for Fiber break (identical FK shape, shared implementation) |
| **B3** | WARNING | a *resolvable* reference whose point is far from that cable |

### Spatial design

- **One combined index, not one per layer.** A cable endpoint has ~15 candidate node
  layers; querying each separately would be 15 index hits per endpoint. Instead there's a
  single synthetic point index over all node layers.
- **Cable endpoints get their own synthetic index.** A plain `QgsSpatialIndex` over cable
  *features* indexes their bounding boxes, which says nothing about where the ends are —
  so endpoint-to-endpoint joins need a point index built from the endpoints themselves.
- **Every index hit is confirmed with a real geometry distance.** Hits are bbox-level; this
  matters for A3/B3 where the targets are lines, since a bbox hit on a long diagonal cable
  can be nowhere near the actual geometry.
- Both indexes are cached on the new `ValidationContext.cache` and built once per run.
- An endpoint never counts its own feature's other end as a connection.

### Two deliberate choices worth review attention

1. **A2 refines A1, it does not partition it.** A near-miss endpoint yields *both* an A1
   warning and an A2 hint. That keeps A1's count a clean "number of unconnected endpoints"
   for the audit report — if near-misses were excluded, the headline count would understate
   real connectivity problems. Pinned by a test.
2. **B3 stays silent when the link is broken**, so a broken FK is reported once (by B1/B2)
   rather than twice.

### Testing

- flake8 `--isolated` + Bandit `-ll`: **0/0**
- **90 tests green** on QGIS 3.44 (Qt5) and QGIS 4.0 (Qt6) via `make test` in the CI images
- 27 new cases covering each rule, the configured-tolerance path, cable-to-cable joins, the
  self-connection guard, and the unlinked-vs-broken FK distinction
- Includes a regression guard that the plural **"Optical slacks"** layer really is reached
  by B1 through canonical-name resolution — a `mapLayersByName()` lookup would silently
  skip it and B1 would report nothing at all

Two earlier tests in `test_validation.py` are updated: they pinned a 3-rule registry and
indexed `RULES[0]`, both invalidated by this batch. The full rule list is now pinned in one
place only.
