### PR TITLE
feat(wp2): Validate project action, results panel, and true ground-metre lengths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,6 @@ __marimo__/
 
 # Local dev helpers (not shipped in the plugin zip)
 /dev/
+
+# QGIS writes this into the CWD when it runs headless in the test containers.
+symbology-style.db

--- a/fiberq/addons/reserve_hook.py
+++ b/fiberq/addons/reserve_hook.py
@@ -8,6 +8,7 @@ import os
 
 # Phase 5.3: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -245,7 +246,7 @@ class ReserveHook(QObject):
         try:
             kf = next(lyr.getFeatures(f'id={int(cable_fid)}'))
             geom = kf.geometry()
-            g_m = geom.length() if isinstance(geom, QgsGeometry) else 0.0
+            g_m = ground_length(geom, lyr) if isinstance(geom, QgsGeometry) else 0.0
         except StopIteration:
             pass
 

--- a/fiberq/core/cable_manager.py
+++ b/fiberq/core/cable_manager.py
@@ -39,6 +39,7 @@ from qgis.core import (
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 # Phase 0.1: UUID support for FiberQ Designer
@@ -935,7 +936,7 @@ class CableManager:
         except Exception as e:
             logger.debug(f"Error setting UUID on cable: {e}")
         try:
-            cable_length = cable_geom.length()
+            cable_length = ground_length(cable_geom, cables_layer)
             feat.setAttribute("duzina_m", cable_length)
             feat.setAttribute("slack_m", 0.0)  # Issue #1: Initialize slack to 0
             feat.setAttribute("total_len_m", cable_length)  # Issue #1: Set total_len_m = duzina_m initially

--- a/fiberq/core/length_manager.py
+++ b/fiberq/core/length_manager.py
@@ -1,0 +1,259 @@
+"""Bring stored lengths back into line with the geometry they describe.
+
+Companion to the D3 validation rule. D3 reports that a stored length disagrees
+with the drawn feature; this rewrites it so it agrees. The two share a tolerance
+(:class:`ValidationConfig`) on purpose, so "recalculate, then validate" is
+guaranteed to clear every D3 finding rather than leaving a residue just under or
+over the threshold.
+
+Two reasons a stored length drifts:
+
+* it was written in map units by a code path that predates
+  :mod:`fiberq.utils.measure` -- 41% long in Web Mercator at Serbian latitudes;
+* the geometry was edited afterwards and nothing recomputed the attribute.
+
+Both look identical in the data, and both are fixed the same way.
+
+The work is split into :func:`plan_recalculation` (reads, decides, writes
+nothing) and :func:`apply_recalculation` (writes). That lets the UI show the user
+exactly what is about to change to their project before anything is committed,
+and lets the tests assert the decision without touching an edit buffer.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ..utils.logger import get_logger
+from ..utils.measure import ground_length, measures_metres
+from .validation_manager import ValidationConfig, ValidationContext
+
+logger = get_logger(__name__)
+
+#: Canonical layer name -> the field holding its length in metres. Mirrors
+#: validation_rules._STORED_LENGTH_FIELD; D3 and this module must agree on which
+#: field is authoritative or one would keep reporting what the other "fixed".
+STORED_LENGTH_FIELD = {
+    "Aerial cables": "duzina_m",
+    "Underground cables": "duzina_m",
+    "PE pipes": "duzina_m",
+    "Transition pipes": "duzina_m",
+    "Route": "duzina",
+}
+
+#: Fields derived from the metre value, recomputed alongside it.
+KM_FIELD = "duzina_km"
+TOTAL_FIELD = "total_len_m"
+SLACK_FIELD = "slack_m"
+
+
+@dataclass
+class LengthChange:
+    """One attribute that would be (or was) rewritten."""
+
+    layer_name: str
+    layer_id: str
+    feature_id: int
+    field_name: str
+    old_value: Optional[float]
+    new_value: float
+
+    @property
+    def delta(self) -> float:
+        return self.new_value - (self.old_value or 0.0)
+
+    @property
+    def ratio(self) -> Optional[float]:
+        if not self.old_value:
+            return None
+        return self.old_value / self.new_value if self.new_value else None
+
+
+@dataclass
+class RecalcPlan:
+    """What :func:`plan_recalculation` decided, before anything is written."""
+
+    changes: List[LengthChange] = field(default_factory=list)
+    #: Layers that could not be measured meaningfully (geographic CRS, no ellipsoid).
+    skipped_layers: List[str] = field(default_factory=list)
+    #: Layers examined and already correct, for an honest "nothing to do".
+    layers_seen: List[str] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return bool(self.changes)
+
+    @property
+    def feature_count(self) -> int:
+        """Features touched, not attributes -- one feature can carry three."""
+        return len({(c.layer_id, c.feature_id) for c in self.changes})
+
+    def counts_by_layer(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for c in self.changes:
+            counts[c.layer_name] = counts.get(c.layer_name, 0) + 1
+        return counts
+
+    def largest_change(self) -> Optional[LengthChange]:
+        """The change with the biggest absolute difference, for a preview line."""
+        scored = [c for c in self.changes if c.old_value is not None]
+        return max(scored, key=lambda c: abs(c.delta), default=None)
+
+
+@dataclass
+class RecalcOutcome:
+    """What :func:`apply_recalculation` actually managed to commit."""
+
+    applied: List[LengthChange] = field(default_factory=list)
+    failures: List[str] = field(default_factory=list)
+
+    @property
+    def feature_count(self) -> int:
+        return len({(c.layer_id, c.feature_id) for c in self.applied})
+
+
+def _disagrees(stored, computed, config) -> bool:
+    """Same test D3 uses, so recalculating clears exactly what it reports."""
+    if stored is None:
+        return True
+    allowed = max(config.length_abs_tol, abs(computed) * config.length_rel_tol)
+    return abs(stored - computed) > allowed
+
+
+def _as_float(value) -> Optional[float]:
+    try:
+        from qgis.core import NULL
+        if value is None or value == NULL:
+            return None
+    except ImportError:
+        if value is None:
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def plan_recalculation(project=None, config: Optional[ValidationConfig] = None) -> RecalcPlan:
+    """Work out which stored lengths disagree with their geometry. Writes nothing."""
+    if project is None:
+        from qgis.core import QgsProject
+        project = QgsProject.instance()
+
+    config = config or ValidationConfig()
+    ctx = ValidationContext(project, config)
+    plan = RecalcPlan()
+
+    for canonical, length_field in STORED_LENGTH_FIELD.items():
+        for layer in ctx.layers_for(canonical):
+            plan.layers_seen.append(layer.name())
+
+            if not measures_metres(layer, project=project):
+                # Measuring here would produce degrees; refuse rather than write
+                # a number that is confidently wrong.
+                plan.skipped_layers.append(layer.name())
+                continue
+
+            names = set(layer.fields().names())
+            if length_field not in names:
+                continue
+
+            for feat in layer.getFeatures():
+                geom = feat.geometry()
+                if geom is None or geom.isNull() or geom.isEmpty():
+                    continue  # nothing to measure; E2 reports the geometry itself
+
+                computed = ground_length(geom, layer, project=project)
+                if computed <= 0:
+                    continue
+
+                stored = _as_float(feat.attribute(length_field))
+                metres_changed = _disagrees(stored, computed, config)
+                if metres_changed:
+                    plan.changes.append(LengthChange(
+                        layer.name(), layer.id(), feat.id(),
+                        length_field, stored, computed))
+
+                # duzina_km is derived; refresh it whenever it no longer follows,
+                # even if the metre value itself was already right.
+                if KM_FIELD in names:
+                    expected_km = round(computed / 1000.0, 2)
+                    stored_km = _as_float(feat.attribute(KM_FIELD))
+                    if stored_km is None or abs(stored_km - expected_km) > 0.005:
+                        plan.changes.append(LengthChange(
+                            layer.name(), layer.id(), feat.id(),
+                            KM_FIELD, stored_km, expected_km))
+
+                # total_len_m = laid length + slack. Slack is a user decision, so
+                # it is read, never rewritten.
+                if TOTAL_FIELD in names:
+                    slack = _as_float(feat.attribute(SLACK_FIELD)) or 0.0
+                    expected_total = computed + slack
+                    stored_total = _as_float(feat.attribute(TOTAL_FIELD))
+                    if _disagrees(stored_total, expected_total, config):
+                        plan.changes.append(LengthChange(
+                            layer.name(), layer.id(), feat.id(),
+                            TOTAL_FIELD, stored_total, expected_total))
+
+    return plan
+
+
+def apply_recalculation(plan: RecalcPlan, project=None) -> RecalcOutcome:
+    """Commit a plan produced by :func:`plan_recalculation`.
+
+    Each layer is committed in its own edit session, so one uncooperative layer
+    (read-only source, locked GeoPackage) does not roll back the others. Failures
+    are collected and returned rather than raised -- the caller shows them.
+    """
+    if project is None:
+        from qgis.core import QgsProject
+        project = QgsProject.instance()
+
+    outcome = RecalcOutcome()
+    if not plan.changes:
+        return outcome
+
+    by_layer: Dict[str, List[LengthChange]] = {}
+    for change in plan.changes:
+        by_layer.setdefault(change.layer_id, []).append(change)
+
+    for layer_id, changes in by_layer.items():
+        layer = project.mapLayer(layer_id)
+        if layer is None:
+            outcome.failures.append(f"{changes[0].layer_name}: layer is gone")
+            continue
+
+        name = layer.name()
+        try:
+            if not layer.startEditing():
+                outcome.failures.append(f"{name}: could not be opened for editing")
+                continue
+
+            indexes = {}
+            for change in changes:
+                idx = indexes.get(change.field_name)
+                if idx is None:
+                    idx = layer.fields().indexFromName(change.field_name)
+                    indexes[change.field_name] = idx
+                if idx < 0:
+                    continue
+                layer.changeAttributeValue(change.feature_id, idx, change.new_value)
+
+            if layer.commitChanges():
+                outcome.applied.extend(changes)
+                layer.triggerRepaint()
+            else:
+                errors = '; '.join(layer.commitErrors()[:3])
+                outcome.failures.append(f"{name}: {errors or 'commit refused'}")
+                layer.rollBack()
+        except Exception as e:
+            logger.warning(f"Length recalculation failed on {name}: {e}")
+            outcome.failures.append(f"{name}: {e}")
+            try:
+                layer.rollBack()
+            except Exception as rollback_error:
+                logger.debug(f"Rollback also failed on {name}: {rollback_error}")
+
+    return outcome
+
+
+def recalculate_lengths(project=None, config: Optional[ValidationConfig] = None) -> RecalcOutcome:
+    """Plan and apply in one call. The UI uses the two phases separately."""
+    return apply_recalculation(plan_recalculation(project, config), project)

--- a/fiberq/core/route_manager.py
+++ b/fiberq/core/route_manager.py
@@ -31,6 +31,7 @@ from qgis.core import (
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -267,7 +268,7 @@ class RouteManager:
         tip_trase = self._ask_route_type()
 
         # Calculate length
-        duzina_m = line_geom.length()
+        duzina_m = ground_length(line_geom, route_layer)
         duzina_km = round(duzina_m / 1000.0, 2)
 
         # Create feature
@@ -395,7 +396,7 @@ class RouteManager:
         # Ask for route type
         tip_trase = self._ask_route_type("Type of connected route")
 
-        duzina_m = geom.length()
+        duzina_m = ground_length(geom, route_layer)
         duzina_km = round(duzina_m / 1000.0, 2)
 
         # Delete old features and add merged
@@ -469,7 +470,7 @@ class RouteManager:
                             geom_line = QgsGeometry.fromPolylineXY(polyline)
                             if src_crs != dst_crs:
                                 geom_line.transform(transform)
-                            duzina_m = geom_line.length()
+                            duzina_m = ground_length(geom_line, route_layer)
                             duzina_km = round(duzina_m / 1000.0, 2)
                             new_feat.setGeometry(geom_line)
                             new_feat.setAttribute("naziv", f"Imported route {route_layer.featureCount() + 1}")
@@ -491,7 +492,7 @@ class RouteManager:
                     geom_line = QgsGeometry.fromPolylineXY(polyline)
                     if src_crs != dst_crs:
                         geom_line.transform(transform)
-                    duzina_m = geom_line.length()
+                    duzina_m = ground_length(geom_line, route_layer)
                     duzina_km = round(duzina_m / 1000.0, 2)
                     new_feat.setGeometry(geom_line)
                     new_feat.setAttribute("naziv", f"Imported route {route_layer.featureCount() + 1}")

--- a/fiberq/core/slack_manager.py
+++ b/fiberq/core/slack_manager.py
@@ -30,6 +30,7 @@ from qgis.PyQt.QtGui import QColor
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -224,7 +225,7 @@ class SlackManager:
                 cable_f[fld_slack] = float(slack)
             if has_total:
                 try:
-                    geom_len = float(cable_f.geometry().length())
+                    geom_len = ground_length(cable_f.geometry(), cable_lyr)
                 except Exception:
                     geom_len = 0.0
                 cable_f["total_len_m"] = geom_len + float(slack)

--- a/fiberq/core/validation_rules.py
+++ b/fiberq/core/validation_rules.py
@@ -25,7 +25,10 @@ asserted in a pure unit test; QGIS types (``NULL``, feature/geometry access) are
 imported lazily inside the checks, which only run under QGIS.
 """
 from ..models import schema
+from ..utils.logger import get_logger
 from .validation_manager import Severity, ValidationIssue, ValidationRule
+
+logger = get_logger(__name__)
 
 try:
     from qgis.PyQt.QtCore import QCoreApplication, QT_TRANSLATE_NOOP
@@ -136,14 +139,32 @@ def _uuid_of(feat) -> str:
     return "" if value is None else str(value)
 
 
-def _fmt(value) -> str:
+def _fmt(value, places: int = 2) -> str:
     """Compact number for a message: trims trailing zeros so a tolerance of 5.0
-    reads as "5" and a distance of 7.25 keeps its precision."""
+    reads as "5" and a distance of 7.25 keeps its precision. ``places`` is raised
+    for small magnitudes (kilometres) where 2 decimals would print both sides of
+    a mismatch identically."""
     try:
-        text = f"{float(value):.2f}".rstrip("0").rstrip(".")
+        text = f"{float(value):.{places}f}".rstrip("0").rstrip(".")
         return text or "0"
     except (TypeError, ValueError):
         return str(value)
+
+
+def _half_ulp(value) -> float:
+    """Half the precision the stored value appears to carry.
+
+    ``0.03`` looks 2-decimal, so anything within 0.005 of it is consistent with
+    that rounding and must not be reported as a mismatch.
+    """
+    try:
+        text = f"{float(value)!r}"
+    except (TypeError, ValueError):
+        return 0.0
+    if "." not in text or "e" in text.lower():
+        return 0.0
+    decimals = len(text.split(".", 1)[1].rstrip("0"))
+    return 0.5 * (10 ** -decimals) if decimals else 0.0
 
 
 def _safe_format(translated, source, **kwargs):
@@ -154,15 +175,26 @@ def _safe_format(translated, source, **kwargs):
 
 
 def _allowed_domain(field_def):
-    """The set of valid *stored* values for an enum field. ``value_map`` is
-    ``{display: stored}``, so the stored domain is its values (e.g. cable ``tip``
-    -> ``{opticki, bakarnI}`` — the as-built typo is honoured because the domain
-    is read from the schema, not hardcoded)."""
+    """Valid values for an enum field -- **both** sides of ``value_map``.
+
+    ``value_map`` is declared ``{display: stored}``, but the plugin does not
+    consistently store the mapped side. The cable dialog offers "Optical"/"Copper"
+    and maps them to themselves (fiberq/dialogs/cable_dialog.py), so real projects
+    hold the English label where schema.py declares ``opticki``/``bakarnI``; older
+    projects hold the Serbian form. Both are legitimate as-built values.
+
+    Accepting the union keeps D1 doing its actual job -- catching typos and
+    garbage -- without taking sides in a vocabulary split that WP3's schema
+    inventory is the right place to resolve. Narrowing to one side floods every
+    real project with false positives on every cable.
+    """
+    allowed = set()
     if field_def.value_map:
-        return set(field_def.value_map.values())
+        allowed |= set(field_def.value_map.values())
+        allowed |= set(field_def.value_map.keys())
     if field_def.options:
-        return set(field_def.options)
-    return set()
+        allowed |= set(field_def.options)
+    return allowed
 
 
 def _required_fields_for(canonical: str):
@@ -765,6 +797,57 @@ def _is_metric(layer) -> bool:
     return bool(crs and crs.isValid() and not crs.isGeographic())
 
 
+def _has_ellipsoid(ctx) -> bool:
+    ellipsoid = (ctx.project.ellipsoid() or "").strip().upper()
+    return bool(ellipsoid) and ellipsoid != "NONE"
+
+
+def _measures_metres(ctx, layer) -> bool:
+    """Whether :func:`_measure_length` will return real metres for this layer.
+
+    With an ellipsoid configured, QgsDistanceArea returns metres from any CRS,
+    geographic included. Without one it falls back to planar maths, which is only
+    meaningful in a projected CRS.
+    """
+    return _has_ellipsoid(ctx) or _is_metric(layer)
+
+
+def _distance_area(ctx, layer):
+    """A QgsDistanceArea configured exactly as the plugin's own measuring code is.
+
+    This is the crux of D3: the plugin writes ``duzina_m`` with
+    ``QgsDistanceArea`` + the project ellipsoid (see dialogs/bom_dialog.py and
+    tools/pipe_tool.py), i.e. true ground metres. Comparing that against a raw
+    ``QgsGeometry.length()`` compares metres to *projected* units, and in Web
+    Mercator those differ by 1/cos(latitude) -- about 1.41x at 45 degrees, so
+    every length in a normal EPSG:3857 project looked wrong by ~41%.
+    """
+    key = f"distance_area:{layer.id()}"
+    cached = ctx.cache.get(key)
+    if cached is None:
+        from qgis.core import QgsDistanceArea
+        cached = QgsDistanceArea()
+        try:
+            cached.setSourceCrs(layer.crs(), ctx.project.transformContext())
+        except Exception as e:
+            logger.debug(f"Could not set distance-area CRS for {layer.name()}: {e}")
+        try:
+            cached.setEllipsoid(ctx.project.ellipsoid())
+        except Exception as e:
+            logger.debug(f"Could not set distance-area ellipsoid: {e}")
+        ctx.cache[key] = cached
+    return cached
+
+
+def _measure_length(ctx, layer, geom) -> float:
+    """Ground length of ``geom``, measured the same way the plugin stores it."""
+    try:
+        return float(_distance_area(ctx, layer).measureLength(geom))
+    except Exception as e:
+        logger.debug(f"Falling back to planar length on {layer.name()}: {e}")
+        return float(geom.length())
+
+
 def _disagrees(stored, computed, cfg) -> bool:
     """Whether two lengths differ by more than the configured tolerance."""
     allowed = max(cfg.length_abs_tol, abs(computed) * cfg.length_rel_tol)
@@ -785,9 +868,9 @@ def _check_length_coherence(ctx):
         for layer in ctx.layers_for(canonical):
             names = set(layer.fields().names())
 
-            if not _is_metric(layer):
-                src = ("Length checks skipped: they need a projected (metric) CRS, "
-                       "but this layer uses {crs}")
+            if not _measures_metres(ctx, layer):
+                src = ("Length checks skipped: they need either a projected CRS or "
+                       "a project ellipsoid, but this layer uses {crs} with none set")
                 yield ValidationIssue(
                     rule_id="D3", severity=Severity.INFO, category=_CAT_DOMAIN,
                     message=_safe_format(
@@ -802,7 +885,7 @@ def _check_length_coherence(ctx):
                 geom = feat.geometry()
                 if geom is None or geom.isNull() or geom.isEmpty():
                     continue  # E2's concern
-                computed = geom.length()
+                computed = _measure_length(ctx, layer, geom)
 
                 # 1. stored length vs the geometry it describes
                 if stored_field in names:
@@ -851,7 +934,13 @@ def _check_length_coherence(ctx):
                     km = _as_number(feat.attribute("duzina_km"), NULL)
                     if None not in (metres, km) and km > 0:
                         expected = metres / 1000.0
-                        allowed = max(cfg.length_abs_tol / 1000.0,
+                        # duzina_km is stored rounded (typically 2 decimals), so a
+                        # 34.5 m route legitimately reads 0.03 km. Allow half of
+                        # the stored value's own precision, otherwise every route
+                        # in a real project reports a mismatch whose two numbers
+                        # then print identically.
+                        allowed = max(_half_ulp(km),
+                                      cfg.length_abs_tol / 1000.0,
                                       abs(expected) * cfg.length_rel_tol)
                         if abs(km - expected) > allowed:
                             src = ("duzina_km ({km}) does not match duzina/1000 "
@@ -861,7 +950,7 @@ def _check_length_coherence(ctx):
                                 category=_CAT_DOMAIN,
                                 message=_safe_format(
                                     QCoreApplication.translate(_CTX, src), src,
-                                    km=_fmt(km), expected=_fmt(expected)),
+                                    km=_fmt(km, 4), expected=_fmt(expected, 4)),
                                 layer_name=layer.name(), layer_id=layer.id(),
                                 feature_id=feat.id(), fiberq_uuid=_uuid_of(feat),
                                 where=_feature_xy(feat),
@@ -882,9 +971,11 @@ def _check_crs_consistency(ctx):
             authid = (crs.authid() if crs and crs.isValid() else "") or "?"
             seen.setdefault(authid, []).append(layer.name())
 
-            if canonical in _STORED_LENGTH_FIELD and not _is_metric(layer):
-                src = ("Layer uses a geographic CRS ({crs}); length and area checks "
-                       "need a projected CRS in metres")
+            # Only a problem when nothing can measure in metres: with a project
+            # ellipsoid set, QgsDistanceArea handles a geographic CRS fine.
+            if canonical in _STORED_LENGTH_FIELD and not _measures_metres(ctx, layer):
+                src = ("Layer uses a geographic CRS ({crs}) and the project has no "
+                       "ellipsoid set, so lengths cannot be checked")
                 yield ValidationIssue(
                     rule_id="E1", severity=Severity.WARNING, category=_CAT_DOMAIN,
                     message=_safe_format(

--- a/fiberq/core/validation_rules.py
+++ b/fiberq/core/validation_rules.py
@@ -791,25 +791,15 @@ def _check_numeric_ranges(ctx):
 # D3 -- length coherence (needs a projected CRS; see E1)
 # ---------------------------------------------------------------------------
 
-def _is_metric(layer) -> bool:
-    """True when the layer's CRS measures in linear units rather than degrees."""
-    crs = layer.crs()
-    return bool(crs and crs.isValid() and not crs.isGeographic())
-
-
-def _has_ellipsoid(ctx) -> bool:
-    ellipsoid = (ctx.project.ellipsoid() or "").strip().upper()
-    return bool(ellipsoid) and ellipsoid != "NONE"
-
-
 def _measures_metres(ctx, layer) -> bool:
     """Whether :func:`_measure_length` will return real metres for this layer.
 
-    With an ellipsoid configured, QgsDistanceArea returns metres from any CRS,
-    geographic included. Without one it falls back to planar maths, which is only
-    meaningful in a projected CRS.
+    Delegates to :mod:`fiberq.utils.measure` so D3 and core.length_manager agree
+    on which layers are measurable -- if they disagreed, "recalculate" would skip
+    a layer the rule keeps reporting, or vice versa.
     """
-    return _has_ellipsoid(ctx) or _is_metric(layer)
+    from ..utils.measure import measures_metres
+    return measures_metres(layer, project=ctx.project)
 
 
 def _distance_area(ctx, layer):

--- a/fiberq/core/validation_rules.py
+++ b/fiberq/core/validation_rules.py
@@ -813,14 +813,17 @@ def _measures_metres(ctx, layer) -> bool:
 
 
 def _distance_area(ctx, layer):
-    """A QgsDistanceArea configured exactly as the plugin's own measuring code is.
+    """A QgsDistanceArea configured the way :mod:`fiberq.utils.measure` is.
 
-    This is the crux of D3: the plugin writes ``duzina_m`` with
-    ``QgsDistanceArea`` + the project ellipsoid (see dialogs/bom_dialog.py and
-    tools/pipe_tool.py), i.e. true ground metres. Comparing that against a raw
-    ``QgsGeometry.length()`` compares metres to *projected* units, and in Web
-    Mercator those differ by 1/cos(latitude) -- about 1.41x at 45 degrees, so
-    every length in a normal EPSG:3857 project looked wrong by ~41%.
+    D3 asks "is the stored length the real length?", so it has to measure the
+    real one: ground metres on the project ellipsoid, not ``QgsGeometry.length()``
+    in map units. The two differ by the local scale factor -- 1/cos(latitude) in
+    Web Mercator, about 1.41x at 45 degrees.
+
+    That distinction is the whole point of the rule. Running it on real projects
+    showed the plugin storing *both* kinds in one file: pipes measured on the
+    ellipsoid, routes and cables measured in map units, so a trench and the duct
+    inside it disagreed by 41%. See :mod:`fiberq.utils.measure`.
     """
     key = f"distance_area:{layer.id()}"
     cached = ctx.cache.get(key)

--- a/fiberq/dialogs/schematic_dialog.py
+++ b/fiberq/dialogs/schematic_dialog.py
@@ -35,6 +35,7 @@ from qgis.core import (
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -379,7 +380,7 @@ class OpticalSchematicDialog(QDialog):
             except Exception:
                 coords = []
             try:
-                length_m = float(geom.length())
+                length_m = ground_length(geom, lyr)
             except Exception:
                 length_m = 0.0
 

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -311,6 +311,126 @@ class FiberQPlugin:
             except Exception as e:
                 logger.debug(f"Could not show message bar info: {e}")
 
+    # ------------------------------------------------------------------
+    # WP2 - project validation
+    # ------------------------------------------------------------------
+
+    def _ensure_validation_panel(self):
+        """Create the results dock on first use and keep a reference to it."""
+        panel = getattr(self, '_validation_panel', None)
+        if panel is not None:
+            return panel
+
+        from qgis.PyQt.QtCore import Qt as _Qt
+        from .ui.validation_panel import ValidationPanel
+
+        panel = ValidationPanel(self.iface.mainWindow())
+        panel.rerunRequested.connect(self.run_validation)
+        panel.issueActivated.connect(self._zoom_to_issue)
+        self.iface.addDockWidget(_Qt.DockWidgetArea.RightDockWidgetArea, panel)
+        self._validation_panel = panel
+        return panel
+
+    def run_validation(self):
+        """Run the WP2 validation engine and show the results.
+
+        Deliberately thin: every rule lives in core.validation_manager /
+        validation_rules, so this only wires the engine to the UI.
+        """
+        from datetime import datetime
+
+        from . import __version__ as _plugin_version
+        from .core.validation_manager import run_validation as _run
+        from .i18n import safe_format
+
+        panel = self._ensure_validation_panel()
+        panel.set_busy(True)
+        try:
+            result = _run(
+                timestamp=datetime.now().isoformat(timespec='seconds'),
+                plugin_version=_plugin_version,
+            )
+        except Exception as e:
+            # The runner is documented never to raise; if it somehow does, say so
+            # rather than leaving the panel stuck on "Validating...".
+            logger.warning(f"Validation failed: {e}")
+            panel.set_busy(False)
+            panel.set_result(None)
+            src = 'Validation could not run: {details}'
+            self.iface.messageBar().pushWarning(
+                'FiberQ', safe_format(self.tr(src), src, details=e))
+            return
+        panel.set_busy(False)
+        panel.set_result(result)
+        panel.show()
+        panel.raise_()
+
+        counts = result.counts_by_severity()
+        summary = ', '.join([
+            self.tr('%n error(s)', '', counts['error']),
+            self.tr('%n warning(s)', '', counts['warning']),
+            self.tr('%n info', '', counts['info']),
+        ])
+        bar = self.iface.messageBar()
+        if counts['error']:
+            bar.pushWarning('FiberQ', summary)
+        elif result.issues:
+            bar.pushInfo('FiberQ', summary)
+        else:
+            bar.pushSuccess('FiberQ', self.tr('Validation found no issues.'))
+
+    def _zoom_to_issue(self, issue):
+        """Centre the canvas on an issue and mark it.
+
+        ``issue.where`` is in the *layer's* CRS, which need not be the canvas
+        CRS, so the point is transformed before use -- otherwise a project whose
+        layers differ from the canvas would jump somewhere arbitrary.
+        """
+        where = getattr(issue, 'where', None)
+        if not where:
+            # Layer-level findings (E1, a layer missing its uuid field) have no
+            # coordinate to go to.
+            self.iface.messageBar().pushInfo(
+                'FiberQ', self.tr('This issue is not tied to a map location.'))
+            return
+
+        try:
+            canvas = self.iface.mapCanvas()
+            point = QgsPointXY(float(where[0]), float(where[1]))
+
+            source = None
+            layer = QgsProject.instance().mapLayer(getattr(issue, 'layer_id', '') or '')
+            if layer is not None:
+                source = layer.crs()
+            dest = canvas.mapSettings().destinationCrs()
+            if source is not None and source.isValid() and dest.isValid() and source != dest:
+                xform = QgsCoordinateTransform(source, dest, QgsProject.instance())
+                point = xform.transform(point)
+
+            canvas.setCenter(point)
+            canvas.refresh()
+            self._mark_point(point)
+        except Exception as e:
+            logger.warning(f"Could not zoom to issue: {e}")
+
+    def _mark_point(self, point):
+        """Drop the shared locator marker on a canvas-CRS point."""
+        try:
+            self.clear_locator_marker()
+        except Exception as e:
+            logger.debug(f"Could not clear previous marker: {e}")
+        try:
+            marker = QgsVertexMarker(self.iface.mapCanvas())
+            marker.setCenter(point)
+            marker.setIconType(QgsVertexMarker.IconType.ICON_CROSS)
+            marker.setIconSize(18)
+            marker.setPenWidth(3)
+            marker.setColor(QColor(255, 0, 0))
+            marker.show()
+            self._locator_marker = marker
+        except Exception as e:
+            logger.warning(f"Could not create marker: {e}")
+
     def clear_locator_marker(self):
         if hasattr(self, "_locator_marker") and self._locator_marker:
             try:
@@ -1592,6 +1712,35 @@ class FiberQPlugin:
         except Exception as e:
             logger.debug(f"Error in FiberQPlugin.initGui: {e}")
 
+        # --- Validate project (WP2) ---
+        try:
+            #: Toolbar action running the WP2 validation engine (topology,
+            #: referential integrity, required attributes, value domains,
+            #: geometry health) and opening the results panel. Imperative verb;
+            #: this is the data-quality audit, distinct from the "Check (health
+            #: check)" action above, which only checks that layers exist.
+            self.action_validate = QAction(
+                self.tr('Validate project'), self.iface.mainWindow())
+            try:
+                self.action_validate.setIcon(_load_icon('ic_health.svg'))
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+            self.action_validate.triggered.connect(self.run_validation)
+            try:
+                self.actions.append(self.action_validate)
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+            try:
+                self.toolbar.addAction(self.action_validate)
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+            try:
+                self.iface.addPluginToMenu('FiberQ', self.action_validate)
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+        except Exception as e:
+            logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+
         # --- Reserve hook ---
         try:
             from .addons.reserve_hook import ReserveHook
@@ -2210,6 +2359,18 @@ class FiberQPlugin:
             QgsProject.instance().layersAdded.disconnect(self._on_layers_added)
         except Exception as e:
             logger.debug(f"Error in FiberQPlugin.unload: {e}")
+
+        # WP2: take the validation dock back down. It is added with
+        # iface.addDockWidget(), so it is NOT covered by the self.actions loop
+        # below and would survive a plugin reload as a dead panel.
+        try:
+            panel = getattr(self, '_validation_panel', None)
+            if panel is not None:
+                self.iface.removeDockWidget(panel)
+                panel.deleteLater()
+        except Exception as e:
+            logger.debug(f"Could not remove validation panel: {e}")
+        self._validation_panel = None
 
         # Auto-cleanup for save_gpkg action (safety)
         try:

--- a/fiberq/main_plugin.py
+++ b/fiberq/main_plugin.py
@@ -379,6 +379,82 @@ class FiberQPlugin:
         else:
             bar.pushSuccess('FiberQ', self.tr('Validation found no issues.'))
 
+    def recalculate_lengths(self):
+        """Rewrite stored lengths that disagree with their geometry.
+
+        Shows the user what is about to change before writing anything: this
+        touches their data, and the numbers it replaces may have been in the
+        project for years. Re-runs validation afterwards so the D3 findings it
+        was invoked to clear visibly disappear.
+        """
+        from qgis.PyQt.QtWidgets import QMessageBox
+
+        from .core.length_manager import apply_recalculation, plan_recalculation
+        from .i18n import safe_format
+
+        bar = self.iface.messageBar()
+        try:
+            plan = plan_recalculation()
+        except Exception as e:
+            logger.warning(f"Length recalculation could not be planned: {e}")
+            src = 'Could not check lengths: {details}'
+            bar.pushWarning('FiberQ', safe_format(self.tr(src), src, details=e))
+            return
+
+        if plan.skipped_layers:
+            src = 'Skipped {layers}: lengths cannot be measured without a projected CRS or a project ellipsoid'
+            bar.pushInfo('FiberQ', safe_format(
+                self.tr(src), src, layers=', '.join(sorted(set(plan.skipped_layers)))))
+
+        if not plan:
+            bar.pushSuccess('FiberQ', self.tr('All stored lengths already match the geometry.'))
+            return
+
+        lines = [
+            self.tr('%n feature(s) will have their stored length rewritten '
+                    'from the drawn geometry.', '', plan.feature_count),
+            '',
+        ]
+        for layer_name, count in sorted(plan.counts_by_layer().items()):
+            lines.append(f'  {layer_name}: {count}')
+
+        biggest = plan.largest_change()
+        if biggest is not None:
+            src = 'Largest change: {field} {old} -> {new} on {layer}'
+            lines += ['', safe_format(
+                self.tr(src), src, field=biggest.field_name,
+                old=f'{biggest.old_value:.2f}', new=f'{biggest.new_value:.2f}',
+                layer=biggest.layer_name)]
+
+        confirm = QMessageBox(self.iface.mainWindow())
+        confirm.setIcon(QMessageBox.Icon.Question)
+        confirm.setWindowTitle(self.tr('Recalculate lengths'))
+        confirm.setText(self.tr('Recalculate stored lengths?'))
+        confirm.setInformativeText('\n'.join(lines))
+        confirm.setDetailedText(self.tr(
+            'Lengths are measured on the project ellipsoid, the same way the '
+            'QGIS measure tool does. Slack values are read but never changed.'))
+        confirm.setStandardButtons(
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel)
+        confirm.setDefaultButton(QMessageBox.StandardButton.Cancel)
+        if confirm.exec() != QMessageBox.StandardButton.Yes:
+            return
+
+        outcome = apply_recalculation(plan)
+
+        if outcome.applied:
+            src = 'Recalculated lengths on {count} feature(s).'
+            bar.pushSuccess('FiberQ', safe_format(
+                self.tr(src), src, count=outcome.feature_count))
+        if outcome.failures:
+            src = 'Some layers could not be updated: {details}'
+            bar.pushWarning('FiberQ', safe_format(
+                self.tr(src), src, details='; '.join(outcome.failures[:3])))
+
+        # Re-run only if the panel is already open; do not open it unbidden.
+        if getattr(self, '_validation_panel', None) is not None:
+            self.run_validation()
+
     def _zoom_to_issue(self, issue):
         """Centre the canvas on an issue and mark it.
 
@@ -1736,6 +1812,27 @@ class FiberQPlugin:
                 logger.debug(f"Error in FiberQPlugin.initGui: {e}")
             try:
                 self.iface.addPluginToMenu('FiberQ', self.action_validate)
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+        except Exception as e:
+            logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+
+        # --- Recalculate lengths (WP2 companion to the D3 rule) ---
+        try:
+            #: Menu-only on purpose: this rewrites the user's attributes, so it
+            #: should be a deliberate trip to the menu rather than a click away
+            #: on an already-crowded toolbar.
+            self.action_recalc_lengths = QAction(
+                self.tr('Recalculate lengths…'), self.iface.mainWindow())
+            self.action_recalc_lengths.setToolTip(self.tr(
+                'Rewrite stored lengths that disagree with the drawn geometry'))
+            self.action_recalc_lengths.triggered.connect(self.recalculate_lengths)
+            try:
+                self.actions.append(self.action_recalc_lengths)
+            except Exception as e:
+                logger.debug(f"Error in FiberQPlugin.initGui: {e}")
+            try:
+                self.iface.addPluginToMenu('FiberQ', self.action_recalc_lengths)
             except Exception as e:
                 logger.debug(f"Error in FiberQPlugin.initGui: {e}")
         except Exception as e:

--- a/fiberq/tools/branch_tool.py
+++ b/fiberq/tools/branch_tool.py
@@ -14,6 +14,7 @@ from qgis.gui import QgsMapToolIdentify
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -79,7 +80,8 @@ class BranchInfoTool(QgsMapToolIdentify):
         total_len = 0.0
         by_type = Counter()
 
-        for f in feats:
+        for hit in cable_hits:
+            f = hit.mFeature
             tip = self._attr(f, ["tip", "Tip", "TIP"], "n/a")
             br_c = self._attr(f, ["broj_cevcica", "cevi"], "")  # noqa: F841
             br_v = self._attr(f, ["broj_vlakana", "vlakna"], "")
@@ -90,7 +92,7 @@ class BranchInfoTool(QgsMapToolIdentify):
             try:
                 geom = f.geometry()
                 if geom:
-                    total_len += float(geom.length())
+                    total_len += ground_length(geom, hit.mLayer)
             except Exception as e:
                 logger.debug(f"Error in BranchInfoTool.canvasReleaseEvent: {e}")
 

--- a/fiberq/tools/breakpoint_tool.py
+++ b/fiberq/tools/breakpoint_tool.py
@@ -13,6 +13,7 @@ from .base import (
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -194,7 +195,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         feat1.setGeometry(geom1)
         feat1.setAttribute('naziv', naziv + "_a")
         feat1.setAttribute('tip_trase', tip_trase)
-        duzina_m1 = geom1.length()
+        duzina_m1 = ground_length(geom1, route_layer)
         feat1.setAttribute('duzina', duzina_m1)
         feat1.setAttribute('duzina_km', round(duzina_m1 / 1000.0, 2))
 
@@ -203,7 +204,7 @@ class BreakpointTool(QgsMapToolEmitPoint):
         feat2.setGeometry(geom2)
         feat2.setAttribute('naziv', naziv + "_b")
         feat2.setAttribute('tip_trase', tip_trase)
-        duzina_m2 = geom2.length()
+        duzina_m2 = ground_length(geom2, route_layer)
         feat2.setAttribute('duzina', duzina_m2)
         feat2.setAttribute('duzina_km', round(duzina_m2 / 1000.0, 2))
 

--- a/fiberq/tools/pipe_tool.py
+++ b/fiberq/tools/pipe_tool.py
@@ -13,13 +13,9 @@ from .base import (
     QgsMapTool, QgsVertexMarker
 )
 
-try:
-    from qgis.core import QgsDistanceArea
-except ImportError:
-    QgsDistanceArea = None
-
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -307,30 +303,10 @@ class PipePlaceTool(QgsMapTool):
         except Exception:
             f['fi'] = None
 
-        # Calculate length
-        try:
-            if QgsDistanceArea is not None:
-                d = QgsDistanceArea()
-                try:
-                    d.setSourceCrs(layer.crs(), QgsProject.instance().transformContext())
-                except Exception:
-                    try:
-                        d.setSourceCrs(
-                            self.iface.mapCanvas().mapSettings().destinationCrs(),
-                            QgsProject.instance().transformContext()
-                        )
-                    except Exception as e:
-                        logger.debug(f"Error in PipePlaceTool._finish: {e}")
-                d.setEllipsoid(QgsProject.instance().ellipsoid())
-                length_m = d.measureLength(geom) if geom is not None else 0.0
-            else:
-                length_m = geom.length() if geom is not None else 0.0
-            f['duzina_m'] = float(length_m) if length_m else 0.0
-        except Exception:
-            try:
-                f['duzina_m'] = float(geom.length()) if geom is not None else None
-            except Exception:
-                f['duzina_m'] = None
+        # Calculate length. This tool measured on the ellipsoid before the shared
+        # helper existed, which is why pipes were right while routes and cables
+        # were 41% long in the same project (see fiberq/utils/measure.py).
+        f['duzina_m'] = ground_length(geom, layer)
 
         # Find FROM/TO names
         node_names = {"Poles", "Stubovi", "OKNA", "Manholes"}

--- a/fiberq/tools/route_tool.py
+++ b/fiberq/tools/route_tool.py
@@ -14,6 +14,7 @@ from .base import (
 
 # Phase 5.2: Logging
 from ..utils.logger import get_logger
+from ..utils.measure import ground_length
 logger = get_logger(__name__)
 
 
@@ -257,7 +258,7 @@ class ManualRouteTool(QgsMapTool):
 
         # Create geometry
         line_geom = QgsGeometry.fromPolylineXY(self.points)
-        duzina_m = line_geom.length()
+        duzina_m = ground_length(line_geom, route_layer)
         duzina_km = round(duzina_m / 1000.0, 2)
 
         # Get route type options

--- a/fiberq/ui/validation_panel.py
+++ b/fiberq/ui/validation_panel.py
@@ -1,0 +1,291 @@
+"""FiberQ validation results panel (WP2, task 2.1 - UI).
+
+A dockable list of :class:`~fiberq.core.validation_manager.ValidationIssue`, with
+severity/layer/rule filters, live counts, a Re-run button and click-to-zoom.
+
+This is the first QDockWidget in the plugin, so it sets the pattern: the widget
+owns no validation logic and never touches QgsProject. It renders a
+``ValidationResult`` and emits signals; the plugin decides what running and
+zooming actually mean. That keeps the panel constructible (and testable) without
+a live project.
+
+i18n: ``tr()`` below must keep the context string equal to the class name --
+pylupdate6 derives the catalogue context from the enclosing class, so renaming
+the class without renaming the context silently reverts every string to English.
+"""
+from qgis.PyQt.QtCore import QCoreApplication, Qt, pyqtSignal
+from qgis.PyQt.QtGui import QBrush, QColor
+from qgis.PyQt.QtWidgets import (
+    QComboBox,
+    QDockWidget,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..core.validation_manager import SEVERITY_ORDER, Severity
+from ..i18n import safe_format
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: Foreground colours per severity. Chosen to stay legible on both the light and
+#: dark QGIS themes (mid-tones rather than saturated primaries).
+_SEVERITY_COLOUR = {
+    Severity.ERROR: QColor(200, 60, 60),
+    Severity.WARNING: QColor(200, 140, 30),
+    Severity.INFO: QColor(90, 140, 200),
+}
+
+_ALL = "__all__"  # sentinel stored as combo item data; never displayed
+
+#: Item data roles for values that must sort differently from how they display.
+_ROLE_ISSUE = Qt.ItemDataRole.UserRole
+_ROLE_RANK = Qt.ItemDataRole.UserRole + 1
+
+
+class _IssueItem(QTreeWidgetItem):
+    """A row that sorts on meaning rather than on displayed text.
+
+    Column 0 shows a translated severity label, so the default string sort would
+    order Error/Warning/Info differently in every language; it sorts on the
+    numeric severity rank instead. Column 3 holds a feature id, where a string
+    sort puts "10" before "9".
+    """
+
+    def __lt__(self, other):
+        tree = self.treeWidget()
+        column = tree.sortColumn() if tree is not None else 0
+        if column == 0:
+            mine = self.data(0, _ROLE_RANK)
+            theirs = other.data(0, _ROLE_RANK)
+            if mine is not None and theirs is not None:
+                return mine < theirs
+        if column == 3:
+            try:
+                return int(self.text(3) or -1) < int(other.text(3) or -1)
+            except (TypeError, ValueError):
+                pass
+        return super().__lt__(other)
+
+
+class ValidationPanel(QDockWidget):
+    """Dockable results list for a validation run."""
+
+    #: The user asked for the validation to run again.
+    rerunRequested = pyqtSignal()
+    #: The user activated an issue (wants the map to go there). Carries the
+    #: ValidationIssue; typed as ``object`` because it is a plain dataclass.
+    issueActivated = pyqtSignal(object)
+    #: The user asked to export the current result.
+    exportRequested = pyqtSignal()
+
+    def tr(self, message, disambiguation=None, n=-1):
+        """Context must stay equal to the class name (pylupdate6 keys on it)."""
+        return QCoreApplication.translate(
+            'ValidationPanel', message, disambiguation, n)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName('FiberQValidationPanel')
+        self.setWindowTitle(self.tr('FiberQ validation'))
+
+        self._issues = []
+        self._result = None
+
+        body = QWidget(self)
+        outer = QVBoxLayout(body)
+        outer.setContentsMargins(6, 6, 6, 6)
+        outer.setSpacing(6)
+
+        # --- summary + actions -------------------------------------------------
+        top = QHBoxLayout()
+        self.lbl_summary = QLabel(self.tr('No validation run yet.'), body)
+        self.lbl_summary.setWordWrap(True)
+        top.addWidget(self.lbl_summary, 1)
+
+        self.btn_rerun = QPushButton(self.tr('Re-run'), body)
+        self.btn_rerun.setToolTip(self.tr('Validate the project again'))
+        self.btn_rerun.clicked.connect(self.rerunRequested)
+        top.addWidget(self.btn_rerun, 0)
+
+        self.btn_export = QPushButton(self.tr('Export report…'), body)
+        self.btn_export.setToolTip(self.tr('Save the results as a report'))
+        self.btn_export.clicked.connect(self.exportRequested)
+        self.btn_export.setEnabled(False)
+        top.addWidget(self.btn_export, 0)
+        outer.addLayout(top)
+
+        # --- filters -----------------------------------------------------------
+        filters = QHBoxLayout()
+        filters.addWidget(QLabel(self.tr('Severity:'), body), 0)
+        self.cb_severity = QComboBox(body)
+        filters.addWidget(self.cb_severity, 0)
+
+        filters.addWidget(QLabel(self.tr('Layer:'), body), 0)
+        self.cb_layer = QComboBox(body)
+        filters.addWidget(self.cb_layer, 1)
+
+        filters.addWidget(QLabel(self.tr('Rule:'), body), 0)
+        self.cb_rule = QComboBox(body)
+        filters.addWidget(self.cb_rule, 0)
+        filters.addStretch(1)
+        outer.addLayout(filters)
+
+        for combo in (self.cb_severity, self.cb_layer, self.cb_rule):
+            combo.currentIndexChanged.connect(self._apply_filters)
+
+        # --- issue list --------------------------------------------------------
+        self.tree = QTreeWidget(body)
+        self.tree.setColumnCount(5)
+        self.tree.setHeaderLabels([
+            self.tr('Severity'),
+            self.tr('Rule'),
+            self.tr('Layer'),
+            self.tr('Feature'),
+            self.tr('Message'),
+        ])
+        self.tree.setRootIsDecorated(False)
+        self.tree.setAlternatingRowColors(True)
+        self.tree.setSortingEnabled(True)
+        self.tree.setSelectionBehavior(
+            QTreeWidget.SelectionBehavior.SelectRows)
+        header = self.tree.header()
+        header.setStretchLastSection(True)
+        for col in range(4):
+            header.setSectionResizeMode(
+                col, QHeaderView.ResizeMode.ResizeToContents)
+        self.tree.itemActivated.connect(self._on_item_activated)
+        self.tree.itemDoubleClicked.connect(self._on_item_activated)
+        outer.addWidget(self.tree, 1)
+
+        self.setWidget(body)
+        self._reset_filters()
+
+    # -- public API ---------------------------------------------------------
+
+    def set_result(self, result):
+        """Render a :class:`ValidationResult` (or ``None`` to clear)."""
+        self._result = result
+        self._issues = list(result.sorted_issues()) if result else []
+        self.btn_export.setEnabled(bool(result))
+        self._reset_filters()
+        self._populate()
+        self._update_summary()
+
+    def set_busy(self, busy: bool):
+        """Disable the controls while a run is in flight."""
+        self.btn_rerun.setEnabled(not busy)
+        if busy:
+            self.lbl_summary.setText(self.tr('Validating…'))
+
+    # -- internals ----------------------------------------------------------
+
+    def _severity_label(self, severity) -> str:
+        if severity == Severity.ERROR:
+            return self.tr('Error')
+        if severity == Severity.WARNING:
+            return self.tr('Warning')
+        return self.tr('Info')
+
+    def _reset_filters(self):
+        """Rebuild the filter combos from the current issue set."""
+        for combo in (self.cb_severity, self.cb_layer, self.cb_rule):
+            combo.blockSignals(True)
+            combo.clear()
+
+        self.cb_severity.addItem(self.tr('All'), _ALL)
+        for severity in sorted(_SEVERITY_COLOUR, key=lambda s: SEVERITY_ORDER[s]):
+            self.cb_severity.addItem(self._severity_label(severity), severity.value)
+
+        self.cb_layer.addItem(self.tr('All'), _ALL)
+        for name in sorted({i.layer_name for i in self._issues if i.layer_name}):
+            self.cb_layer.addItem(name, name)
+
+        self.cb_rule.addItem(self.tr('All'), _ALL)
+        for rule_id in sorted({i.rule_id for i in self._issues}):
+            self.cb_rule.addItem(rule_id, rule_id)
+
+        for combo in (self.cb_severity, self.cb_layer, self.cb_rule):
+            combo.blockSignals(False)
+
+    def _populate(self):
+        self.tree.setSortingEnabled(False)
+        self.tree.clear()
+        for issue in self._issues:
+            item = _IssueItem([
+                self._severity_label(issue.severity),
+                issue.rule_id,
+                issue.layer_name,
+                str(issue.feature_id) if issue.feature_id >= 0 else '',
+                issue.message,
+            ])
+            colour = _SEVERITY_COLOUR.get(issue.severity)
+            if colour is not None:
+                item.setForeground(0, QBrush(colour))
+            item.setData(0, _ROLE_RANK, SEVERITY_ORDER.get(issue.severity, 9))
+            item.setData(0, _ROLE_ISSUE, issue)
+            if issue.fix_hint:
+                item.setToolTip(4, issue.fix_hint)
+            self.tree.addTopLevelItem(item)
+        # Sort by severity rank ascending, i.e. errors first, before handing
+        # sorting back to the user.
+        self.tree.sortByColumn(0, Qt.SortOrder.AscendingOrder)
+        self.tree.setSortingEnabled(True)
+        self._apply_filters()
+
+    def _apply_filters(self):
+        severity = self.cb_severity.currentData()
+        layer = self.cb_layer.currentData()
+        rule = self.cb_rule.currentData()
+
+        shown = 0
+        for index in range(self.tree.topLevelItemCount()):
+            item = self.tree.topLevelItem(index)
+            issue = item.data(0, _ROLE_ISSUE)
+            if issue is None:
+                continue
+            visible = (
+                (severity in (None, _ALL) or issue.severity.value == severity)
+                and (layer in (None, _ALL) or issue.layer_name == layer)  # noqa: W503
+                and (rule in (None, _ALL) or issue.rule_id == rule)  # noqa: W503
+            )
+            item.setHidden(not visible)
+            shown += 1 if visible else 0
+        self._update_summary(shown)
+
+    def _update_summary(self, shown=None):
+        if self._result is None:
+            self.lbl_summary.setText(self.tr('No validation run yet.'))
+            return
+
+        counts = self._result.counts_by_severity()
+        if not self._issues:
+            self.lbl_summary.setText(self.tr('No issues found.'))
+            return
+
+        # %n plurals: Qt picks the right form per language from the count.
+        parts = [
+            self.tr('%n error(s)', '', counts['error']),
+            self.tr('%n warning(s)', '', counts['warning']),
+            self.tr('%n info', '', counts['info']),
+        ]
+        text = ', '.join(parts)
+        if shown is not None and shown != len(self._issues):
+            src = '{summary} — showing {shown} of {total}'
+            text = safe_format(self.tr(src), src,
+                               summary=text, shown=shown, total=len(self._issues))
+        if self._result.rule_errors:
+            text += '\n' + self.tr('%n rule(s) failed to run',
+                                   '', len(self._result.rule_errors))
+        self.lbl_summary.setText(text)
+
+    def _on_item_activated(self, item, _column=0):
+        issue = item.data(0, _ROLE_ISSUE) if item else None
+        if issue is not None:
+            self.issueActivated.emit(issue)

--- a/fiberq/utils/geometry.py
+++ b/fiberq/utils/geometry.py
@@ -407,6 +407,10 @@ def calculate_geometry_length(geom: QgsGeometry) -> float:
     """
     Calculate the length of a geometry in map units.
 
+    Map units are not metres in a projected CRS: Web Mercator inflates distance
+    by 1/cos(latitude). For anything stored in a field or shown to the user, use
+    :func:`fiberq.utils.measure.ground_length` instead.
+
     Args:
         geom: Geometry (typically line)
 

--- a/fiberq/utils/measure.py
+++ b/fiberq/utils/measure.py
@@ -1,0 +1,97 @@
+"""Ground-truth length measurement.
+
+Every length the plugin stores or shows to the user is a **real-world** distance:
+metres of cable to buy, metres of trench to dig. ``QgsGeometry.length()`` does not
+give that -- it returns the length in the layer's *map* units, which in a
+conformal projection is the ground length multiplied by the local scale factor.
+
+In Web Mercator (EPSG:3857), by far the most common working CRS because it is what
+the web basemaps use, that factor is ``1 / cos(latitude)``. It is 1.00 on the
+equator, 1.41 in Serbia, 1.55 in the Netherlands and 1.86 in Finland. A cable
+digitised over a 276 m street in Niš therefore stores as 389 m, and the bill of
+materials over-orders by 41%.
+
+So: never call ``geom.length()`` on a value that reaches a field or a user. Call
+:func:`ground_length`, which measures on the project ellipsoid the way the QGIS
+measure tool does, and agrees with what a surveyor would find on site.
+"""
+from qgis.core import QgsDistanceArea, QgsProject
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+#: QgsDistanceArea is not free to build, and these calls happen per feature during
+#: route import. Keyed on (CRS, ellipsoid) so it re-derives if either changes.
+_CACHE = {}
+
+
+def _project(project=None):
+    return project if project is not None else QgsProject.instance()
+
+
+def distance_area(crs=None, project=None):
+    """A :class:`QgsDistanceArea` configured from the project's measurement settings."""
+    prj = _project(project)
+    if crs is None or not crs.isValid():
+        crs = prj.crs()
+    ellipsoid = prj.ellipsoid() or ""
+    key = (crs.authid() or crs.toWkt(), ellipsoid)
+
+    cached = _CACHE.get(key)
+    if cached is None:
+        cached = QgsDistanceArea()
+        try:
+            cached.setSourceCrs(crs, prj.transformContext())
+        except Exception as e:
+            logger.debug(f"Could not set measurement CRS to {key[0]}: {e}")
+        try:
+            cached.setEllipsoid(ellipsoid)
+        except Exception as e:
+            logger.debug(f"Could not set measurement ellipsoid to {ellipsoid}: {e}")
+        _CACHE[key] = cached
+    return cached
+
+
+def ground_length(geom, layer=None, crs=None, project=None) -> float:
+    """Length of ``geom`` in metres on the ground.
+
+    Pass the ``layer`` the geometry belongs to (or its ``crs``) so the measurement
+    starts from the right coordinate system; without either, the project CRS is
+    assumed, which is right for anything drawn on the canvas.
+
+    Falls back to the planar length rather than raising -- a slightly wrong number
+    beats losing the attribute -- and says so in the log.
+    """
+    if geom is None:
+        return 0.0
+    try:
+        if geom.isEmpty():
+            return 0.0
+    except Exception:
+        return 0.0
+
+    if crs is None and layer is not None:
+        try:
+            crs = layer.crs()
+        except Exception:
+            crs = None
+
+    try:
+        return float(distance_area(crs, project).measureLength(geom))
+    except Exception as e:
+        logger.debug(f"Ellipsoidal measurement failed, using planar length: {e}")
+        try:
+            return float(geom.length())
+        except Exception:
+            return 0.0
+
+
+def ground_length_km(geom, layer=None, crs=None, project=None, places: int = 2) -> float:
+    """:func:`ground_length` in kilometres, rounded the way the layers store it."""
+    return round(ground_length(geom, layer, crs, project) / 1000.0, places)
+
+
+def clear_cache():
+    """Drop the cached measurers (call if the project's ellipsoid changes)."""
+    _CACHE.clear()

--- a/fiberq/utils/measure.py
+++ b/fiberq/utils/measure.py
@@ -53,6 +53,31 @@ def distance_area(crs=None, project=None):
     return cached
 
 
+def has_ellipsoid(project=None) -> bool:
+    """Whether the project has measurement on an ellipsoid switched on."""
+    ellipsoid = (_project(project).ellipsoid() or "").strip().upper()
+    return bool(ellipsoid) and ellipsoid != "NONE"
+
+
+def measures_metres(layer=None, crs=None, project=None) -> bool:
+    """Whether :func:`ground_length` will return metres rather than degrees.
+
+    With an ellipsoid configured, QgsDistanceArea returns metres from any CRS,
+    geographic included. Without one it falls back to planar maths, which is only
+    meaningful where the CRS itself is linear.
+    """
+    if has_ellipsoid(project):
+        return True
+    if crs is None and layer is not None:
+        try:
+            crs = layer.crs()
+        except Exception:
+            crs = None
+    if crs is None:
+        crs = _project(project).crs()
+    return bool(crs and crs.isValid() and not crs.isGeographic())
+
+
 def ground_length(geom, layer=None, crs=None, project=None) -> float:
     """Length of ``geom`` in metres on the ground.
 

--- a/tests/test_length_recalc.py
+++ b/tests/test_length_recalc.py
@@ -1,0 +1,342 @@
+"""Tests for core.length_manager -- rewriting stored lengths from geometry.
+
+The contract that matters most is the one with D3: recalculate then validate must
+leave nothing behind. Several tests below assert exactly that round trip rather
+than just checking the arithmetic, because a tolerance drift between the rule and
+the fix would be invisible to a unit test of either one alone.
+"""
+import ast
+import inspect
+import math
+import textwrap
+
+import pytest
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsCoordinateTransformContext,
+    QgsFeature,
+    QgsField,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProject,
+    QgsVectorLayer,
+)
+from qgis.PyQt.QtCore import QVariant
+
+from fiberq.core import validation_rules as vr
+from fiberq.core.length_manager import (
+    apply_recalculation,
+    plan_recalculation,
+    recalculate_lengths,
+)
+from fiberq.core.validation_manager import ValidationConfig, ValidationContext
+from fiberq.utils.measure import clear_cache, ground_length
+
+LAT, LON = 43.32, 21.90
+SCALE = 1.0 / math.cos(math.radians(LAT))
+
+
+@pytest.fixture
+def project():
+    prj = QgsProject()
+    prj.setCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+    prj.setEllipsoid("EPSG:7030")
+    clear_cache()
+    yield prj
+    clear_cache()
+
+
+def _line(length_map_units=1000.0):
+    xform = QgsCoordinateTransform(
+        QgsCoordinateReferenceSystem("EPSG:4326"),
+        QgsCoordinateReferenceSystem("EPSG:3857"),
+        QgsCoordinateTransformContext())
+    start = xform.transform(QgsPointXY(LON, LAT))
+    return QgsGeometry.fromPolylineXY(
+        [start, QgsPointXY(start.x() + length_map_units, start.y())])
+
+
+def _layer(project, name, fields, rows, crs="EPSG:3857"):
+    """A FiberQ line layer whose canonical name resolves, with `rows` features.
+
+    `rows` is a list of (geometry, {field: value}).
+    """
+    layer = QgsVectorLayer(f"LineString?crs={crs}", name, "memory")
+    assert layer.isValid()
+    layer.dataProvider().addAttributes(
+        [QgsField(f, QVariant.Double) for f in fields])
+    layer.updateFields()
+
+    feats = []
+    for geom, attrs in rows:
+        feat = QgsFeature(layer.fields())
+        feat.setGeometry(geom)
+        for key, value in attrs.items():
+            feat.setAttribute(key, value)
+        feats.append(feat)
+    layer.dataProvider().addFeatures(feats)
+    layer.updateExtents()
+    project.addMapLayer(layer)
+    return layer
+
+
+def _route(project, rows):
+    return _layer(project, "Route", ["duzina", "duzina_km"], rows)
+
+
+def _cables(project, rows):
+    return _layer(project, "Aerial cables",
+                  ["duzina_m", "slack_m", "total_len_m"], rows)
+
+
+def _d3_messages(project):
+    ctx = ValidationContext(project, ValidationConfig())
+    return list(vr._check_length_coherence(ctx))
+
+
+# ---------------------------------------------------------------------------
+# Planning
+# ---------------------------------------------------------------------------
+
+def test_plan_finds_a_planar_length_and_proposes_the_ground_one(project):
+    geom = _line()
+    _route(project, [(geom, {"duzina": geom.length()})])  # the old, wrong value
+
+    plan = plan_recalculation(project)
+
+    change = next(c for c in plan.changes if c.field_name == "duzina")
+    assert change.old_value == pytest.approx(geom.length())
+    assert change.new_value == pytest.approx(ground_length(geom, project=project))
+    assert change.ratio == pytest.approx(SCALE, rel=0.01)
+
+
+def test_plan_writes_nothing(project):
+    geom = _line()
+    layer = _route(project, [(geom, {"duzina": geom.length()})])
+
+    plan_recalculation(project)
+
+    assert next(layer.getFeatures()).attribute("duzina") == pytest.approx(geom.length())
+    assert not layer.isEditable()
+
+
+def test_correct_lengths_produce_an_empty_plan(project):
+    geom = _line()
+    correct = ground_length(geom, project=project)
+    _route(project, [(geom, {"duzina": correct,
+                             "duzina_km": round(correct / 1000.0, 2)})])
+
+    plan = plan_recalculation(project)
+
+    assert not plan
+    assert plan.layers_seen  # it did look, it just found nothing
+
+
+def test_plan_counts_features_not_attributes(project):
+    """One feature with a wrong metre AND a wrong km value is still one feature."""
+    geom = _line()
+    _route(project, [(geom, {"duzina": geom.length(), "duzina_km": 99.0})])
+
+    plan = plan_recalculation(project)
+
+    assert len(plan.changes) == 2
+    assert plan.feature_count == 1
+
+
+def test_null_stored_length_is_treated_as_needing_a_value(project):
+    _route(project, [(_line(), {})])
+    assert any(c.field_name == "duzina" for c in plan_recalculation(project).changes)
+
+
+def test_empty_geometry_is_left_alone(project):
+    """E2 reports the broken geometry; there is nothing to measure here."""
+    _route(project, [(QgsGeometry(), {"duzina": 123.0})])
+    assert not plan_recalculation(project).changes
+
+
+def test_unmeasurable_layer_is_skipped_not_guessed(project):
+    """Degrees must never be written into a metre field."""
+    project.setEllipsoid("NONE")
+    clear_cache()
+    geom = QgsGeometry.fromPolylineXY(
+        [QgsPointXY(LON, LAT), QgsPointXY(LON + 0.01, LAT)])
+    _layer(project, "Route", ["duzina", "duzina_km"],
+           [(geom, {"duzina": 810.0})], crs="EPSG:4326")
+
+    plan = plan_recalculation(project)
+
+    assert plan.skipped_layers == ["Route"]
+    assert not plan.changes
+
+
+def test_largest_change_is_reported_for_the_preview(project):
+    _route(project, [
+        (_line(100.0), {"duzina": 100.0}),
+        (_line(5000.0), {"duzina": 5000.0}),
+    ])
+    biggest = plan_recalculation(project).largest_change()
+    assert biggest.old_value == pytest.approx(5000.0, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Derived fields
+# ---------------------------------------------------------------------------
+
+def test_km_field_follows_the_metre_field(project):
+    geom = _line()
+    layer = _route(project, [(geom, {"duzina": geom.length(), "duzina_km": 1.0})])
+
+    recalculate_lengths(project)
+
+    feat = next(layer.getFeatures())
+    assert feat.attribute("duzina_km") == pytest.approx(
+        round(feat.attribute("duzina") / 1000.0, 2))
+
+
+def test_total_length_is_laid_length_plus_slack(project):
+    geom = _line()
+    layer = _cables(project, [(geom, {"duzina_m": geom.length(),
+                                      "slack_m": 20.0,
+                                      "total_len_m": geom.length() + 20.0})])
+
+    recalculate_lengths(project)
+
+    feat = next(layer.getFeatures())
+    assert feat.attribute("total_len_m") == pytest.approx(
+        feat.attribute("duzina_m") + 20.0)
+
+
+def test_slack_is_never_rewritten(project):
+    """Slack is a design decision, not something measurable from geometry."""
+    geom = _line()
+    layer = _cables(project, [(geom, {"duzina_m": geom.length(),
+                                      "slack_m": 20.0,
+                                      "total_len_m": 0.0})])
+
+    plan = plan_recalculation(project)
+    assert not any(c.field_name == "slack_m" for c in plan.changes)
+
+    apply_recalculation(plan, project)
+    assert next(layer.getFeatures()).attribute("slack_m") == pytest.approx(20.0)
+
+
+# ---------------------------------------------------------------------------
+# Applying
+# ---------------------------------------------------------------------------
+
+def test_apply_commits_the_new_values(project):
+    geom = _line()
+    layer = _route(project, [(geom, {"duzina": geom.length()})])
+
+    outcome = apply_recalculation(plan_recalculation(project), project)
+
+    assert not outcome.failures
+    assert outcome.feature_count == 1
+    stored = next(layer.getFeatures()).attribute("duzina")
+    assert stored == pytest.approx(ground_length(geom, layer, project=project))
+    assert not layer.isEditable()  # committed, not left open
+
+
+def test_apply_leaves_no_edit_session_open_on_an_empty_plan(project):
+    layer = _route(project, [(_line(), {"duzina": 0.0})])
+    layer.rollBack()
+    apply_recalculation(plan_recalculation(project), project)
+    assert not layer.isEditable()
+
+
+def test_a_missing_layer_is_a_failure_not_a_crash(project):
+    geom = _line()
+    layer = _route(project, [(geom, {"duzina": geom.length()})])
+    plan = plan_recalculation(project)
+    project.removeMapLayer(layer.id())
+
+    outcome = apply_recalculation(plan, project)
+
+    assert outcome.failures
+    assert not outcome.applied
+
+
+# ---------------------------------------------------------------------------
+# The contract with D3
+# ---------------------------------------------------------------------------
+
+def test_recalculating_clears_every_d3_finding(project):
+    """The whole point: run this, and the rule that prompted it goes quiet."""
+    geom = _line()
+    _route(project, [(geom, {"duzina": geom.length(), "duzina_km": 9.9})])
+    _cables(project, [(geom, {"duzina_m": geom.length(),
+                              "slack_m": 10.0,
+                              "total_len_m": 1.0})])
+    assert _d3_messages(project), "fixture must actually be broken first"
+
+    recalculate_lengths(project)
+
+    assert _d3_messages(project) == []
+
+
+def test_recalculation_is_idempotent(project):
+    geom = _line()
+    layer = _route(project, [(geom, {"duzina": geom.length()})])
+
+    recalculate_lengths(project)
+    first = next(layer.getFeatures()).attribute("duzina")
+    second_run = recalculate_lengths(project)
+
+    assert not second_run.applied  # nothing left to do
+    assert next(layer.getFeatures()).attribute("duzina") == pytest.approx(first)
+
+
+def test_the_fix_and_the_rule_share_one_tolerance(project):
+    """A drift between them would leave findings that recalculating cannot clear."""
+    from fiberq.core import length_manager as lm
+
+    assert lm.STORED_LENGTH_FIELD == vr._STORED_LENGTH_FIELD
+    assert "config.length_abs_tol" in inspect.getsource(lm._disagrees)
+    assert "config.length_rel_tol" in inspect.getsource(lm._disagrees)
+
+
+# ---------------------------------------------------------------------------
+# Plugin wiring (FiberQPlugin needs a live iface to instantiate)
+# ---------------------------------------------------------------------------
+
+def _called_names(func):
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            target = node.func
+            if isinstance(target, ast.Attribute):
+                names.add(target.attr)
+            elif isinstance(target, ast.Name):
+                names.add(target.id)
+    return names
+
+
+def test_plugin_exposes_the_action(qgis_app):
+    import fiberq.main_plugin as mp
+    assert callable(getattr(mp.FiberQPlugin, "recalculate_lengths", None))
+
+
+def test_the_user_is_asked_before_their_data_changes(qgis_app):
+    """This rewrites attributes that may have been in the project for years."""
+    import fiberq.main_plugin as mp
+
+    called = _called_names(mp.FiberQPlugin.recalculate_lengths)
+    assert "plan_recalculation" in called
+    assert "apply_recalculation" in called
+    assert "exec" in called  # the confirmation dialog
+
+    src = inspect.getsource(mp.FiberQPlugin.recalculate_lengths)
+    assert src.index("plan_recalculation(") < src.index("QMessageBox(")
+    assert src.index("QMessageBox(") < src.index("apply_recalculation(")
+
+
+def test_action_is_registered_for_cleanup(qgis_app):
+    import fiberq.main_plugin as mp
+
+    src = inspect.getsource(mp.FiberQPlugin.initGui)
+    assert "self.actions.append(self.action_recalc_lengths)" in src
+    assert "self.action_recalc_lengths.triggered.connect(self.recalculate_lengths)" in src
+    # Menu-only: it edits data, so it should not be one stray click on the toolbar.
+    assert "self.toolbar.addAction(self.action_recalc_lengths)" not in src

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -1,0 +1,194 @@
+"""Tests for ground-truth length measurement.
+
+The bug these pin down was found by running the WP2 validator against two real
+Serbian projects: routes and cables stored ``QgsGeometry.length()`` (map units)
+while pipes stored an ellipsoidal measurement, so a trench and the duct inside it
+disagreed by 41% in the same GeoPackage.
+"""
+import ast
+import math
+import pathlib
+
+import pytest
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransformContext,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProject,
+    QgsVectorLayer,
+)
+
+from fiberq.utils.measure import clear_cache, ground_length, ground_length_km
+
+#: Niš, Serbia -- where the projects that surfaced this live.
+LAT = 43.32
+LON = 21.90
+#: Web Mercator inflates east-west distance by 1/cos(latitude).
+SCALE = 1.0 / math.cos(math.radians(LAT))
+
+
+@pytest.fixture
+def project():
+    """A standalone project, never QgsProject.instance().
+
+    The singleton is shared by the whole session, so clearing it here would tear
+    the ground out from under every other test file (the rest of the suite builds
+    its own QgsProject() for the same reason).
+    """
+    prj = QgsProject()
+    # setEllipsoid is a silent no-op until the project has a CRS.
+    prj.setCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+    prj.setEllipsoid("EPSG:7030")  # WGS 84
+    clear_cache()
+    yield prj
+    clear_cache()
+
+
+def _mercator_line(length_map_units=1000.0):
+    """A horizontal line of the given length in EPSG:3857 metres, at LAT."""
+    from qgis.core import QgsCoordinateTransform
+
+    xform = QgsCoordinateTransform(
+        QgsCoordinateReferenceSystem("EPSG:4326"),
+        QgsCoordinateReferenceSystem("EPSG:3857"),
+        QgsCoordinateTransformContext())
+    start = xform.transform(QgsPointXY(LON, LAT))
+    end = QgsPointXY(start.x() + length_map_units, start.y())
+    return QgsGeometry.fromPolylineXY([start, end])
+
+
+def _layer(crs="EPSG:3857"):
+    layer = QgsVectorLayer(f"LineString?crs={crs}", "lines", "memory")
+    assert layer.isValid()
+    return layer
+
+
+# ---------------------------------------------------------------------------
+# The core claim
+# ---------------------------------------------------------------------------
+
+def test_ground_length_is_shorter_than_map_length_in_web_mercator(project):
+    geom = _mercator_line(1000.0)
+    planar = geom.length()
+    ground = ground_length(geom, _layer(), project=project)
+
+    assert planar == pytest.approx(1000.0, abs=1.0)
+    assert ground < planar
+    assert planar / ground == pytest.approx(SCALE, rel=0.01)
+
+
+def test_ground_length_matches_the_qgis_measure_tool(project):
+    """Same configuration the QGIS measure tool uses, so the numbers agree."""
+    from qgis.core import QgsDistanceArea
+
+    geom = _mercator_line(1000.0)
+    da = QgsDistanceArea()
+    da.setSourceCrs(QgsCoordinateReferenceSystem("EPSG:3857"),
+                    project.transformContext())
+    da.setEllipsoid("EPSG:7030")
+
+    assert ground_length(geom, _layer(), project=project) == pytest.approx(da.measureLength(geom))
+
+
+def test_km_helper_rounds_like_the_layer_stores_it(project):
+    geom = _mercator_line(1000.0)
+    assert ground_length_km(geom, _layer(), project=project) == pytest.approx(
+        round(ground_length(geom, _layer(), project=project) / 1000.0, 2))
+
+
+# ---------------------------------------------------------------------------
+# Robustness -- a wrong number beats a lost attribute
+# ---------------------------------------------------------------------------
+
+def test_none_and_empty_geometries_measure_zero(project):
+    assert ground_length(None) == 0.0
+    assert ground_length(QgsGeometry()) == 0.0
+
+
+def test_works_without_a_layer_argument(project):
+    """Callers on the canvas can omit the layer; the project CRS is assumed."""
+    geom = _mercator_line(1000.0)
+    assert ground_length(geom, project=project) == pytest.approx(
+        ground_length(geom, _layer(), project=project))
+
+
+def test_no_ellipsoid_falls_back_to_planar(project):
+    """Old projects with measurement off keep the previous behaviour."""
+    project.setEllipsoid("NONE")
+    clear_cache()
+    geom = _mercator_line(1000.0)
+    assert ground_length(geom, _layer(), project=project) == pytest.approx(geom.length(), rel=1e-6)
+
+
+def test_geographic_crs_returns_metres_not_degrees(project):
+    """A layer in EPSG:4326 must not report a length of 0.01."""
+    geom = QgsGeometry.fromPolylineXY(
+        [QgsPointXY(LON, LAT), QgsPointXY(LON + 0.01, LAT)])
+    metres = ground_length(geom, _layer("EPSG:4326"), project=project)
+    assert 700 < metres < 900  # ~810 m at this latitude
+
+
+def test_cache_is_keyed_on_crs_and_ellipsoid(project):
+    """Changing the project ellipsoid must change the answer, not reuse a stale one."""
+    geom = _mercator_line(1000.0)
+    ellipsoidal = ground_length(geom, _layer(), project=project)
+    project.setEllipsoid("NONE")
+    clear_cache()
+    assert ground_length(geom, _layer(), project=project) != pytest.approx(ellipsoidal)
+
+
+# ---------------------------------------------------------------------------
+# No caller may regress to planar maths for a stored length
+# ---------------------------------------------------------------------------
+
+#: (module, function) pairs that write a metre value into a field or show one.
+LENGTH_WRITERS = [
+    ("fiberq/core/route_manager.py", 4),
+    ("fiberq/core/cable_manager.py", 1),
+    ("fiberq/core/slack_manager.py", 1),
+    ("fiberq/tools/route_tool.py", 1),
+    ("fiberq/tools/breakpoint_tool.py", 2),
+    ("fiberq/tools/branch_tool.py", 1),
+    ("fiberq/dialogs/schematic_dialog.py", 1),
+    ("fiberq/addons/reserve_hook.py", 1),
+    ("fiberq/tools/pipe_tool.py", 1),
+]
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.parametrize("rel,count", LENGTH_WRITERS)
+def test_length_writers_use_ground_length(rel, count):
+    src = (REPO / rel).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    calls = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id == "ground_length"  # noqa: W503
+    ]
+    assert len(calls) == count, f"{rel} should call ground_length {count}x"
+    assert "from ..utils.measure import ground_length" in src
+
+
+def test_stored_length_fields_are_never_assigned_a_planar_length():
+    """The regression itself: `duzina* = <something>.length()` must not come back."""
+    offenders = []
+    for path in (REPO / "fiberq").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if not any(t.startswith("duzina") or "length" in t or "len" in t
+                       for t in targets):
+                continue
+            for call in ast.walk(node.value):
+                if (isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Attribute)  # noqa: W503
+                        and call.func.attr == "length"):  # noqa: W503
+                    offenders.append(
+                        f"{path.relative_to(REPO)}:{node.lineno} {targets}")
+    # utils/geometry.py documents itself as map units and has no callers.
+    offenders = [o for o in offenders if "utils/geometry.py" not in o]
+    assert not offenders, "planar length assigned to a length variable: " + "; ".join(offenders)

--- a/tests/test_validation_domain.py
+++ b/tests/test_validation_domain.py
@@ -6,6 +6,7 @@ geographic CRS, so lengths in these fixtures are directly comparable to the
 stored values.
 """
 from qgis.core import (
+    QgsCoordinateReferenceSystem,
     QgsFeature,
     QgsGeometry,
     QgsPointXY,
@@ -320,6 +321,103 @@ def test_e2_flags_a_bowtie_polygon(qgis_app):
     issues = _ids(_run(project, {"E2"}), "E2")
     assert len(issues) == 1
     assert issues[0].details["expected_geometry"] == "Polygon"
+
+
+# ---------------------------------------------------------------------------
+# Regressions found by running against real projects (QGIS 4.2, EPSG:3857)
+# ---------------------------------------------------------------------------
+
+def test_d1_accepts_the_english_labels_the_plugin_actually_stores(qgis_app):
+    """The cable dialog offers "Optical"/"Copper" and maps them to themselves, so
+    real projects store the English label where schema.py declares opticki /
+    bakarnI. Both sides of value_map must pass, or every cable is flagged."""
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "Underground cables", "LineString",
+        ("fiberq_uuid:string", "tip:string"),
+        [({"fiberq_uuid": "c1", "tip": "Optical"}, _line((0, 0), (100, 0))),
+         ({"fiberq_uuid": "c2", "tip": "opticki"}, _line((0, 10), (100, 10))),
+         ({"fiberq_uuid": "c3", "tip": "bakarnI"}, _line((0, 20), (100, 20))),
+         ({"fiberq_uuid": "c4", "tip": "Copper"}, _line((0, 30), (100, 30)))],
+    ))
+    assert _ids(_run(project, {"D1"}), "D1") == []
+
+
+def test_d1_still_catches_genuine_garbage(qgis_app):
+    """Widening the domain must not blunt the rule."""
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "Underground cables", "LineString",
+        ("fiberq_uuid:string", "tip:string"),
+        [({"fiberq_uuid": "c1", "tip": "banana"}, _line((0, 0), (100, 0)))],
+    ))
+    assert len(_ids(_run(project, {"D1"}), "D1")) == 1
+
+
+def test_d3_measures_ground_length_not_projected_length(qgis_app):
+    """The Web Mercator regression.
+
+    The plugin writes duzina_m with QgsDistanceArea + the project ellipsoid, i.e.
+    true ground metres. Comparing that to a raw geometry length in EPSG:3857 is
+    off by 1/cos(latitude) -- about 1.41x at 45 degrees -- so every length in a
+    normal project looked ~41% wrong.
+
+    This line spans 100 projected units at a realistic Serbian northing; its true
+    ground length is ~71 m. Storing the ground length must validate cleanly.
+    """
+    project = QgsProject()
+    # setEllipsoid() is a silent no-op while the project CRS is unset -- it leaves
+    # the ellipsoid at "NONE". The CRS has to be set first.
+    project.setCrs(QgsCoordinateReferenceSystem(METRIC))
+    project.setEllipsoid("EPSG:7030")  # WGS 84
+    assert project.ellipsoid() == "EPSG:7030"
+    northing = 5589866  # ~44.8 N, from the reported project
+    layer = _layer("Underground cables", "LineString", CABLE_FIELDS, [
+        ({"fiberq_uuid": "c1"}, _line((2344313, northing), (2344413, northing))),
+    ])
+    project.addMapLayer(layer)
+
+    from qgis.core import QgsDistanceArea
+    da = QgsDistanceArea()
+    da.setSourceCrs(layer.crs(), project.transformContext())
+    da.setEllipsoid(project.ellipsoid())
+    ground = da.measureLength(next(layer.getFeatures()).geometry())
+
+    # Sanity: the projection really does inflate by ~1.41 here.
+    assert 1.35 < 100.0 / ground < 1.45, ground
+
+    layer.startEditing()
+    for feat in layer.getFeatures():
+        layer.changeAttributeValue(
+            feat.id(), layer.fields().indexOf("duzina_m"), round(ground, 2))
+    layer.commitChanges()
+
+    assert _ids(_run(project, {"D3"}), "D3") == []
+
+
+def test_d3_tolerates_rounded_kilometres(qgis_app):
+    """duzina_km is stored rounded, so a 34.5 m route legitimately reads 0.03."""
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "Route", "LineString",
+        ("fiberq_uuid:string", "duzina:double", "duzina_km:double"),
+        [({"fiberq_uuid": "r1", "duzina": 34.5, "duzina_km": 0.03},
+          _line((0, 0), (34.5, 0)))],
+    ))
+    km = [i for i in _ids(_run(project, {"D3"}), "D3") if "duzina_km" in i.details]
+    assert km == []
+
+
+def test_d3_still_catches_a_wrong_kilometre_value(qgis_app):
+    project = QgsProject()
+    project.addMapLayer(_layer(
+        "Route", "LineString",
+        ("fiberq_uuid:string", "duzina:double", "duzina_km:double"),
+        [({"fiberq_uuid": "r1", "duzina": 1000.0, "duzina_km": 7.5},
+          _line((0, 0), (1000, 0)))],
+    ))
+    km = [i for i in _ids(_run(project, {"D3"}), "D3") if "duzina_km" in i.details]
+    assert len(km) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validation_panel.py
+++ b/tests/test_validation_panel.py
@@ -1,0 +1,251 @@
+"""Tests for the WP2 validation results panel and its wiring in main_plugin.
+
+The panel is deliberately logic-free -- it renders a ValidationResult and emits
+signals -- so it can be built and driven without a project, which is what these
+tests do. The plugin-side wiring is checked at source level, because FiberQPlugin
+needs a live iface and the whole initGui chain to instantiate (same approach as
+tests/test_stray_poles_layer.py).
+"""
+import ast
+import inspect
+import textwrap
+
+from fiberq.core import validation_manager as vm
+from fiberq.ui.validation_panel import ValidationPanel
+
+
+def _issue(rule_id="A1", severity=vm.Severity.WARNING, layer="Underground cables",
+           fid=1, message="something is off", where=(10.0, 20.0)):
+    return vm.ValidationIssue(
+        rule_id=rule_id, severity=severity, category="topology",
+        message=message, layer_name=layer, layer_id=f"{layer}_id",
+        feature_id=fid, where=where,
+    )
+
+
+def _result(issues, rule_errors=None):
+    result = vm.ValidationResult(project_name="t", crs="EPSG:3857")
+    result.issues = list(issues)
+    result.rule_errors = list(rule_errors or [])
+    return result
+
+
+def _rows(panel):
+    return [panel.tree.topLevelItem(i) for i in range(panel.tree.topLevelItemCount())]
+
+
+def _visible(panel):
+    return [r for r in _rows(panel) if not r.isHidden()]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def test_panel_builds_without_a_project(qgis_app):
+    panel = ValidationPanel()
+    assert panel.objectName() == "FiberQValidationPanel"
+    assert panel.tree.topLevelItemCount() == 0
+    assert not panel.btn_export.isEnabled()
+
+
+def test_set_result_populates_rows(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([
+        _issue(rule_id="A1"),
+        _issue(rule_id="B4", severity=vm.Severity.ERROR, layer="ODF"),
+    ]))
+    assert len(_rows(panel)) == 2
+    assert panel.btn_export.isEnabled()
+
+
+def test_errors_sort_above_warnings(qgis_app):
+    """sorted_issues() puts the most severe first, and the panel keeps that."""
+    panel = ValidationPanel()
+    panel.set_result(_result([
+        _issue(rule_id="A1", severity=vm.Severity.INFO),
+        _issue(rule_id="B4", severity=vm.Severity.ERROR),
+        _issue(rule_id="C1", severity=vm.Severity.WARNING),
+    ]))
+    assert [r.text(1) for r in _rows(panel)] == ["B4", "C1", "A1"]
+
+
+def test_summary_reports_counts(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([
+        _issue(severity=vm.Severity.ERROR),
+        _issue(severity=vm.Severity.WARNING),
+        _issue(severity=vm.Severity.WARNING),
+    ]))
+    text = panel.lbl_summary.text()
+    assert "1" in text and "2" in text
+
+
+def test_clean_result_says_so(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([]))
+    assert "No issues" in panel.lbl_summary.text()
+
+
+def test_failed_rules_are_surfaced(qgis_app):
+    """A rule that blew up must be visible, not silently absent."""
+    panel = ValidationPanel()
+    panel.set_result(_result([_issue()], rule_errors=["A1: boom"]))
+    assert "1" in panel.lbl_summary.text()
+
+
+def test_set_result_none_clears(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([_issue()]))
+    panel.set_result(None)
+    assert _rows(panel) == []
+    assert not panel.btn_export.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+def test_severity_filter_hides_other_rows(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([
+        _issue(rule_id="B4", severity=vm.Severity.ERROR),
+        _issue(rule_id="A1", severity=vm.Severity.WARNING),
+        _issue(rule_id="A2", severity=vm.Severity.INFO),
+    ]))
+    index = panel.cb_severity.findData(vm.Severity.ERROR.value)
+    panel.cb_severity.setCurrentIndex(index)
+    assert [r.text(1) for r in _visible(panel)] == ["B4"]
+
+
+def test_layer_filter_hides_other_rows(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([
+        _issue(layer="ODF"),
+        _issue(layer="Underground cables"),
+    ]))
+    panel.cb_layer.setCurrentIndex(panel.cb_layer.findData("ODF"))
+    assert [r.text(2) for r in _visible(panel)] == ["ODF"]
+
+
+def test_rule_filter_hides_other_rows(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([_issue(rule_id="A1"), _issue(rule_id="D2")]))
+    panel.cb_rule.setCurrentIndex(panel.cb_rule.findData("D2"))
+    assert [r.text(1) for r in _visible(panel)] == ["D2"]
+
+
+def test_filters_reset_to_all_shows_everything(qgis_app):
+    panel = ValidationPanel()
+    panel.set_result(_result([_issue(rule_id="A1"), _issue(rule_id="D2")]))
+    panel.cb_rule.setCurrentIndex(panel.cb_rule.findData("D2"))
+    panel.cb_rule.setCurrentIndex(0)  # "All"
+    assert len(_visible(panel)) == 2
+
+
+def test_filter_combos_only_offer_present_values(qgis_app):
+    """No point offering a layer filter for a layer with no issues."""
+    panel = ValidationPanel()
+    panel.set_result(_result([_issue(layer="ODF")]))
+    layers = [panel.cb_layer.itemData(i) for i in range(panel.cb_layer.count())]
+    assert "Underground cables" not in layers
+    assert "ODF" in layers
+
+
+# ---------------------------------------------------------------------------
+# Signals
+# ---------------------------------------------------------------------------
+
+def test_activating_a_row_emits_the_issue(qgis_app):
+    panel = ValidationPanel()
+    issue = _issue(rule_id="A3")
+    panel.set_result(_result([issue]))
+
+    seen = []
+    panel.issueActivated.connect(seen.append)
+    panel._on_item_activated(_rows(panel)[0])
+
+    assert len(seen) == 1
+    assert seen[0].rule_id == "A3"
+
+
+def test_rerun_button_emits(qgis_app):
+    panel = ValidationPanel()
+    fired = []
+    panel.rerunRequested.connect(lambda: fired.append(True))
+    panel.btn_rerun.click()
+    assert fired == [True]
+
+
+def test_busy_state_disables_rerun(qgis_app):
+    panel = ValidationPanel()
+    panel.set_busy(True)
+    assert not panel.btn_rerun.isEnabled()
+    panel.set_busy(False)
+    assert panel.btn_rerun.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# Plugin wiring (source level -- FiberQPlugin needs a live iface to build)
+# ---------------------------------------------------------------------------
+
+def _called_names(func):
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            target = node.func
+            if isinstance(target, ast.Attribute):
+                names.add(target.attr)
+            elif isinstance(target, ast.Name):
+                names.add(target.id)
+    return names
+
+
+def test_plugin_exposes_the_validation_entry_points(qgis_app):
+    import fiberq.main_plugin as mp
+
+    for name in ("run_validation", "_ensure_validation_panel", "_zoom_to_issue"):
+        assert callable(getattr(mp.FiberQPlugin, name, None)), name
+
+
+def test_trigger_stays_thin(qgis_app):
+    """All rule logic must live in validation_manager, not in the monolith."""
+    import fiberq.main_plugin as mp
+
+    src = inspect.getsource(mp.FiberQPlugin.run_validation)
+    assert "run_validation as _run" in src
+    # The trigger must not start reimplementing checks.
+    assert "getFeatures" not in src
+    assert "QgsSpatialIndex" not in src
+
+
+def test_dock_is_removed_on_unload(qgis_app):
+    """iface.addDockWidget is not covered by the self.actions cleanup loop, so
+    unload must take the panel down explicitly or a reload leaves a dead dock."""
+    import fiberq.main_plugin as mp
+
+    assert "removeDockWidget" in _called_names(mp.FiberQPlugin.unload)
+
+
+def test_validate_action_is_registered_for_cleanup(qgis_app):
+    """Appending to self.actions is what gets the menu entry and toolbar icon
+    removed on unload."""
+    import fiberq.main_plugin as mp
+
+    src = inspect.getsource(mp.FiberQPlugin.initGui)
+    assert "self.action_validate" in src
+    assert "self.actions.append(self.action_validate)" in src
+    assert "self.action_validate.triggered.connect(self.run_validation)" in src
+
+
+def test_panel_strings_use_the_class_context(qgis_app):
+    """The context must equal the class name or every string silently reverts to
+    English at runtime (docs/i18n.md, the tr() context trap)."""
+    import fiberq.ui.validation_panel as vp
+
+    src = inspect.getsource(vp)
+    assert "QCoreApplication.translate(\n            'ValidationPanel'" in src \
+        or "'ValidationPanel', message" in src
+    # A module-level tr() helper is the trap the docs warn about.
+    assert "\ndef tr(" not in src


### PR DESCRIPTION
Fourth and last WP2 branch before the report exporters. Adds the user-facing half of the
validation engine — the toolbar action and the results dock — and then fixes what running it
against two real projects turned up.

## Validate project + results panel

`FiberQ → Validate project` runs the engine from `feat/wp2-core` and opens a dockable results
list: severity/layer/rule filters, live counts, click-to-zoom, and a Re-run button. The panel
owns no validation logic and never touches `QgsProject` — it renders a `ValidationResult` and
emits signals, which is what lets it be built and driven in tests without a live project.

Rows sort on meaning rather than on displayed text: severity by numeric rank (a string sort
would order Error/Warning/Info differently in every language) and feature id numerically.

## What real projects revealed

Running this on two Serbian GPON projects (EPSG:3857) surfaced four things. Two were the
rule's fault, two were the plugin's.

**Rules were wrong (7295403):** D3 compared stored lengths against `QgsGeometry.length()`,
and D1 rejected the enum labels the cable dialog actually writes. Both flagged every feature
in every project.

**The plugin was wrong (eb8f9d3):** with D3 measuring correctly, the numbers said the stored
values were the inflated ones.

```
layer                stored   planar   ground   st/planar   st/ground
Route                242.96   242.96   172.64      1.0000      1.4073
Aerial_cables        169.61   169.61   120.52      1.0000      1.4073
PE_pipes              29.54    41.70    29.54      0.7084      1.0000
```

Routes and cables stored the planar figure; pipes stored the ellipsoidal one — in the same
GeoPackage, so a trench and the duct inside it disagreed by 41%. The split traced to which
code path wrote the value: `pipe_tool` and `bom_dialog` built a `QgsDistanceArea`, while
`route_manager`, `cable_manager`, `route_tool` and `breakpoint_tool` called
`QgsGeometry.length()` straight. Web Mercator inflates that by 1/cos(latitude) — 1.41x in
Serbia, 1.55x in the Netherlands, 1.86x in Finland. A bill of materials over-ordered cable by
the same margin.

New `fiberq/utils/measure.py` owns the one correct way to measure. Every writer of a metre
value now goes through it. An AST test fails the build if a raw `.length()` is ever assigned
to a length variable again — it caught a leftover fallback branch while the commit was being
written.

**Existing data (1229cf0):** the fix above only corrects what is written from now on, so
`FiberQ → Recalculate lengths…` repairs what is already stored. It plans first and shows the
user exactly what will change before committing, because these attributes may have been in a
project for years. It shares D3's tolerance deliberately: if the rule and the fix drifted
apart, recalculating would leave findings that no amount of clicking could clear.

Menu-only, not on the toolbar — it rewrites user data.

## Verification

Dry-run against the two reported projects, read-only:

| Project | D3 findings | Would rewrite | Largest change |
|---|---|---|---|
| test | 9 | 18 attrs / 9 features | Route 13 `duzina` 177.78 → 61.45 |
| Simple GPON design | 13 | 25 attrs / 13 features | Underground cables 2 `duzina_m` 388.80 → **276.22** |

Confirmed in QGIS 4.2 after applying: **Simple GPON design validates clean**, and the cable
labelled "389 m Optical 12f" now reads 276 m. A newly drawn route stores 107.12653 where the
QGIS measure tool reports 107.127.

The A3 orphan findings that remain in `test` were checked against the data and are correct —
every flagged element is 6–184 m from the nearest line, while everything genuinely connected
measures exactly 0.00. That project has elements placed but never connected, which is what the
rule is for.

## Not in this PR

`Route 13: 177.78 → 61.45` is 2.9x, not 1.41x — that geometry was edited after its length was
written, and nothing recomputed it. Editing a line still leaves its length stale. Recalculate
repairs it today; a `geometryChanged` hook is the real fix and needs care with edit-buffer
reentrancy. Filed as WP4 FU-5.

## Gate

178 tests on `qgis/qgis:3.44-trixie` (Qt5) and `qgis/qgis:4.0-trixie` (Qt6); flake8 and bandit
0/0.
