### PR TITLE
WP2 — domain rules: D2 ranges, D3 length coherence, E1 CRS, E2 geometry

### DIFF
--- a/fiberq/core/validation_manager.py
+++ b/fiberq/core/validation_manager.py
@@ -90,6 +90,10 @@ class ValidationConfig:
     """Runtime configuration. Persisted to a project entry
     (``FiberQPlugin/validation``) by the UI layer so it travels with the project."""
     tol: float = 5.0  # snap tolerance in map units (reuses the relations default)
+    # Length agreement: a stored length may differ from the computed one by the
+    # larger of these two, so short features are not flagged for rounding noise.
+    length_rel_tol: float = 0.01   # 1%
+    length_abs_tol: float = 0.5    # map units
     disabled_rules: set = field(default_factory=set)
     severity_overrides: Dict[str, Severity] = field(default_factory=dict)
 

--- a/fiberq/core/validation_rules.py
+++ b/fiberq/core/validation_rules.py
@@ -60,6 +60,37 @@ _LINEAR_LAYERS = _CABLE_LAYERS + ("Route",)
 # Layers carrying a cable_layer_id + cable_fid foreign key.
 _FK_LAYERS = ("Optical slack", "Fiber break")
 
+# D2 numeric bounds: field -> (minimum, maximum, exclusive_min). ``None`` means
+# unbounded on that side. Only applied to fields the schema declares int/double,
+# which is why pipe ``kapacitet`` (text, as-built) is skipped rather than
+# mis-parsed -- the same schema-driven approach D1 uses for enums.
+_NUMERIC_BOUNDS = {
+    "broj_vlakana": (0, 1152, True),    # a cable with zero fibres is not a cable
+    "broj_cevcica": (0, None, False),
+    "fi": (0, None, True),              # duct diameter in mm
+    "visina": (0, None, True),          # pole height in m
+    "kapacitet": (0, None, False),
+    "slabljenje_dbkm": (0, 10, False),  # dB/km; typical single-mode is 0.2-0.4
+    "duzina_m": (0, None, False),
+    "duzina": (0, None, False),
+    "duzina_km": (0, None, False),
+    "total_len_m": (0, None, False),
+    "slack_m": (0, None, False),
+    "area_m2": (0, None, False),
+    "perim_m": (0, None, False),
+}
+
+# D3: the field holding a line layer's stored length. Route is the odd one out --
+# it stores ``duzina`` (m) plus ``duzina_km``, every other line layer uses
+# ``duzina_m``.
+_STORED_LENGTH_FIELD = {
+    "Aerial cables": "duzina_m",
+    "Underground cables": "duzina_m",
+    "PE pipes": "duzina_m",
+    "Transition pipes": "duzina_m",
+    "Route": "duzina",
+}
+
 # Required, domain-meaningful fields per layer type (fiberq_uuid is B4's concern,
 # not repeated here). Element layers share one set; the rest are keyed by
 # canonical layer name.
@@ -156,8 +187,17 @@ def _first_point(geom):
 
 
 def _line_parts(geom):
-    """Vertex lists of every line part with at least two vertices."""
+    """Vertex lists of every line part with at least two vertices.
+
+    Guards on the *actual* geometry type rather than trusting the schema: a layer
+    whose real geometry differs from its declared type would otherwise raise
+    ("Point geometry cannot be converted to a polyline") instead of simply having
+    no endpoints to check.
+    """
     if geom is None or geom.isNull() or geom.isEmpty():
+        return []
+    from qgis.core import QgsWkbTypes
+    if geom.type() != QgsWkbTypes.GeometryType.LineGeometry:
         return []
     if geom.isMultipart():
         return [part for part in geom.asMultiPolyline() if len(part) >= 2]
@@ -649,6 +689,284 @@ def _check_enum_conformance(ctx):
 
 
 # ---------------------------------------------------------------------------
+# D2 -- numeric ranges
+# ---------------------------------------------------------------------------
+
+def _as_number(value, null):
+    """Coerce an attribute to float, or None when blank / not numeric."""
+    if _is_blank(value, null):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bound_text(low, high, exclusive) -> str:
+    """Human-readable bound, e.g. "> 0 and <= 1152". Not translated: it is a
+    mathematical expression, and its pieces are numbers."""
+    low_part = f"> {_fmt(low)}" if exclusive else f">= {_fmt(low)}"
+    if high is None:
+        return low_part
+    return f"{low_part} and <= {_fmt(high)}"
+
+
+def _check_numeric_ranges(ctx):
+    from qgis.core import NULL
+
+    for canonical, layers in ctx.layers_by_canonical.items():
+        layer_schema = schema.get_layer_schema(canonical)
+        if layer_schema is None:
+            continue
+        # Only fields the schema declares numeric. Pipe `kapacitet` is text
+        # (as-built) and is skipped rather than mis-parsed -- the same
+        # schema-driven approach D1 uses for enum domains.
+        checks = [
+            (fd.key, _NUMERIC_BOUNDS[fd.key], fd.units)
+            for fd in layer_schema.fields
+            if fd.key in _NUMERIC_BOUNDS and fd.field_type in ("int", "double")
+        ]
+        if not checks:
+            continue
+        for layer in layers:
+            names = set(layer.fields().names())
+            active = [c for c in checks if c[0] in names]
+            for feat in layer.getFeatures():
+                for key, (low, high, exclusive), units in active:
+                    number = _as_number(feat.attribute(key), NULL)
+                    if number is None:
+                        continue  # emptiness is C1's concern
+                    too_low = number <= low if exclusive else number < low
+                    too_high = high is not None and number > high
+                    if not (too_low or too_high):
+                        continue
+                    src = "Field {field}: {value} is out of range (expected {bound})"
+                    yield ValidationIssue(
+                        rule_id="D2", severity=Severity.WARNING, category=_CAT_DOMAIN,
+                        message=_safe_format(
+                            QCoreApplication.translate(_CTX, src), src,
+                            field=key, value=_fmt(number),
+                            bound=_bound_text(low, high, exclusive)),
+                        layer_name=layer.name(), layer_id=layer.id(),
+                        feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                        where=_feature_xy(feat),
+                        details={"field": key, "value": number, "units": units,
+                                 "min": low, "max": high, "exclusive_min": exclusive},
+                    )
+
+
+# ---------------------------------------------------------------------------
+# D3 -- length coherence (needs a projected CRS; see E1)
+# ---------------------------------------------------------------------------
+
+def _is_metric(layer) -> bool:
+    """True when the layer's CRS measures in linear units rather than degrees."""
+    crs = layer.crs()
+    return bool(crs and crs.isValid() and not crs.isGeographic())
+
+
+def _disagrees(stored, computed, cfg) -> bool:
+    """Whether two lengths differ by more than the configured tolerance."""
+    allowed = max(cfg.length_abs_tol, abs(computed) * cfg.length_rel_tol)
+    return abs(stored - computed) > allowed
+
+
+def _check_length_coherence(ctx):
+    """Stored lengths should agree with the geometry, and with each other.
+
+    Length comparisons are meaningless in a geographic CRS -- geometry length
+    comes out in degrees while the stored value is metres -- so the check is
+    skipped there and *says so*, rather than emitting a page of false warnings.
+    """
+    from qgis.core import NULL
+
+    cfg = ctx.config
+    for canonical, stored_field in _STORED_LENGTH_FIELD.items():
+        for layer in ctx.layers_for(canonical):
+            names = set(layer.fields().names())
+
+            if not _is_metric(layer):
+                src = ("Length checks skipped: they need a projected (metric) CRS, "
+                       "but this layer uses {crs}")
+                yield ValidationIssue(
+                    rule_id="D3", severity=Severity.INFO, category=_CAT_DOMAIN,
+                    message=_safe_format(
+                        QCoreApplication.translate(_CTX, src), src,
+                        crs=layer.crs().authid() or "?"),
+                    layer_name=layer.name(), layer_id=layer.id(),
+                    details={"skipped": True, "crs": layer.crs().authid()},
+                )
+                continue
+
+            for feat in layer.getFeatures():
+                geom = feat.geometry()
+                if geom is None or geom.isNull() or geom.isEmpty():
+                    continue  # E2's concern
+                computed = geom.length()
+
+                # 1. stored length vs the geometry it describes
+                if stored_field in names:
+                    stored = _as_number(feat.attribute(stored_field), NULL)
+                    if stored is not None and stored > 0 and _disagrees(stored, computed, cfg):
+                        src = ("Stored {field} ({stored}) does not match the drawn "
+                               "geometry ({computed})")
+                        yield ValidationIssue(
+                            rule_id="D3", severity=Severity.WARNING, category=_CAT_DOMAIN,
+                            message=_safe_format(
+                                QCoreApplication.translate(_CTX, src), src,
+                                field=stored_field, stored=_fmt(stored),
+                                computed=_fmt(computed)),
+                            layer_name=layer.name(), layer_id=layer.id(),
+                            feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                            where=_feature_xy(feat),
+                            details={"field": stored_field, "stored": stored,
+                                     "computed": computed},
+                        )
+
+                # 2. cable total = laid length + slack
+                if {"total_len_m", "duzina_m", "slack_m"} <= names:
+                    total = _as_number(feat.attribute("total_len_m"), NULL)
+                    base = _as_number(feat.attribute("duzina_m"), NULL)
+                    slack = _as_number(feat.attribute("slack_m"), NULL)
+                    if None not in (total, base, slack) and total > 0:
+                        expected = base + slack
+                        if _disagrees(total, expected, cfg):
+                            src = ("total_len_m ({total}) should equal duzina_m + "
+                                   "slack_m ({expected})")
+                            yield ValidationIssue(
+                                rule_id="D3", severity=Severity.WARNING,
+                                category=_CAT_DOMAIN,
+                                message=_safe_format(
+                                    QCoreApplication.translate(_CTX, src), src,
+                                    total=_fmt(total), expected=_fmt(expected)),
+                                layer_name=layer.name(), layer_id=layer.id(),
+                                feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                                where=_feature_xy(feat),
+                                details={"total_len_m": total, "expected": expected},
+                            )
+
+                # 3. route kilometres agree with metres
+                if {"duzina", "duzina_km"} <= names:
+                    metres = _as_number(feat.attribute("duzina"), NULL)
+                    km = _as_number(feat.attribute("duzina_km"), NULL)
+                    if None not in (metres, km) and km > 0:
+                        expected = metres / 1000.0
+                        allowed = max(cfg.length_abs_tol / 1000.0,
+                                      abs(expected) * cfg.length_rel_tol)
+                        if abs(km - expected) > allowed:
+                            src = ("duzina_km ({km}) does not match duzina/1000 "
+                                   "({expected})")
+                            yield ValidationIssue(
+                                rule_id="D3", severity=Severity.WARNING,
+                                category=_CAT_DOMAIN,
+                                message=_safe_format(
+                                    QCoreApplication.translate(_CTX, src), src,
+                                    km=_fmt(km), expected=_fmt(expected)),
+                                layer_name=layer.name(), layer_id=layer.id(),
+                                feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                                where=_feature_xy(feat),
+                                details={"duzina_km": km, "expected": expected},
+                            )
+
+
+# ---------------------------------------------------------------------------
+# E1 -- CRS consistency
+# ---------------------------------------------------------------------------
+
+def _check_crs_consistency(ctx):
+    """FiberQ layers should share one CRS, and a metric one where lengths matter."""
+    seen = {}
+    for canonical, layers in ctx.layers_by_canonical.items():
+        for layer in layers:
+            crs = layer.crs()
+            authid = (crs.authid() if crs and crs.isValid() else "") or "?"
+            seen.setdefault(authid, []).append(layer.name())
+
+            if canonical in _STORED_LENGTH_FIELD and not _is_metric(layer):
+                src = ("Layer uses a geographic CRS ({crs}); length and area checks "
+                       "need a projected CRS in metres")
+                yield ValidationIssue(
+                    rule_id="E1", severity=Severity.WARNING, category=_CAT_DOMAIN,
+                    message=_safe_format(
+                        QCoreApplication.translate(_CTX, src), src, crs=authid),
+                    layer_name=layer.name(), layer_id=layer.id(),
+                    details={"crs": authid, "geographic": True},
+                )
+
+    if len(seen) > 1:
+        src = "FiberQ layers do not all share one CRS: {list}"
+        yield ValidationIssue(
+            rule_id="E1", severity=Severity.WARNING, category=_CAT_DOMAIN,
+            message=_safe_format(
+                QCoreApplication.translate(_CTX, src), src,
+                list=", ".join(sorted(seen))),
+            details={"crs_list": sorted(seen), "layers_by_crs": seen},
+        )
+
+
+# ---------------------------------------------------------------------------
+# E2 -- geometry health
+# ---------------------------------------------------------------------------
+
+def _check_geometry_validity(ctx):
+    """Missing geometry is an error; degenerate or self-crossing shapes warn.
+
+    Dispatches on the feature's *actual* geometry type, not the schema's declared
+    one. Trusting the schema would call ``length()`` on a point (always 0) and
+    report a phantom zero-length line whenever a layer's real geometry differs
+    from its declaration.
+    """
+    from qgis.core import QgsWkbTypes
+
+    for canonical, layers in ctx.layers_by_canonical.items():
+        layer_schema = schema.get_layer_schema(canonical)
+        expected = layer_schema.geometry if layer_schema else ""
+        for layer in layers:
+            for feat in layer.getFeatures():
+                geom = feat.geometry()
+
+                if geom is None or geom.isNull() or geom.isEmpty():
+                    src = "Feature has no geometry"
+                    yield ValidationIssue(
+                        rule_id="E2", severity=Severity.ERROR, category=_CAT_DOMAIN,
+                        message=QCoreApplication.translate(_CTX, src),
+                        layer_name=layer.name(), layer_id=layer.id(),
+                        feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                        details={"expected_geometry": expected},
+                    )
+                    continue
+
+                gtype = geom.type()
+                if gtype == QgsWkbTypes.GeometryType.LineGeometry:
+                    if geom.length() <= 0:
+                        src = "Line has zero length"
+                    elif not geom.isSimple():
+                        # A self-crossing LineString is OGC-valid, so
+                        # isGeosValid() will not catch it -- isSimple() does.
+                        src = "Line crosses itself"
+                    else:
+                        continue
+                elif gtype == QgsWkbTypes.GeometryType.PolygonGeometry:
+                    if geom.area() <= 0:
+                        src = "Polygon has zero area"
+                    elif not geom.isGeosValid():
+                        src = "Polygon boundary is self-intersecting"
+                    else:
+                        continue
+                else:
+                    continue
+
+                yield ValidationIssue(
+                    rule_id="E2", severity=Severity.WARNING, category=_CAT_DOMAIN,
+                    message=QCoreApplication.translate(_CTX, src),
+                    layer_name=layer.name(), layer_id=layer.id(),
+                    feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
+                    where=_feature_xy(feat),
+                    details={"expected_geometry": expected},
+                )
+
+
+# ---------------------------------------------------------------------------
 # Registry — [core] rules shipping in v1.4.0. Append as the engine grows;
 # keep each rule independent (the runner continues past a failing one).
 # ---------------------------------------------------------------------------
@@ -722,5 +1040,34 @@ RULES = [
         category=_CAT_DOMAIN,
         default_severity=Severity.WARNING,
         check=_check_enum_conformance,
+    ),
+    ValidationRule(
+        id="D2",
+        title=QT_TRANSLATE_NOOP(_CTX, "Numeric attributes within plausible ranges"),
+        category=_CAT_DOMAIN,
+        default_severity=Severity.WARNING,
+        check=_check_numeric_ranges,
+    ),
+    ValidationRule(
+        id="D3",
+        title=QT_TRANSLATE_NOOP(_CTX, "Stored lengths agree with geometry"),
+        category=_CAT_DOMAIN,
+        default_severity=Severity.WARNING,
+        check=_check_length_coherence,
+        applies_to=tuple(_STORED_LENGTH_FIELD),
+    ),
+    ValidationRule(
+        id="E1",
+        title=QT_TRANSLATE_NOOP(_CTX, "Coordinate reference systems are consistent"),
+        category=_CAT_DOMAIN,
+        default_severity=Severity.WARNING,
+        check=_check_crs_consistency,
+    ),
+    ValidationRule(
+        id="E2",
+        title=QT_TRANSLATE_NOOP(_CTX, "Geometries are present and well formed"),
+        category=_CAT_DOMAIN,
+        default_severity=Severity.ERROR,
+        check=_check_geometry_validity,
     ),
 ]

--- a/tests/test_validation_domain.py
+++ b/tests/test_validation_domain.py
@@ -1,0 +1,360 @@
+"""Tests for the WP2 domain rules: D2 numeric ranges, D3 length coherence,
+E1 CRS consistency, E2 geometry health.
+
+Geometry is in EPSG:3857 (metres) unless a test is specifically about a
+geographic CRS, so lengths in these fixtures are directly comparable to the
+stored values.
+"""
+from qgis.core import (
+    QgsFeature,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProject,
+    QgsVectorLayer,
+)
+
+from fiberq.core import validation_manager as vm
+from fiberq.core import validation_rules as vr
+
+METRIC = "EPSG:3857"
+GEOGRAPHIC = "EPSG:4326"
+
+
+def _layer(name, geom_type, fields, rows, crs=METRIC):
+    """rows: [(attrs, QgsGeometry|None)]"""
+    uri = f"{geom_type}?crs={crs}"
+    for spec in fields:
+        uri += "&field=" + spec
+    layer = QgsVectorLayer(uri, name, "memory")
+    assert layer.isValid(), name
+    feats = []
+    for attrs, geom in rows:
+        feat = QgsFeature(layer.fields())
+        for key, value in attrs.items():
+            feat.setAttribute(key, value)
+        if geom is not None:
+            feat.setGeometry(geom)
+        feats.append(feat)
+    layer.dataProvider().addFeatures(feats)
+    layer.updateExtents()
+    return layer
+
+
+def _line(*xy):
+    return QgsGeometry.fromPolylineXY([QgsPointXY(x, y) for x, y in xy])
+
+
+def _run(project, rule_ids, config=None):
+    rules = [r for r in vr.RULES if r.id in rule_ids]
+    assert len(rules) == len(rule_ids)
+    result = vm.run_validation(project, rules=rules, config=config)
+    assert not result.rule_errors, result.rule_errors
+    return result
+
+
+def _ids(result, rule_id):
+    return [i for i in result.issues if i.rule_id == rule_id]
+
+
+CABLE_FIELDS = (
+    "fiberq_uuid:string", "broj_vlakana:integer", "broj_cevcica:integer",
+    "slabljenje_dbkm:double", "duzina_m:double", "slack_m:double",
+    "total_len_m:double",
+)
+
+
+# ---------------------------------------------------------------------------
+# D2 -- numeric ranges
+# ---------------------------------------------------------------------------
+
+def test_d2_accepts_plausible_values(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "broj_vlakana": 24, "broj_cevcica": 4,
+          "slabljenje_dbkm": 0.35}, _line((0, 0), (100, 0))),
+    ]))
+    assert _ids(_run(project, {"D2"}), "D2") == []
+
+
+def test_d2_flags_zero_and_excessive_fibre_counts(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "broj_vlakana": 0}, _line((0, 0), (100, 0))),
+        ({"fiberq_uuid": "c2", "broj_vlakana": 5000}, _line((0, 10), (100, 10))),
+        ({"fiberq_uuid": "c3", "broj_vlakana": 1152}, _line((0, 20), (100, 20))),
+    ]))
+    issues = _ids(_run(project, {"D2"}), "D2")
+    # 1152 is the documented maximum and must be accepted.
+    assert len(issues) == 2
+    assert {i.details["value"] for i in issues} == {0.0, 5000.0}
+    assert all(i.severity == vm.Severity.WARNING for i in issues)
+
+
+def test_d2_flags_a_negative_duct_count(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "broj_vlakana": 12, "broj_cevcica": -2},
+         _line((0, 0), (100, 0))),
+    ]))
+    issues = _ids(_run(project, {"D2"}), "D2")
+    assert [i.details["field"] for i in issues] == ["broj_cevcica"]
+
+
+def test_d2_flags_implausible_attenuation(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "broj_vlakana": 12, "slabljenje_dbkm": 250.0},
+         _line((0, 0), (100, 0))),
+    ]))
+    issues = _ids(_run(project, {"D2"}), "D2")
+    assert [i.details["field"] for i in issues] == ["slabljenje_dbkm"]
+
+
+def test_d2_skips_blank_values(qgis_app):
+    """An unset number is incompleteness (C1), not an out-of-range value."""
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((0, 0), (100, 0))),
+    ]))
+    assert _ids(_run(project, {"D2"}), "D2") == []
+
+
+def test_d2_ignores_text_capacity_on_pipes(qgis_app):
+    """Pipe `kapacitet` is text as-built, so it must not be range-checked."""
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "PE pipes", "LineString",
+        ("fiberq_uuid:string", "kapacitet:string", "fi:integer", "duzina_m:double"),
+        [({"fiberq_uuid": "p1", "kapacitet": "not a number", "fi": 40},
+          _line((0, 0), (100, 0)))],
+    ))
+    assert _ids(_run(project, {"D2"}), "D2") == []
+
+
+def test_d2_flags_a_zero_pipe_diameter(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "PE pipes", "LineString",
+        ("fiberq_uuid:string", "fi:integer", "duzina_m:double"),
+        [({"fiberq_uuid": "p1", "fi": 0}, _line((0, 0), (100, 0)))],
+    ))
+    assert [i.details["field"] for i in _ids(_run(project, {"D2"}), "D2")] == ["fi"]
+
+
+# ---------------------------------------------------------------------------
+# D3 -- length coherence
+# ---------------------------------------------------------------------------
+
+def test_d3_accepts_a_matching_stored_length(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "duzina_m": 100.0}, _line((0, 0), (100, 0))),
+    ]))
+    assert _ids(_run(project, {"D3"}), "D3") == []
+
+
+def test_d3_flags_a_stored_length_that_contradicts_geometry(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "duzina_m": 750.0}, _line((0, 0), (100, 0))),
+    ]))
+    issues = _ids(_run(project, {"D3"}), "D3")
+    assert len(issues) == 1
+    assert issues[0].details["stored"] == 750.0
+    assert round(issues[0].details["computed"]) == 100
+
+
+def test_d3_tolerates_small_rounding_differences(qgis_app):
+    """100.4 vs 100.0 is inside the 1% / 0.5-unit allowance."""
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "duzina_m": 100.4}, _line((0, 0), (100, 0))),
+    ]))
+    assert _ids(_run(project, {"D3"}), "D3") == []
+
+
+def test_d3_checks_total_equals_length_plus_slack(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "ok", "duzina_m": 100.0, "slack_m": 10.0,
+          "total_len_m": 110.0}, _line((0, 0), (100, 0))),
+        ({"fiberq_uuid": "bad", "duzina_m": 100.0, "slack_m": 10.0,
+          "total_len_m": 999.0}, _line((0, 10), (100, 10))),
+    ]))
+    issues = _ids(_run(project, {"D3"}), "D3")
+    assert len(issues) == 1
+    assert issues[0].details["total_len_m"] == 999.0
+    assert issues[0].details["expected"] == 110.0
+
+
+def test_d3_checks_route_kilometres_against_metres(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "Route", "LineString",
+        ("fiberq_uuid:string", "duzina:double", "duzina_km:double"),
+        [({"fiberq_uuid": "r1", "duzina": 1000.0, "duzina_km": 7.5},
+          _line((0, 0), (1000, 0)))],
+    ))
+    issues = _ids(_run(project, {"D3"}), "D3")
+    km = [i for i in issues if "duzina_km" in i.details]
+    assert len(km) == 1
+    assert km[0].details["expected"] == 1.0
+
+
+def test_d3_skips_and_says_so_in_a_geographic_crs(qgis_app):
+    """The whole point: degrees vs metres would produce nonsense warnings."""
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "duzina_m": 100.0}, _line((0, 0), (1, 0))),
+    ], crs=GEOGRAPHIC))
+    issues = _ids(_run(project, {"D3"}), "D3")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.INFO
+    assert issues[0].details["skipped"] is True
+    assert issues[0].details["crs"] == GEOGRAPHIC
+
+
+def test_d3_tolerance_is_configurable(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1", "duzina_m": 130.0}, _line((0, 0), (100, 0))),
+    ]))
+    assert len(_ids(_run(project, {"D3"}), "D3")) == 1
+    loose = vm.ValidationConfig(length_rel_tol=0.5)
+    assert _ids(_run(project, {"D3"}, config=loose), "D3") == []
+
+
+# ---------------------------------------------------------------------------
+# E1 -- CRS consistency
+# ---------------------------------------------------------------------------
+
+def test_e1_is_clean_for_one_projected_crs(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((0, 0), (100, 0))),
+    ]))
+    project.addMapLayer(_layer(
+        "ODF", "Point", ("fiberq_uuid:string",),
+        [({"fiberq_uuid": "n1"}, QgsGeometry.fromPointXY(QgsPointXY(0, 0)))]))
+    assert _ids(_run(project, {"E1"}), "E1") == []
+
+
+def test_e1_flags_mixed_crs(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((0, 0), (100, 0))),
+    ]))
+    project.addMapLayer(_layer(
+        "ODF", "Point", ("fiberq_uuid:string",),
+        [({"fiberq_uuid": "n1"}, QgsGeometry.fromPointXY(QgsPointXY(0, 0)))],
+        crs=GEOGRAPHIC))
+    mixed = [i for i in _ids(_run(project, {"E1"}), "E1") if "crs_list" in i.details]
+    assert len(mixed) == 1
+    assert set(mixed[0].details["crs_list"]) == {METRIC, GEOGRAPHIC}
+
+
+def test_e1_flags_a_geographic_crs_where_lengths_are_stored(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((0, 0), (1, 0))),
+    ], crs=GEOGRAPHIC))
+    geographic = [i for i in _ids(_run(project, {"E1"}), "E1")
+                  if i.details.get("geographic")]
+    assert len(geographic) == 1
+    assert geographic[0].severity == vm.Severity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# E2 -- geometry health
+# ---------------------------------------------------------------------------
+
+def test_e2_flags_missing_geometry_as_an_error(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "ODF", "Point", ("fiberq_uuid:string",),
+        [({"fiberq_uuid": "n1"}, None)]))
+    issues = _ids(_run(project, {"E2"}), "E2")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.ERROR
+
+
+def test_e2_flags_a_zero_length_line(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((5, 5), (5, 5))),
+    ]))
+    issues = _ids(_run(project, {"E2"}), "E2")
+    assert len(issues) == 1
+    assert issues[0].severity == vm.Severity.WARNING
+
+
+def test_e2_flags_a_self_crossing_line(qgis_app):
+    """A self-crossing LineString is OGC-valid, so this needs isSimple()."""
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((0, 0), (100, 100), (0, 100), (100, 0))),
+    ]))
+    issues = _ids(_run(project, {"E2"}), "E2")
+    assert len(issues) == 1
+    assert issues[0].details["expected_geometry"] == "LineString"
+
+
+def test_e2_accepts_a_normal_line(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((0, 0), (100, 0), (200, 50))),
+    ]))
+    assert _ids(_run(project, {"E2"}), "E2") == []
+
+
+def test_e2_flags_a_bowtie_polygon(qgis_app):
+    project = QgsProject()
+    bowtie = QgsGeometry.fromPolygonXY([[
+        QgsPointXY(0, 0), QgsPointXY(100, 100),
+        QgsPointXY(100, 0), QgsPointXY(0, 100), QgsPointXY(0, 0),
+    ]])
+    project.addMapLayer(_layer(
+        "Service Area", "Polygon",
+        ("fiberq_uuid:string", "area_m2:double", "perim_m:double"),
+        [({"fiberq_uuid": "a1"}, bowtie)]))
+    issues = _ids(_run(project, {"E2"}), "E2")
+    assert len(issues) == 1
+    assert issues[0].details["expected_geometry"] == "Polygon"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_registry_holds_the_full_v140_core_set(qgis_app):
+    ids = [r.id for r in vr.RULES]
+    assert ids == ["A1", "A2", "A3", "B1", "B2", "B3", "B4",
+                   "C1", "D1", "D2", "D3", "E1", "E2"]
+    assert len(ids) == len(set(ids))
+    for rule in vr.RULES:
+        assert rule.title and rule.category and callable(rule.check)
+        assert isinstance(rule.default_severity, vm.Severity)
+
+
+def test_a_clean_project_passes_every_rule(qgis_app):
+    """End-to-end: a small, correct project produces no issues at all."""
+    project = QgsProject()
+    cables = _layer("Underground cables", "LineString", CABLE_FIELDS + (
+        "tip:string", "naziv:string"), [
+        ({"fiberq_uuid": "c1", "tip": "opticki", "broj_vlakana": 24,
+          "broj_cevcica": 2, "slabljenje_dbkm": 0.35, "duzina_m": 100.0,
+          "slack_m": 10.0, "total_len_m": 110.0}, _line((0, 0), (100, 0))),
+    ])
+    project.addMapLayer(cables)
+    project.addMapLayer(_layer(
+        "ODF", "Point", ("fiberq_uuid:string", "naziv:string",
+                         "kapacitet:integer", "stanje:string"),
+        [({"fiberq_uuid": "n1", "naziv": "ODF-1", "kapacitet": 48,
+           "stanje": "Planned"}, QgsGeometry.fromPointXY(QgsPointXY(0, 0))),
+         ({"fiberq_uuid": "n2", "naziv": "ODF-2", "kapacitet": 48,
+           "stanje": "Built"}, QgsGeometry.fromPointXY(QgsPointXY(100, 0)))]))
+
+    result = vm.run_validation(project)
+    assert not result.rule_errors, result.rule_errors
+    assert result.issues == [], [(i.rule_id, i.message) for i in result.issues]
+    assert len(result.ran_rules) == len(vr.RULES)

--- a/tests/test_validation_topology.py
+++ b/tests/test_validation_topology.py
@@ -348,12 +348,26 @@ def test_plural_slack_layer_is_actually_checked(qgis_app):
     assert len(_ids(_run(project, {"B1"}), "B1")) == 1
 
 
-def test_registry_is_wellformed_after_the_topology_batch(qgis_app):
-    ids = [r.id for r in vr.RULES]
-    assert ids == ["A1", "A2", "A3", "B1", "B2", "B3", "B4", "C1", "D1"]
-    assert len(ids) == len(set(ids))
-    for rule in vr.RULES:
-        assert rule.title and rule.category and callable(rule.check)
+def test_topology_rules_are_registered(qgis_app):
+    """The full rule list is pinned once, in test_validation_domain.py."""
+    ids = {r.id for r in vr.RULES}
+    assert {"A1", "A2", "A3", "B1", "B2", "B3"} <= ids
+
+
+def test_line_rules_survive_a_layer_with_unexpected_geometry(qgis_app):
+    """A layer whose real geometry differs from its declared type must not crash.
+
+    A1/A2 previously called asPolyline() on whatever the layer held, so a point
+    layer named like a cable raised "Point geometry cannot be converted to a
+    polyline". The runner caught it, but the rule produced nothing useful.
+    """
+    project = QgsProject()
+    project.addMapLayer(_point_layer("Underground cables", [
+        ({"fiberq_uuid": "odd"}, QgsPointXY(0, 0)),
+    ]))
+    result = _run(project, {"A1", "A2"})
+    assert result.rule_errors == []
+    assert result.issues == []
 
 
 def test_endpoint_scan_is_built_once_per_run(qgis_app):


### PR DESCRIPTION
## WP2 — domain rules: D2 ranges, D3 length coherence, E1 CRS, E2 geometry

Third WP2 branch, after #34 (core) and #36 (topology). **This completes the v1.4.0 core
rule set at 13 rules** — the validation engine (task 2.1) is now feature-complete, and the
remaining WP2 branches are the UI and the audit report.

### Rules added

| Rule | Severity | Fires when |
|---|---|---|
| **D2** | WARNING | a numeric attribute is outside a plausible range |
| **D3** | WARNING | stored length disagrees with geometry, `total_len_m` ≠ `duzina_m + slack_m`, or `duzina_km` ≠ `duzina/1000` |
| **E1** | WARNING | FiberQ layers don't share one CRS, or a length-storing layer uses a geographic CRS |
| **E2** | ERROR / WARNING | missing geometry (error); zero-length line, self-crossing line, zero-area polygon, self-intersecting polygon (warnings) |

### Design notes

- **D2 is schema-driven, like D1.** Bounds apply only to fields the schema declares
  `int`/`double`, so pipe `kapacitet` — which is **text** as-built — is skipped rather than
  mis-parsed. No hardcoded assumptions about which fields are numeric.
- **D3 is gated on a projected CRS.** In a geographic CRS the computed geometry length comes
  out in *degrees* while the stored value is metres. Rather than emit a page of false
  warnings, D3 skips and emits one INFO explaining why. Length agreement uses
  `max(0.5 units, 1%)`, both configurable on `ValidationConfig`.
- **Route is the odd layer out** — it stores `duzina` (m) and `duzina_km`, while every other
  line layer uses `duzina_m`. Mapped explicitly.
- **Self-crossing lines need `isSimple()`, not `isGeosValid()`** — a self-crossing
  `LineString` is valid per OGC, so the obvious check would silently miss them.

### Robustness fix found while testing this batch

A1, A2 and E2 trusted the schema's *declared* geometry type instead of the feature's
**actual** one. On a layer whose real geometry differed:

- A1/A2 raised `Point geometry cannot be converted to a polyline`
- E2 reported a phantom "Line has zero length" (because `length()` on a point is 0)

All three now dispatch on `geom.type()`. Worth noting the runner's per-rule isolation is
what surfaced this — the failure landed in `rule_errors` with a clear message instead of
sinking the whole validation run. Regression test included.

### Testing

- flake8 `--isolated` + Bandit `-ll`: **0/0**
- **115 tests green** on QGIS 3.44 (Qt5) and QGIS 4.0 (Qt6)
- 22 new cases, plus an end-to-end assertion that a clean project produces **zero** issues
  across all 13 rules — the check that the rule set isn't quietly crying wolf
- The full rule list is now pinned in exactly one place (it was in two, meaning two tests to
  update per batch)
